### PR TITLE
remove erroneous --config=opt flag

### DIFF
--- a/site/en/guide/performance/overview.md
+++ b/site/en/guide/performance/overview.md
@@ -147,7 +147,7 @@ For TensorFlow source versions after 1.3.0:
 ```bash
 ./configure
 # Pick the desired options
-bazel build --config=mkl --config=opt //tensorflow/tools/pip_package:build_pip_package
+bazel build --config=mkl //tensorflow/tools/pip_package:build_pip_package
 ```
 
 For TensorFlow versions 1.2.0 through 1.3.0:

--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -216,7 +216,7 @@ run on older CPUs.
 Use `bazel` to make the TensorFlow package builder with CPU-only support:
 
 <pre class="devsite-terminal devsite-click-to-copy">
-bazel build --config=opt //tensorflow/tools/pip_package:build_pip_package
+bazel build //tensorflow/tools/pip_package:build_pip_package
 </pre>
 
 #### GPU support
@@ -224,7 +224,7 @@ bazel build --config=opt //tensorflow/tools/pip_package:build_pip_package
 To make the TensorFlow package builder with GPU support:
 
 <pre class="devsite-terminal devsite-click-to-copy">
-bazel build --config=opt --config=cuda //tensorflow/tools/pip_package:build_pip_package
+bazel build --config=cuda //tensorflow/tools/pip_package:build_pip_package
 </pre>
 
 #### Bazel build options
@@ -313,7 +313,7 @@ virtual environment:
 <pre class="devsite-disable-click-to-copy prettyprint lang-bsh">
 <code class="devsite-terminal tfo-terminal-root">./configure  # answer prompts or use defaults</code>
 
-<code class="devsite-terminal tfo-terminal-root">bazel build --config=opt //tensorflow/tools/pip_package:build_pip_package</code>
+<code class="devsite-terminal tfo-terminal-root">bazel build //tensorflow/tools/pip_package:build_pip_package</code>
 
 <code class="devsite-terminal tfo-terminal-root">./bazel-bin/tensorflow/tools/pip_package/build_pip_package /mnt  # create package</code>
 
@@ -360,7 +360,7 @@ with GPU support:
 <pre class="devsite-disable-click-to-copy prettyprint lang-bsh">
 <code class="devsite-terminal tfo-terminal-root">./configure  # answer prompts or use defaults</code>
 
-<code class="devsite-terminal tfo-terminal-root">bazel build --config=opt --config=cuda //tensorflow/tools/pip_package:build_pip_package</code>
+<code class="devsite-terminal tfo-terminal-root">bazel build --config=cuda //tensorflow/tools/pip_package:build_pip_package</code>
 
 <code class="devsite-terminal tfo-terminal-root">./bazel-bin/tensorflow/tools/pip_package/build_pip_package /mnt  # create package</code>
 

--- a/site/en/install/source_windows.md
+++ b/site/en/install/source_windows.md
@@ -159,7 +159,7 @@ run on older CPUs.
 Use `bazel` to make the TensorFlow package builder with CPU-only support:
 
 <pre class="devsite-terminal tfo-terminal-windows devsite-click-to-copy">
-bazel build --config=opt //tensorflow/tools/pip_package:build_pip_package
+bazel build //tensorflow/tools/pip_package:build_pip_package
 </pre>
 
 #### GPU support
@@ -167,7 +167,7 @@ bazel build --config=opt //tensorflow/tools/pip_package:build_pip_package
 To make the TensorFlow package builder with GPU support:
 
 <pre class="devsite-terminal tfo-terminal-windows devsite-click-to-copy">
-bazel build --config=opt --config=cuda //tensorflow/tools/pip_package:build_pip_package
+bazel build --config=cuda //tensorflow/tools/pip_package:build_pip_package
 </pre>
 
 #### Bazel build options


### PR DESCRIPTION
Using this flag results in the build failing with:

```
ERROR: Config value opt is not defined in any .rc file
```

and per https://github.com/tensorflow/probability/issues/176 this flag is not actually used.