### PR TITLE
Remove API Guides from api_docs/ leftnav

### DIFF
--- a/site/en/api_docs/_book.yaml
+++ b/site/en/api_docs/_book.yaml
@@ -13,8 +13,6 @@ upper_tabs:
       - include: {VERSION_ROOT}/api_docs/python/_toc.yaml
       - title: All Symbols
         path: {VERSION_ROOT}/api_docs/python/
-      - title: Guides
-      - include: {VERSION_ROOT}/api_guides/python/_toc.yaml
 
     - name: JavaScript
       contents:


### PR DESCRIPTION
Some redirects here: cl/214344585
Not many, though, and I'm not sure there's much here worth saving.