### PR TITLE
Move xla warp zone readme

### DIFF
--- a/site/en/extend/xla/README.md
+++ b/site/en/extend/xla/README.md
@@ -1,5 +1,5 @@
 Welcome to the warp zone!
 
-# XLA compiler
+# XLA: Accelerated Linear Algebra
 
 These docs are available here: https://github.com/tensorflow/tensorflow/tree/master/tensorflow/compiler/xla/g3doc


### PR DESCRIPTION
Missed this one. XLA is under /extend now