### PR TITLE
Add a section on saved_model

### DIFF
--- a/site/en/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/tutorials/keras/save_and_restore_models.ipynb
@@ -599,7 +599,7 @@
       "source": [
         "model = create_model()\n",
         "\n",
-        "# You need to use  a keras.optimizer to restore the optimizer state from an HDF5 file. \n",
+        "# You need to use a keras.optimizer to restore the optimizer state from an HDF5 file.\n",
         "model.compile(optimizer=keras.optimizers.Adam(), \n",
         "              loss=tf.keras.losses.sparse_categorical_crossentropy,\n",
         "              metrics=['accuracy'])\n",

--- a/site/en/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/tutorials/keras/save_and_restore_models.ipynb
@@ -572,7 +572,7 @@
       "source": [
         "## Save the entire model\n",
         "\n",
-        "The entire model can be saved to a file that contains the weight values, the model's configuration, and potentially even the optimizer's configuration. This allows you to checkpoint a model and resume training later—from the exact same state—without access to the original code.\n",
+        "The entire model can be saved to a file that contains the weight values, the model's configuration, and even the optimizer's configuration (depends on set up). This allows you to checkpoint a model and resume training later—from the exact same state—without access to the original code.\n",
         "\n",
         "Saving a fully-functional model is very useful—you can load them in TensorFlow.js ([HDF5](https://js.tensorflow.org/tutorials/import-keras.html), [Saved Model](https://js.tensorflow.org/tutorials/import-saved-model.html)) and then train and run them in web browsers, or convert them to run on mobile devices using TFLite([HDF5](https://www.tensorflow.org/lite/convert/python_api#exporting_a_tfkeras_file_), [Saved Model](https://www.tensorflow.org/lite/convert/python_api#exporting_a_savedmodel_))"
       ]

--- a/site/en/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/tutorials/keras/save_and_restore_models.ipynb
@@ -572,11 +572,21 @@
       "source": [
         "## Save the entire model\n",
         "\n",
-        "The entire model can be saved to a file that contains the weight values, the model's configuration, and even the optimizer's configuration. This allows you to checkpoint a model and resume training later—from the exact same state—without access to the original code.\n",
+        "The entire model can be saved to a file that contains the weight values, the model's configuration, and potentially even the optimizer's configuration. This allows you to checkpoint a model and resume training later—from the exact same state—without access to the original code.\n",
         "\n",
-        "Saving a fully-functional model in Keras is very useful—you can load them in [TensorFlow.js](https://js.tensorflow.org/tutorials/import-keras.html) and then train and run them in web browsers.\n",
+        "Saving a fully-functional model is very useful—you can load them in TensorFlow.js ([HDF5](https://js.tensorflow.org/tutorials/import-keras.html), [Saved Model](https://js.tensorflow.org/tutorials/import-saved-model.html)) and then train and run them in web browsers, or convert them to run on mobile devices using TFLite([HDF5](https://www.tensorflow.org/lite/convert/python_api#exporting_a_tfkeras_file_), [Saved Model](https://www.tensorflow.org/lite/convert/python_api#exporting_a_savedmodel_))"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "SkGwf-50zLNn",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### As an HDF5 file\n",
         "\n",
-        "Keras provides a basic save format using the [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) standard. For our purposes, the saved model can be treated as a single binary blob.\n"
+        "Keras provides a basic save format using the [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) standard. For our purposes, the saved model can be treated as a single binary blob."
       ]
     },
     {
@@ -588,6 +598,11 @@
       "cell_type": "code",
       "source": [
         "model = create_model()\n",
+        "\n",
+        "# You need to use  a keras.optimizer to restore the optimizer state from an HDF5 file. \n",
+        "model.compile(optimizer=keras.optimizers.Adam(), \n",
+        "              loss=tf.keras.losses.sparse_categorical_crossentropy,\n",
+        "              metrics=['accuracy'])\n",
         "\n",
         "model.fit(train_images, train_labels, epochs=5)\n",
         "\n",
@@ -617,11 +632,7 @@
       "source": [
         "# Recreate the exact same model, including weights and optimizer.\n",
         "new_model = keras.models.load_model('my_model.h5')\n",
-        "new_model.summary()\n",
-        "\n",
-        "new_model.compile(optimizer=tf.train.AdamOptimizer(), \n",
-        "              loss=tf.keras.losses.sparse_categorical_crossentropy,\n",
-        "              metrics=['accuracy'])\n"
+        "new_model.summary()"
       ],
       "execution_count": 0,
       "outputs": []
@@ -665,6 +676,150 @@
         "\n",
         "Keras saves models by inspecting the architecture. Currently, it is not able to save TensorFlow optimizers (from `tf.train`). When using those you will need to re-compile the model after loading, and you will loose the state of the optimizer.\n"
       ]
+    },
+    {
+      "metadata": {
+        "id": "kPyhgcoVzqUB",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### As a `saved_model`"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "LtcN4VIb7JkK",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Caution: This method of saving a keras model is experimental, and may change in future versions. "
+      ]
+    },
+    {
+      "metadata": {
+        "id": "DSWiSB0Q8c46",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Build a fresh model:"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "sI1YvCDFzpl3",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "model = create_model()\n",
+        "\n",
+        "model.fit(train_images, train_labels, epochs=5)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "iUvT_3qE8hV5",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Create a `saved_model`: "
+      ]
+    },
+    {
+      "metadata": {
+        "id": "sq8fPglI1RWA",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "saved_model_path = tf.contrib.saved_model.save_keras_model(model, \"./saved_models\")"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "MjpmyPfh8-1n",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Saved models are placed in a time-stamped directory:"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "ZtOvxA7V0iTv",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "!ls saved_models/"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "B7qfpvpY9HCe",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Reload a fresh keras model from the saved model."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "0YofwHdN0pxa",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "new_model = tf.contrib.saved_model.load_keras_model(saved_model_path)\n",
+        "new_model"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "uWwgNaz19TH2",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Run the restored model."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "Pc9e6G6w1AWG",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "# The optimizer was not restored, re-attach a new one.\n",
+        "new_model.compile(optimizer=tf.train.AdamOptimizer(), \n",
+        "              loss=tf.keras.losses.sparse_categorical_crossentropy,\n",
+        "              metrics=['accuracy'])\n",
+        "\n",
+        "loss, acc = new_model.evaluate(test_images, test_labels)\n",
+        "print(\"Restored model, accuracy: {:5.2f}%\".format(100*acc))"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "metadata": {

--- a/site/en/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/tutorials/keras/save_and_restore_models.ipynb
@@ -694,7 +694,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "Caution: This method of saving a keras model is experimental, and may change in future versions. "
+        "Caution: This method of saving a `tf.keras` model is experimental and may change in future versions. "
       ]
     },
     {

--- a/site/en/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/tutorials/keras/save_and_restore_models.ipynb
@@ -574,7 +574,7 @@
         "\n",
         "The entire model can be saved to a file that contains the weight values, the model's configuration, and even the optimizer's configuration (depends on set up). This allows you to checkpoint a model and resume training later—from the exact same state—without access to the original code.\n",
         "\n",
-        "Saving a fully-functional model is very useful—you can load them in TensorFlow.js ([HDF5](https://js.tensorflow.org/tutorials/import-keras.html), [Saved Model](https://js.tensorflow.org/tutorials/import-saved-model.html)) and then train and run them in web browsers, or convert them to run on mobile devices using TFLite([HDF5](https://www.tensorflow.org/lite/convert/python_api#exporting_a_tfkeras_file_), [Saved Model](https://www.tensorflow.org/lite/convert/python_api#exporting_a_savedmodel_))"
+        "Saving a fully-functional model is very useful—you can load them in TensorFlow.js ([HDF5](https://js.tensorflow.org/tutorials/import-keras.html), [Saved Model](https://js.tensorflow.org/tutorials/import-saved-model.html)) and then train and run them in web browsers, or convert them to run on mobile devices using TensorFlow Lite ([HDF5](https://www.tensorflow.org/lite/convert/python_api#exporting_a_tfkeras_file_), [Saved Model](https://www.tensorflow.org/lite/convert/python_api#exporting_a_savedmodel_))"
       ]
     },
     {


### PR DESCRIPTION
This is still in contrib, but there's no other other similarly easy way to get a saved model out, so I think it's worth including. I've included a "Caution: this is experimental" above.

Staging: https://colab.sandbox.google.com/github/MarkDaoust/docs/blob/saved-model/site/en/tutorials/keras/save_and_restore_models.ipynb