### PR TITLE
typo fix for some mismatch between code and comment

### DIFF
--- a/site/en/api_guides/cc/guide.md
+++ b/site/en/api_guides/cc/guide.md
@@ -270,7 +270,7 @@ the graph need to be executed, and what values need feeding. For example:
 ```c++
 Scope root = Scope::NewRootScope();
 auto c = Const(root, { {1, 1} });
-auto m = MatMul(root, c, { {42}, {1} });
+auto m = MatMul(root, c, { {41}, {1} });
 
 ClientSession session(root);
 std::vector<Tensor> outputs;


### PR DESCRIPTION
The code and the following comment doesn't match. 

// outputs[0] == {42}