### PR TITLE
cuDNN 7.2 required for tf 1.11+

### DIFF
--- a/site/en/install/install_linux.md
+++ b/site/en/install/install_linux.md
@@ -506,8 +506,7 @@ The following NVIDIA® <i>software</i> must be installed on your system:
 
 *   [GPU drivers](http://nvidia.com/driver). CUDA 9.0 requires 384.x or higher.
 *   [CUDA Toolkit 9.0](http://nvidia.com/cuda).
-*   [cuDNN SDK](http://developer.nvidia.com/cudnn) (>= 7.0). Version 7.1 is
-    recommended.
+*   [cuDNN SDK](http://developer.nvidia.com/cudnn) (>= 7.2).
 *   [CUPTI](http://docs.nvidia.com/cuda/cupti/) ships with the CUDA Toolkit, but
     you also need to append its path to the `LD_LIBRARY_PATH` environment
     variable: `export
@@ -534,9 +533,9 @@ sudo dpkg -i nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb
 sudo apt-get update
 # Includes optional NCCL 2.x.
 sudo apt-get install cuda9.0 cuda-cublas-9-0 cuda-cufft-9-0 cuda-curand-9-0 \
-  cuda-cusolver-9-0 cuda-cusparse-9-0 libcudnn7=7.1.4.18-1+cuda9.0 \
+  cuda-cusolver-9-0 cuda-cusparse-9-0 libcudnn7=7.2.1.38-1+cuda9.0 \
    libnccl2=2.2.13-1+cuda9.0 cuda-command-line-tools-9-0
-# Optionally install TensorRT runtime, must be done after above cuda install.
+# Optionally install TensorRT runtime, must be done after above CUDA install.
 sudo apt-get update
 sudo apt-get install libnvinfer4=4.1.2-1+cuda9.0
 ```


### PR DESCRIPTION
Updated install guide to indicate cuDNN 7.2 is needed.  This does not need to wait until 1.11 is final as moving to cuDNN 7.2 works just fine with current 1.10 binaries.  The move is needed because the latest TensorRT requires cuDNN 7.2.  