### PR TITLE
Removing some outdated sample references from guides

### DIFF
--- a/site/en/api_guides/python/reading_data.md
+++ b/site/en/api_guides/python/reading_data.md
@@ -483,12 +483,6 @@ using the `shuffle_batch` functions, we use the plain
 multiple preprocessing threads, set the `num_threads` parameter to a number
 bigger than 1.
 
-An MNIST example that preloads the data using constants can be found in
-[`tensorflow/examples/how_tos/reading_data/fully_connected_preloaded.py`](https://www.tensorflow.org/code/tensorflow/examples/how_tos/reading_data/fully_connected_preloaded.py), and one that preloads the data using variables can be found in
-[`tensorflow/examples/how_tos/reading_data/fully_connected_preloaded_var.py`](https://www.tensorflow.org/code/tensorflow/examples/how_tos/reading_data/fully_connected_preloaded_var.py),
-You can compare these with the `fully_connected_feed` and
-`fully_connected_reader` versions above.
-
 ## Multiple input pipelines
 
 Commonly you will want to train on one dataset and evaluate (or "eval") on

--- a/site/en/api_guides/python/regression_examples.md
+++ b/site/en/api_guides/python/regression_examples.md
@@ -7,12 +7,6 @@ to implement regression in Estimators:
   <tr> <th>Example</th> <th>Demonstrates How To...</th></tr>
 
   <tr>
-    <td><a href="https://www.tensorflow.org/code/tensorflow/examples/get_started/regression/linear_regression.py">linear_regression.py</a></td>
-    <td>Use the `tf.estimator.LinearRegressor` Estimator to train a
-        regression model on numeric data.</td>
-  </tr>
-
-  <tr>
     <td><a href="https://www.tensorflow.org/code/tensorflow/examples/get_started/regression/linear_regression_categorical.py">linear_regression_categorical.py</a></td>
     <td>Use the `tf.estimator.LinearRegressor` Estimator to train a
         regression model on categorical data.</td>


### PR DESCRIPTION
As part of our sample modernization, we are removing references to outdated samples until such time as they can be cleaned up.  These are two that need updating.