### PR TITLE
Add missing return in example code

### DIFF
--- a/site/en/guide/keras.md
+++ b/site/en/guide/keras.md
@@ -377,6 +377,7 @@ class MyLayer(keras.layers.Layer):
   def get_config(self):
     base_config = super(MyLayer, self).get_config()
     base_config['output_dim'] = self.output_dim
+    return base_config
 
   @classmethod
   def from_config(cls, config):


### PR DESCRIPTION
Keras custom layers example code missed a return statement, which
caused layers to not have a config when the example was followed.