### PR TITLE
Mention 64-bit python need on windows

### DIFF
--- a/site/en/install/pip.html
+++ b/site/en/install/pip.html
@@ -146,7 +146,7 @@
 <li>Select <em>Redistributables and Build Tools</em>,</li>
 <li>Download and install the <em>Microsoft Visual C++ 2015 Redistributable Update 3</em>.</li>
 </ol>
-<p>Install an 64-bit <a href="https://www.python.org/downloads/windows/" class="external">Python 3 release for Windows</a> (select <code>pip</code> as an optional feature).</p>
+<p>Install the <em>64-bit</em> <a href="https://www.python.org/downloads/windows/" class="external">Python 3 release for Windows</a> (select <code>pip</code> as an optional feature).</p>
 <pre class="devsite-terminal tfo-terminal-windows devsite-click-to-copy">pip3 install -U pip virtualenv</pre>
 </section>
 

--- a/site/en/install/pip.html
+++ b/site/en/install/pip.html
@@ -146,7 +146,7 @@
 <li>Select <em>Redistributables and Build Tools</em>,</li>
 <li>Download and install the <em>Microsoft Visual C++ 2015 Redistributable Update 3</em>.</li>
 </ol>
-<p>Install a <a href="https://www.python.org/downloads/windows/" class="external">Python 3 release for Windows</a> (select <code>pip</code> as an optional feature).</p>
+<p>Install an 64-bit <a href="https://www.python.org/downloads/windows/" class="external">Python 3 release for Windows</a> (select <code>pip</code> as an optional feature).</p>
 <pre class="devsite-terminal tfo-terminal-windows devsite-click-to-copy">pip3 install -U pip virtualenv</pre>
 </section>
 


### PR DESCRIPTION
Tensorflow only supports 64-bit versions of Python 3.5.x and 3.6.x on Windows.
It was mentioned on previous install guides.