### PR TITLE
TF doc: guide/datasets: int32 is not supported in Example proto.

### DIFF
--- a/site/en/guide/datasets.md
+++ b/site/en/guide/datasets.md
@@ -558,7 +558,7 @@ tensors.
 # a scalar integer, representing an image and its label, respectively.
 def _parse_function(example_proto):
   features = {"image": tf.FixedLenFeature((), tf.string, default_value=""),
-              "label": tf.FixedLenFeature((), tf.int32, default_value=0)}
+              "label": tf.FixedLenFeature((), tf.int64, default_value=0)}
   parsed_features = tf.parse_single_example(example_proto, features)
   return parsed_features["image"], parsed_features["label"]
 


### PR DESCRIPTION
Error:
TypeError: Value passed to parameter 'dense_defaults' has DataType int32 not in list of allowed values: float32, int64, string