### PR TITLE
Use sudo for installing virtualenv

### DIFF
--- a/site/en/install/docker.md
+++ b/site/en/install/docker.md
@@ -21,7 +21,7 @@ be installed).
 2. For GPU support on Linux, [install nvidia-docker](https://github.com/NVIDIA/nvidia-docker){:.external}.
 
 Note: To run the `docker` command without `sudo`, create the `docker` group and
-add your user. For details, the
+add your user. For details, see the
 [post-installation steps for Linux](https://docs.docker.com/install/linux/linux-postinstall/){:.external}.
 
 

--- a/site/en/install/pip.html
+++ b/site/en/install/pip.html
@@ -74,7 +74,7 @@
 <pre class="prettyprint lang-bsh">
 <code class="devsite-terminal">sudo apt update</code>
 <code class="devsite-terminal">sudo apt install python-dev python-pip</code>
-<code class="devsite-terminal">pip install --user --upgrade virtualenv  # install virtualenv in $HOME</code>
+<code class="devsite-terminal">sudo pip install -U virtualenv  # system-wide install</code>
 </pre>
 </section>
 
@@ -86,7 +86,7 @@
 <code class="devsite-terminal">export PATH="/usr/local/bin:/usr/local/sbin:$PATH"</code>
 <code class="devsite-terminal">brew update</code>
 <code class="devsite-terminal">brew install python@2  # Python 2</code>
-<code class="devsite-terminal">pip install --user --upgrade virtualenv  # install virtualenv in $HOME</code>
+<code class="devsite-terminal">sudo pip install -U virtualenv  # system-wide install</code>
 </pre>
 </section>
 
@@ -96,8 +96,8 @@
 <pre class="prettyprint lang-bsh">
 <code class="devsite-terminal">sudo apt update</code>
 <code class="devsite-terminal">sudo apt install python-dev python-pip</code>
-<code class="devsite-terminal">sudo apt install libatlas-base-dev       # required for numpy</code>
-<code class="devsite-terminal">pip install --user --upgrade virtualenv  # install virtualenv in $HOME</code>
+<code class="devsite-terminal">sudo apt install libatlas-base-dev     # required for numpy</code>
+<code class="devsite-terminal">sudo pip install -U virtualenv         # system-wide install</code>
 </pre>
 </section>
 
@@ -106,7 +106,7 @@
 <pre class="prettyprint lang-bsh">
 <code class="devsite-terminal">curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py</code>
 <code class="devsite-terminal">python get-pip.py</code>
-<code class="devsite-terminal">pip install --user --upgrade virtualenv  # install virtualenv in $HOME</code>
+<code class="devsite-terminal">sudo pip install -U virtualenv  # system-wide install</code>
 </pre>
 </section>
 </div><!--/ds-selector-tabs-->
@@ -119,7 +119,7 @@
 <pre class="prettyprint lang-bsh">
 <code class="devsite-terminal">sudo apt update</code>
 <code class="devsite-terminal">sudo apt install python3-dev python3-pip</code>
-<code class="devsite-terminal">pip3 install --user --upgrade virtualenv  # install virtualenv in $HOME</code>
+<code class="devsite-terminal">sudo pip3 install -U virtualenv  # system-wide install</code>
 </pre>  
 </section>
 
@@ -131,14 +131,14 @@
 <code class="devsite-terminal">export PATH="/usr/local/bin:/usr/local/sbin:$PATH"</code>
 <code class="devsite-terminal">brew update</code>
 <code class="devsite-terminal">brew install python  # Python 3</code>
-<code class="devsite-terminal">pip3 install --user --upgrade virtualenv  # install virtualenv in $HOME</code>
+<code class="devsite-terminal">sudo pip3 install -U virtualenv  # system-wide install</code>
 </pre>
 </section>
 
 <section>
 <h3>Windows</h3><!--python3-->
 <p>Install a <a href="https://www.python.org/downloads/windows/" class="external">Python 3 release for Windows</a> (select <code>pip</code> as an optional feature).</p>
-<pre class="devsite-terminal tfo-terminal-windows devsite-click-to-copy">pip3 install --upgrade pip virtualenv</pre>
+<pre class="devsite-terminal tfo-terminal-windows devsite-click-to-copy">pip3 install -U pip virtualenv</pre>
 </section>
 
 <section>
@@ -148,7 +148,7 @@
 <code class="devsite-terminal">sudo apt update</code>
 <code class="devsite-terminal">sudo apt install python3-dev python3-pip</code>
 <code class="devsite-terminal">sudo apt install libatlas-base-dev        # required for numpy</code>
-<code class="devsite-terminal">pip3 install --user --upgrade virtualenv  # install virtualenv in $HOME</code>
+<code class="devsite-terminal">sudo pip3 install -U virtualenv           # system-wide install</code>
 </pre>
 </section>
 
@@ -157,7 +157,7 @@
 <pre class="prettyprint lang-bsh">
 <code class="devsite-terminal">curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py</code>
 <code class="devsite-terminal">python get-pip.py</code>
-<code class="devsite-terminal">pip3 install --user --upgrade virtualenv  # install virtualenv in $HOME</code>
+<code class="devsite-terminal">sudo pip3 install -U virtualenv  # system-wide install</code>
 </pre>
 </section>
 </div><!--/ds-selector-tabs-->


### PR DESCRIPTION
Using `pip install --user virtualenv` presents some complications since the installation `bin/` usually this *isn't* on the user's `PATH`.

Could add something like:
`PATH="$(python -m site --user-base)/bin:$PATH"`
And then another for python3. Not sure if this works for Windows, etc.

Since we're already using `sudo` to use the system package manager, I think—in this case—it's easier for beginners to just to install `virtualenv` system-wide. (This change is based on feedback from a new user.)

stage: go/tfo-stage/install/pip