### PR TITLE
remove link to lite subsite from install toc

### DIFF
--- a/site/en/install/_toc.yaml
+++ b/site/en/install/_toc.yaml
@@ -25,8 +25,6 @@ toc:
   path: /install/lang_c
 - title: Go
   path: /install/lang_go
-- title: TensorFlow Lite
-  path: /lite
 - title: TensorFlow.js
   path: https://js.tensorflow.org
   status: external


### PR DESCRIPTION
Causing lower tabs to not show up on /lite