### PR TITLE
Add plt.show() instruction

### DIFF
--- a/site/en/tutorials/keras/basic_classification.ipynb
+++ b/site/en/tutorials/keras/basic_classification.ipynb
@@ -416,7 +416,8 @@
         "plt.figure()\n",
         "plt.imshow(train_images[0])\n",
         "plt.colorbar()\n",
-        "plt.grid(False)"
+        "plt.grid(False)\n",
+        "plt.show()"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
Without the `plt.show()` instruction, one does not always know how to actually display the GUI through matplotlib/tkinter.

This PR updates the documentation accordingly.