### PR TITLE
Removes eager contrib from some eager tutorials

### DIFF
--- a/site/en/tutorials/eager/automatic_differentiation.ipynb
+++ b/site/en/tutorials/eager/automatic_differentiation.ipynb
@@ -1,331 +1,329 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "automatic_differentiation.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "t09eeeR5prIJ"
+   },
+   "source": [
+    "##### Copyright 2018 The TensorFlow Authors."
+   ]
   },
-  "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "cellView": "form",
+    "colab": {},
+    "colab_type": "code",
+    "id": "GCCk8_dHpuNf"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "xh8WkEwWpnm7"
+   },
+   "source": [
+    "# Automatic differentiation and gradient tape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "idv0bPeCp325"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/eager/automatic_differentiation\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/eager/automatic_differentiation.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/eager/automatic_differentiation.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "vDJ4XzMqodTy"
+   },
+   "source": [
+    "In the previous tutorial we introduced `Tensor`s and operations on them. In this tutorial we will cover [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation), a key technique for optimizing machine learning models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "GQJysDM__Qb0"
+   },
+   "source": [
+    "## Setup\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "OiMPZStlibBv"
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "tf.enable_eager_execution()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "1CLWJl0QliB0"
+   },
+   "source": [
+    "## Gradient tapes\n",
+    "\n",
+    "TensorFlow provides the [tf.GradientTape](https://www.tensorflow.org/api_docs/python/tf/GradientTape) API for automatic differentiation - computing the gradient of a computation with respect to its input variables. Tensorflow \"records\" all operations executed inside the context of a `tf.GradientTape` onto a \"tape\". Tensorflow then uses that tape and the gradients associated with each recorded operation to compute the gradients of a \"recorded\" computation using [reverse mode differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation).\n",
+    "\n",
+    "For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "bAFeIE8EuVIq"
+   },
+   "outputs": [],
+   "source": [
+    "x = tf.ones((2, 2))\n",
+    "  \n",
+    "with tf.GradientTape() as t:\n",
+    "  t.watch(x)\n",
+    "  y = tf.reduce_sum(x)\n",
+    "  z = tf.multiply(y, y)\n",
+    "\n",
+    "# Derivative of z with respect to the original input tensor x\n",
+    "dz_dx = t.gradient(z, x)\n",
+    "for i in [0, 1]:\n",
+    "  for j in [0, 1]:\n",
+    "    assert dz_dx[i][j].numpy() == 8.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "1CLWJl0QliB0"
+   },
+   "source": [
+    "You can also request gradients of the output with respect to intermediate values computed during a \"recorded\" `tf.GradientTape` context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = tf.ones((2, 2))\n",
+    "  \n",
+    "with tf.GradientTape() as t:\n",
+    "  t.watch(x)\n",
+    "  y = tf.reduce_sum(x)\n",
+    "  z = tf.multiply(y, y)\n",
+    "\n",
+    "# Use the tape to compute the derivative of z with respect to the\n",
+    "# intermediate value y.\n",
+    "dz_dy = t.gradient(z, y)\n",
+    "assert dz_dy.numpy() == 8.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "1CLWJl0QliB0"
+   },
+   "source": [
+    "By default, the resources held by a GradientTape are released as soon as GradientTape.gradient() method is called. To compute multiple gradients over the same computation, create a `persistent` gradient tape. This allows multiple calls to the gradient() method. as resources are released when the tape object is garbage collected. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "bAFeIE8EuVIq"
+   },
+   "outputs": [],
+   "source": [
+    "x = tf.constant(3.0)\n",
+    "with tf.GradientTape(persistent=True) as t:\n",
+    "  t.watch(x)\n",
+    "  y = x * x\n",
+    "  z = y * y\n",
+    "dz_dx = t.gradient(z, x)  # 108.0 (4*x^3 at x = 3)\n",
+    "dy_dx = t.gradient(y, x)  # 6.0\n",
+    "del t  # Drop the reference to the tape\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "1CLWJl0QliB0"
+   },
+   "source": [
+    "### Recording control flow\n",
+    "\n",
+    "Because tapes record operations as they are executed, Python control flow (using `if`s and `while`s for example) is naturally handled:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "9FViq92UX7P8"
+   },
+   "outputs": [],
+   "source": [
+    "def f(x, y):\n",
+    "  output = 1.0\n",
+    "  for i in range(y):\n",
+    "    if i > 1 and i < 5:\n",
+    "      output = tf.multiply(output, x)\n",
+    "  return output\n",
+    "\n",
+    "def grad(x, y):\n",
+    "  with tf.GradientTape() as t:\n",
+    "    t.watch(x)\n",
+    "    out = f(x, y)\n",
+    "  return t.gradient(out, x) \n",
+    "\n",
+    "x = tf.convert_to_tensor(2.0)\n",
+    "\n",
+    "assert grad(x, 6).numpy() == 12.0\n",
+    "assert grad(x, 5).numpy() == 12.0\n",
+    "assert grad(x, 4).numpy() == 4.0\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "DK05KXrAAld3"
+   },
+   "source": [
+    "### Higher-order gradients\n",
+    "\n",
+    "Operations inside of the `GradientTape` context manager are recorded for automatic differentiation. If gradients are computed in that context, then the gradient computation is recorded as well. As a result, the exact same API works for higher-order gradients as well. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "cPQgthZ7ugRJ"
+   },
+   "outputs": [
     {
-      "metadata": {
-        "colab_type": "text",
-        "id": "t09eeeR5prIJ"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "##### Copyright 2018 The TensorFlow Authors."
-      ]
-    },
-    {
-      "metadata": {
-        "cellView": "form",
-        "colab_type": "code",
-        "id": "GCCk8_dHpuNf",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "id": "xh8WkEwWpnm7"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "# Automatic differentiation and gradient tape"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "id": "idv0bPeCp325"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/eager/automatic_differentiation\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/eager/automatic_differentiation.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/eager/automatic_differentiation.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-        "  </td>\n",
-        "</table>"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "id": "vDJ4XzMqodTy"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "In the previous tutorial we introduced `Tensor`s and operations on them. In this tutorial we will cover [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation), a key technique for optimizing machine learning models."
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "id": "GQJysDM__Qb0"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Setup\n"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "OiMPZStlibBv",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "import tensorflow as tf\n",
-        "\n",
-        "tf.enable_eager_execution()\n",
-        "\n",
-        "tfe = tf.contrib.eager # Shorthand for some symbols"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "id": "1CLWJl0QliB0"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Derivatives of a function\n",
-        "\n",
-        "TensorFlow provides APIs for automatic differentiation - computing the derivative of a function. The way that more closely mimics the math is to encapsulate the computation in a Python function, say `f`, and use `tfe.gradients_function` to create a function that computes the derivatives of `f` with respect to its arguments. If you're familiar with [autograd](https://github.com/HIPS/autograd) for differentiating numpy functions, this will be familiar. For example: "
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "9FViq92UX7P8",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "from math import pi\n",
-        "\n",
-        "def f(x):\n",
-        "  return tf.square(tf.sin(x))\n",
-        "\n",
-        "assert f(pi/2).numpy() == 1.0\n",
-        "\n",
-        "\n",
-        "# grad_f will return a list of derivatives of f\n",
-        "# with respect to its arguments. Since f() has a single argument,\n",
-        "# grad_f will return a list with a single element.\n",
-        "grad_f = tfe.gradients_function(f)\n",
-        "assert tf.abs(grad_f(pi/2)[0]).numpy() < 1e-7"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "id": "v9fPs8RyopCf"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "### Higher-order gradients\n",
-        "\n",
-        "The same API can be used to differentiate as many times as you like:\n"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "3D0ZvnGYo0rW",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "def f(x):\n",
-        "  return tf.square(tf.sin(x))\n",
-        "\n",
-        "def grad(f):\n",
-        "  return lambda x: tfe.gradients_function(f)(x)[0]\n",
-        "\n",
-        "x = tf.lin_space(-2*pi, 2*pi, 100)  # 100 points between -2π and +2π\n",
-        "\n",
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "plt.plot(x, f(x), label=\"f\")\n",
-        "plt.plot(x, grad(f)(x), label=\"first derivative\")\n",
-        "plt.plot(x, grad(grad(f))(x), label=\"second derivative\")\n",
-        "plt.plot(x, grad(grad(grad(f)))(x), label=\"third derivative\")\n",
-        "plt.legend()\n",
-        "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "id": "-39gouo7mtgu"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Gradient tapes\n",
-        "\n",
-        "Every differentiable TensorFlow operation has an associated gradient function. For example, the gradient function of `tf.square(x)` would be a function that returns `2.0 * x`.  To compute the gradient of a user-defined function (like `f(x)` in the example above), TensorFlow first \"records\" all the operations applied to compute the output of the function. We call this record a \"tape\". It then uses that tape and the gradients functions associated with each primitive operation to compute the gradients of the user-defined function using [reverse mode differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation).\n",
-        "\n",
-        "Since operations are recorded as they are executed, Python control flow (using `if`s and `while`s for example) is naturally handled:\n",
-        "\n"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "MH0UfjympWf7",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "def f(x, y):\n",
-        "  output = 1\n",
-        "  # Must use range(int(y)) instead of range(y) in Python 3 when\n",
-        "  # using TensorFlow 1.10 and earlier. Can use range(y) in 1.11+\n",
-        "  for i in range(int(y)):\n",
-        "    output = tf.multiply(output, x)\n",
-        "  return output\n",
-        "\n",
-        "def g(x, y):\n",
-        "  # Return the gradient of `f` with respect to it's first parameter\n",
-        "  return tfe.gradients_function(f)(x, y)[0]\n",
-        "\n",
-        "assert f(3.0, 2).numpy() == 9.0   # f(x, 2) is essentially x * x\n",
-        "assert g(3.0, 2).numpy() == 6.0   # And its gradient will be 2 * x\n",
-        "assert f(4.0, 3).numpy() == 64.0  # f(x, 3) is essentially x * x * x\n",
-        "assert g(4.0, 3).numpy() == 48.0  # And its gradient will be 3 * x * x"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "id": "aNmR5-jhpX2t"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "At times it may be inconvenient to encapsulate computation of interest into a function. For example, if you want the gradient of the output with respect to intermediate values computed in the function. In such cases, the slightly more verbose but explicit [tf.GradientTape](https://www.tensorflow.org/api_docs/python/tf/GradientTape) context is useful. All computation inside the context of a `tf.GradientTape` is \"recorded\".\n",
-        "\n",
-        "For example:"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "bAFeIE8EuVIq",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "x = tf.ones((2, 2))\n",
-        "  \n",
-        "# a single t.gradient() call when the bug is resolved.\n",
-        "with tf.GradientTape(persistent=True) as t:\n",
-        "  t.watch(x)\n",
-        "  y = tf.reduce_sum(x)\n",
-        "  z = tf.multiply(y, y)\n",
-        "\n",
-        "# Use the same tape to compute the derivative of z with respect to the\n",
-        "# intermediate value y.\n",
-        "dz_dy = t.gradient(z, y)\n",
-        "assert dz_dy.numpy() == 8.0\n",
-        "\n",
-        "# Derivative of z with respect to the original input tensor x\n",
-        "dz_dx = t.gradient(z, x)\n",
-        "for i in [0, 1]:\n",
-        "  for j in [0, 1]:\n",
-        "    assert dz_dx[i][j].numpy() == 8.0"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "id": "DK05KXrAAld3"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "### Higher-order gradients\n",
-        "\n",
-        "Operations inside of the `GradientTape` context manager are recorded for automatic differentiation. If gradients are computed in that context, then the gradient computation is recorded as well. As a result, the exact same API works for higher-order gradients as well. For example:"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "cPQgthZ7ugRJ",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "x = tf.Variable(1.0)  # Convert the Python 1.0 to a Tensor object\n",
-        "\n",
-        "with tf.GradientTape() as t:\n",
-        "  with tf.GradientTape() as t2:\n",
-        "    y = x * x * x\n",
-        "  # Compute the gradient inside the 't' context manager\n",
-        "  # which means the gradient computation is differentiable as well.\n",
-        "  dy_dx = t2.gradient(y, x)\n",
-        "d2y_dx2 = t.gradient(dy_dx, x)\n",
-        "\n",
-        "assert dy_dx.numpy() == 3.0\n",
-        "assert d2y_dx2.numpy() == 6.0"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "id": "4U1KKzUpNl58"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Next Steps\n",
-        "\n",
-        "In this tutorial we covered gradient computation in TensorFlow. With that we have enough of the primitives required to build and train neural networks."
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /usr/local/google/home/kaftan/.local/lib/python3.6/site-packages/tensorflow/python/ops/resource_variable_ops.py:636: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Colocations handled automatically by placer.\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "x = tf.Variable(1.0)  # Create a Tensorflow variable initialized to 1.0\n",
+    "\n",
+    "with tf.GradientTape() as t:\n",
+    "  with tf.GradientTape() as t2:\n",
+    "    y = x * x * x\n",
+    "  # Compute the gradient inside the 't' context manager\n",
+    "  # which means the gradient computation is differentiable as well.\n",
+    "  dy_dx = t2.gradient(y, x)\n",
+    "d2y_dx2 = t.gradient(dy_dx, x)\n",
+    "\n",
+    "assert dy_dx.numpy() == 3.0\n",
+    "assert d2y_dx2.numpy() == 6.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "4U1KKzUpNl58"
+   },
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "In this tutorial we covered gradient computation in TensorFlow. With that we have enough of the primitives required to build and train neural networks."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "automatic_differentiation.ipynb",
+   "private_outputs": true,
+   "provenance": [],
+   "toc_visible": true,
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/site/en/tutorials/eager/automatic_differentiation.ipynb
+++ b/site/en/tutorials/eager/automatic_differentiation.ipynb
@@ -1,329 +1,311 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "t09eeeR5prIJ"
-   },
-   "source": [
-    "##### Copyright 2018 The TensorFlow Authors."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "cellView": "form",
-    "colab": {},
-    "colab_type": "code",
-    "id": "GCCk8_dHpuNf"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "# https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "xh8WkEwWpnm7"
-   },
-   "source": [
-    "# Automatic differentiation and gradient tape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "idv0bPeCp325"
-   },
-   "source": [
-    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/eager/automatic_differentiation\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/eager/automatic_differentiation.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/eager/automatic_differentiation.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "vDJ4XzMqodTy"
-   },
-   "source": [
-    "In the previous tutorial we introduced `Tensor`s and operations on them. In this tutorial we will cover [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation), a key technique for optimizing machine learning models."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "GQJysDM__Qb0"
-   },
-   "source": [
-    "## Setup\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "OiMPZStlibBv"
-   },
-   "outputs": [],
-   "source": [
-    "import tensorflow as tf\n",
-    "\n",
-    "tf.enable_eager_execution()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "1CLWJl0QliB0"
-   },
-   "source": [
-    "## Gradient tapes\n",
-    "\n",
-    "TensorFlow provides the [tf.GradientTape](https://www.tensorflow.org/api_docs/python/tf/GradientTape) API for automatic differentiation - computing the gradient of a computation with respect to its input variables. Tensorflow \"records\" all operations executed inside the context of a `tf.GradientTape` onto a \"tape\". Tensorflow then uses that tape and the gradients associated with each recorded operation to compute the gradients of a \"recorded\" computation using [reverse mode differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation).\n",
-    "\n",
-    "For example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "bAFeIE8EuVIq"
-   },
-   "outputs": [],
-   "source": [
-    "x = tf.ones((2, 2))\n",
-    "  \n",
-    "with tf.GradientTape() as t:\n",
-    "  t.watch(x)\n",
-    "  y = tf.reduce_sum(x)\n",
-    "  z = tf.multiply(y, y)\n",
-    "\n",
-    "# Derivative of z with respect to the original input tensor x\n",
-    "dz_dx = t.gradient(z, x)\n",
-    "for i in [0, 1]:\n",
-    "  for j in [0, 1]:\n",
-    "    assert dz_dx[i][j].numpy() == 8.0"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "1CLWJl0QliB0"
-   },
-   "source": [
-    "You can also request gradients of the output with respect to intermediate values computed during a \"recorded\" `tf.GradientTape` context."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x = tf.ones((2, 2))\n",
-    "  \n",
-    "with tf.GradientTape() as t:\n",
-    "  t.watch(x)\n",
-    "  y = tf.reduce_sum(x)\n",
-    "  z = tf.multiply(y, y)\n",
-    "\n",
-    "# Use the tape to compute the derivative of z with respect to the\n",
-    "# intermediate value y.\n",
-    "dz_dy = t.gradient(z, y)\n",
-    "assert dz_dy.numpy() == 8.0"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "1CLWJl0QliB0"
-   },
-   "source": [
-    "By default, the resources held by a GradientTape are released as soon as GradientTape.gradient() method is called. To compute multiple gradients over the same computation, create a `persistent` gradient tape. This allows multiple calls to the gradient() method. as resources are released when the tape object is garbage collected. For example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "bAFeIE8EuVIq"
-   },
-   "outputs": [],
-   "source": [
-    "x = tf.constant(3.0)\n",
-    "with tf.GradientTape(persistent=True) as t:\n",
-    "  t.watch(x)\n",
-    "  y = x * x\n",
-    "  z = y * y\n",
-    "dz_dx = t.gradient(z, x)  # 108.0 (4*x^3 at x = 3)\n",
-    "dy_dx = t.gradient(y, x)  # 6.0\n",
-    "del t  # Drop the reference to the tape\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "1CLWJl0QliB0"
-   },
-   "source": [
-    "### Recording control flow\n",
-    "\n",
-    "Because tapes record operations as they are executed, Python control flow (using `if`s and `while`s for example) is naturally handled:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "9FViq92UX7P8"
-   },
-   "outputs": [],
-   "source": [
-    "def f(x, y):\n",
-    "  output = 1.0\n",
-    "  for i in range(y):\n",
-    "    if i > 1 and i < 5:\n",
-    "      output = tf.multiply(output, x)\n",
-    "  return output\n",
-    "\n",
-    "def grad(x, y):\n",
-    "  with tf.GradientTape() as t:\n",
-    "    t.watch(x)\n",
-    "    out = f(x, y)\n",
-    "  return t.gradient(out, x) \n",
-    "\n",
-    "x = tf.convert_to_tensor(2.0)\n",
-    "\n",
-    "assert grad(x, 6).numpy() == 12.0\n",
-    "assert grad(x, 5).numpy() == 12.0\n",
-    "assert grad(x, 4).numpy() == 4.0\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "DK05KXrAAld3"
-   },
-   "source": [
-    "### Higher-order gradients\n",
-    "\n",
-    "Operations inside of the `GradientTape` context manager are recorded for automatic differentiation. If gradients are computed in that context, then the gradient computation is recorded as well. As a result, the exact same API works for higher-order gradients as well. For example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "cPQgthZ7ugRJ"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:From /usr/local/google/home/kaftan/.local/lib/python3.6/site-packages/tensorflow/python/ops/resource_variable_ops.py:636: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "Colocations handled automatically by placer.\n"
-     ]
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "automatic_differentiation.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
     }
-   ],
-   "source": [
-    "x = tf.Variable(1.0)  # Create a Tensorflow variable initialized to 1.0\n",
-    "\n",
-    "with tf.GradientTape() as t:\n",
-    "  with tf.GradientTape() as t2:\n",
-    "    y = x * x * x\n",
-    "  # Compute the gradient inside the 't' context manager\n",
-    "  # which means the gradient computation is differentiable as well.\n",
-    "  dy_dx = t2.gradient(y, x)\n",
-    "d2y_dx2 = t.gradient(dy_dx, x)\n",
-    "\n",
-    "assert dy_dx.numpy() == 3.0\n",
-    "assert d2y_dx2.numpy() == 6.0"
-   ]
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "4U1KKzUpNl58"
-   },
-   "source": [
-    "## Next Steps\n",
-    "\n",
-    "In this tutorial we covered gradient computation in TensorFlow. With that we have enough of the primitives required to build and train neural networks."
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "collapsed_sections": [],
-   "name": "automatic_differentiation.ipynb",
-   "private_outputs": true,
-   "provenance": [],
-   "toc_visible": true,
-   "version": "0.3.2"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.2"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+  "cells": [
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "t09eeeR5prIJ"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "##### Copyright 2018 The TensorFlow Authors."
+      ]
+    },
+    {
+      "metadata": {
+        "cellView": "form",
+        "colab_type": "code",
+        "id": "GCCk8_dHpuNf",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "xh8WkEwWpnm7"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "# Automatic differentiation and gradient tape"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "idv0bPeCp325"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/eager/automatic_differentiation\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/eager/automatic_differentiation.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/eager/automatic_differentiation.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "vDJ4XzMqodTy"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "In the previous tutorial we introduced `Tensor`s and operations on them. In this tutorial we will cover [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation), a key technique for optimizing machine learning models."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "GQJysDM__Qb0"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Setup\n"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "OiMPZStlibBv",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "import tensorflow as tf\n",
+        "\n",
+        "tf.enable_eager_execution()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "1CLWJl0QliB0"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Gradient tapes\n",
+        "\n",
+        "TensorFlow provides the [tf.GradientTape](https://www.tensorflow.org/api_docs/python/tf/GradientTape) API for automatic differentiation - computing the gradient of a computation with respect to its input variables. Tensorflow \"records\" all operations executed inside the context of a `tf.GradientTape` onto a \"tape\". Tensorflow then uses that tape and the gradients associated with each recorded operation to compute the gradients of a \"recorded\" computation using [reverse mode differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation).\n",
+        "\n",
+        "For example:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "bAFeIE8EuVIq",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "x = tf.ones((2, 2))\n",
+        "  \n",
+        "with tf.GradientTape() as t:\n",
+        "  t.watch(x)\n",
+        "  y = tf.reduce_sum(x)\n",
+        "  z = tf.multiply(y, y)\n",
+        "\n",
+        "# Derivative of z with respect to the original input tensor x\n",
+        "dz_dx = t.gradient(z, x)\n",
+        "for i in [0, 1]:\n",
+        "  for j in [0, 1]:\n",
+        "    assert dz_dx[i][j].numpy() == 8.0"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "N4VlqKFzzGaC",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "You can also request gradients of the output with respect to intermediate values computed during a \"recorded\" `tf.GradientTape` context."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "7XaPRAwUyYms",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "x = tf.ones((2, 2))\n",
+        "  \n",
+        "with tf.GradientTape() as t:\n",
+        "  t.watch(x)\n",
+        "  y = tf.reduce_sum(x)\n",
+        "  z = tf.multiply(y, y)\n",
+        "\n",
+        "# Use the tape to compute the derivative of z with respect to the\n",
+        "# intermediate value y.\n",
+        "dz_dy = t.gradient(z, y)\n",
+        "assert dz_dy.numpy() == 8.0"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "ISkXuY7YzIcS",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "By default, the resources held by a GradientTape are released as soon as GradientTape.gradient() method is called. To compute multiple gradients over the same computation, create a `persistent` gradient tape. This allows multiple calls to the `gradient()` method. as resources are released when the tape object is garbage collected. For example:"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "zZaCm3-9zVCi",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "x = tf.constant(3.0)\n",
+        "with tf.GradientTape(persistent=True) as t:\n",
+        "  t.watch(x)\n",
+        "  y = x * x\n",
+        "  z = y * y\n",
+        "dz_dx = t.gradient(z, x)  # 108.0 (4*x^3 at x = 3)\n",
+        "dy_dx = t.gradient(y, x)  # 6.0\n",
+        "del t  # Drop the reference to the tape"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "6kADybtQzYj4",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Recording control flow\n",
+        "\n",
+        "Because tapes record operations as they are executed, Python control flow (using `if`s and `while`s for example) is naturally handled:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "9FViq92UX7P8",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "def f(x, y):\n",
+        "  output = 1.0\n",
+        "  for i in range(y):\n",
+        "    if i > 1 and i < 5:\n",
+        "      output = tf.multiply(output, x)\n",
+        "  return output\n",
+        "\n",
+        "def grad(x, y):\n",
+        "  with tf.GradientTape() as t:\n",
+        "    t.watch(x)\n",
+        "    out = f(x, y)\n",
+        "  return t.gradient(out, x) \n",
+        "\n",
+        "x = tf.convert_to_tensor(2.0)\n",
+        "\n",
+        "assert grad(x, 6).numpy() == 12.0\n",
+        "assert grad(x, 5).numpy() == 12.0\n",
+        "assert grad(x, 4).numpy() == 4.0\n"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "DK05KXrAAld3"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Higher-order gradients\n",
+        "\n",
+        "Operations inside of the `GradientTape` context manager are recorded for automatic differentiation. If gradients are computed in that context, then the gradient computation is recorded as well. As a result, the exact same API works for higher-order gradients as well. For example:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "cPQgthZ7ugRJ",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "x = tf.Variable(1.0)  # Create a Tensorflow variable initialized to 1.0\n",
+        "\n",
+        "with tf.GradientTape() as t:\n",
+        "  with tf.GradientTape() as t2:\n",
+        "    y = x * x * x\n",
+        "  # Compute the gradient inside the 't' context manager\n",
+        "  # which means the gradient computation is differentiable as well.\n",
+        "  dy_dx = t2.gradient(y, x)\n",
+        "d2y_dx2 = t.gradient(dy_dx, x)\n",
+        "\n",
+        "assert dy_dx.numpy() == 3.0\n",
+        "assert d2y_dx2.numpy() == 6.0"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "4U1KKzUpNl58"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Next Steps\n",
+        "\n",
+        "In this tutorial we covered gradient computation in TensorFlow. With that we have enough of the primitives required to build and train neural networks."
+      ]
+    }
+  ]
 }

--- a/site/en/tutorials/eager/custom_layers.ipynb
+++ b/site/en/tutorials/eager/custom_layers.ipynb
@@ -1,405 +1,417 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "custom_layers.ipynb",
-      "version": "0.3.2",
-      "views": {},
-      "default_view": {},
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "tDnwEv8FtJm7"
+   },
+   "source": [
+    "##### Copyright 2018 The TensorFlow Authors."
+   ]
   },
-  "cells": [
-    {
-      "metadata": {
-        "id": "tDnwEv8FtJm7",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "##### Copyright 2018 The TensorFlow Authors."
-      ]
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "autoexec": {
+      "startup": false,
+      "wait_interval": 0
+     }
     },
-    {
-      "metadata": {
-        "id": "JlknJBWQtKkI",
-        "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        },
-        "cellView": "form"
-      },
-      "cell_type": "code",
-      "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
+    "colab_type": "code",
+    "id": "JlknJBWQtKkI"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "60RdWsg1tETW"
+   },
+   "source": [
+    "# Custom layers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "BcJg7Enms86w"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/eager/custom_layers\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/eager/custom_layers.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/eager/custom_layers.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "UEu3q4jmpKVT"
+   },
+   "source": [
+    "We recommend using `tf.keras` as a high-level API for building neural networks. That said, most TensorFlow APIs are usable with eager execution.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "autoexec": {
+      "startup": false,
+      "wait_interval": 0
+     }
     },
-    {
-      "metadata": {
-        "id": "60RdWsg1tETW",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "# Custom layers"
-      ]
+    "colab_type": "code",
+    "id": "pwX7Fii1rwsJ"
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "tf.enable_eager_execution()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "zSFfVVjkrrsI"
+   },
+   "source": [
+    "## Layers: common sets of useful operations\n",
+    "\n",
+    "Most of the time when writing code for machine learning models you want to operate at a higher level of abstraction than individual operations and manipulation of individual variables.\n",
+    "\n",
+    "Many machine learning models are expressible as the composition and stacking of relatively simple layers, and TensorFlow provides both a set of many common layers as a well as easy ways for you to write your own application-specific layers either from scratch or as the composition of existing layers.\n",
+    "\n",
+    "TensorFlow includes the full [Keras](https://keras.io) API in the tf.keras package, and the Keras layers are very useful when building your own models.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "autoexec": {
+      "startup": false,
+      "wait_interval": 0
+     }
     },
-    {
-      "metadata": {
-        "id": "BcJg7Enms86w",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/eager/custom_layers\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/eager/custom_layers.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/eager/custom_layers.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-        "  </td>\n",
-        "</table>"
-      ]
+    "colab_type": "code",
+    "id": "8PyXlPl-4TzQ"
+   },
+   "outputs": [],
+   "source": [
+    "# In the tf.keras.layers package, layers are objects. To construct a layer,\n",
+    "# simply construct the object. Most layers take as a first argument the number\n",
+    "# of output dimensions / channels.\n",
+    "layer = tf.keras.layers.Dense(100)\n",
+    "# The number of input dimensions is often unnecessary, as it can be inferred\n",
+    "# the first time the layer is used, but it can be provided if you want to \n",
+    "# specify it manually, which is useful in some complex models.\n",
+    "layer = tf.keras.layers.Dense(10, input_shape=(None, 5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Fn69xxPO5Psr"
+   },
+   "source": [
+    "The full list of pre-existing layers can be seen in [the documentation](https://www.tensorflow.org/api_docs/python/tf/keras/layers). It includes Dense (a fully-connected layer),\n",
+    "Conv2D, LSTM, BatchNormalization, Dropout, and many others."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "autoexec": {
+      "startup": false,
+      "wait_interval": 0
+     }
     },
-    {
-      "metadata": {
-        "id": "UEu3q4jmpKVT",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "We recommend using `tf.keras` as a high-level API for building neural networks. That said, most TensorFlow APIs are usable with eager execution.\n"
-      ]
+    "colab_type": "code",
+    "id": "E3XKNknP5Mhb"
+   },
+   "outputs": [],
+   "source": [
+    "# To use a layer, simply call it.\n",
+    "layer(tf.zeros([10, 5]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "autoexec": {
+      "startup": false,
+      "wait_interval": 0
+     }
     },
-    {
-      "metadata": {
-        "id": "pwX7Fii1rwsJ",
-        "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "import tensorflow as tf\n",
-        "tfe = tf.contrib.eager\n",
-        "\n",
-        "tf.enable_eager_execution()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+    "colab_type": "code",
+    "id": "Wt_Nsv-L5t2s"
+   },
+   "outputs": [],
+   "source": [
+    "# Layers have many useful methods. For example, you can inspect all variables\n",
+    "# in a layer by calling layer.variables. In this case a fully-connected layer\n",
+    "# will have variables for weights and biases.\n",
+    "layer.variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "autoexec": {
+      "startup": false,
+      "wait_interval": 0
+     }
     },
-    {
-      "metadata": {
-        "id": "zSFfVVjkrrsI",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Layers: common sets of useful operations\n",
-        "\n",
-        "Most of the time when writing code for machine learning models you want to operate at a higher level of abstraction than individual operations and manipulation of individual variables.\n",
-        "\n",
-        "Many machine learning models are expressible as the composition and stacking of relatively simple layers, and TensorFlow provides both a set of many common layers as a well as easy ways for you to write your own application-specific layers either from scratch or as the composition of existing layers.\n",
-        "\n",
-        "TensorFlow includes the full [Keras](https://keras.io) API in the tf.keras package, and the Keras layers are very useful when building your own models.\n"
-      ]
+    "colab_type": "code",
+    "id": "6ilvKjz8_4MQ"
+   },
+   "outputs": [],
+   "source": [
+    "# The variables are also accessible through nice accessors\n",
+    "layer.kernel, layer.bias"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "O0kDbE54-5VS"
+   },
+   "source": [
+    "## Implementing custom layers\n",
+    "The best way to implement your own layer is extending the tf.keras.Layer class and implementing:\n",
+    "  *  `__init__` , where you can do all input-independent initialization\n",
+    "  * `build`, where you know the shapes of the input tensors and can do the rest of the initialization\n",
+    "  * `call`, where you do the forward computation\n",
+    "\n",
+    "Note that you don't have to wait until `build` is called to create your variables, you can also create them in `__init__`. However, the advantage of creating them in `build` is that it enables late variable creation based on the shape of the inputs the layer will operate on. On the other hand, creating variables in `__init__` would mean that shapes required to create the variables will need to be explicitly specified."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "autoexec": {
+      "startup": false,
+      "wait_interval": 0
+     }
     },
-    {
-      "metadata": {
-        "id": "8PyXlPl-4TzQ",
-        "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "# In the tf.keras.layers package, layers are objects. To construct a layer,\n",
-        "# simply construct the object. Most layers take as a first argument the number\n",
-        "# of output dimensions / channels.\n",
-        "layer = tf.keras.layers.Dense(100)\n",
-        "# The number of input dimensions is often unnecessary, as it can be inferred\n",
-        "# the first time the layer is used, but it can be provided if you want to \n",
-        "# specify it manually, which is useful in some complex models.\n",
-        "layer = tf.keras.layers.Dense(10, input_shape=(None, 5))"
-      ],
-      "execution_count": 0,
-      "outputs": []
+    "colab_type": "code",
+    "id": "5Byl3n1k5kIy"
+   },
+   "outputs": [],
+   "source": [
+    "class MyDenseLayer(tf.keras.layers.Layer):\n",
+    "  def __init__(self, num_outputs):\n",
+    "    super(MyDenseLayer, self).__init__()\n",
+    "    self.num_outputs = num_outputs\n",
+    "    \n",
+    "  def build(self, input_shape):\n",
+    "    self.kernel = self.add_variable(\"kernel\", \n",
+    "                                    shape=[input_shape[-1].value, \n",
+    "                                           self.num_outputs])\n",
+    "    \n",
+    "  def call(self, input):\n",
+    "    return tf.matmul(input, self.kernel)\n",
+    "  \n",
+    "layer = MyDenseLayer(10)\n",
+    "print(layer(tf.zeros([10, 5])))\n",
+    "print(layer.variables)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "tk8E2vY0-z4Z"
+   },
+   "source": [
+    "Note that you don't have to wait until `build` is called to create your variables, you can also create them in `__init__`.\n",
+    "\n",
+    "Overall code is easier to read and maintain if it uses standard layers whenever possible, as other readers will be familiar with the behavior of standard layers. If you want to use a layer which is not present in tf.keras.layers or tf.contrib.layers, consider filing a [github issue](http://github.com/tensorflow/tensorflow/issues/new) or, even better, sending us a pull request!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Qhg4KlbKrs3G"
+   },
+   "source": [
+    "## Models: composing layers\n",
+    "\n",
+    "Many interesting layer-like things in machine learning models are implemented by composing existing layers. For example, each residual block in a resnet is a composition of convolutions, batch normalizations, and a shortcut.\n",
+    "\n",
+    "The main class used when creating a layer-like thing which contains other layers is tf.keras.Model. Implementing one is done by inheriting from tf.keras.Model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "autoexec": {
+      "startup": false,
+      "wait_interval": 0
+     }
     },
-    {
-      "metadata": {
-        "id": "Fn69xxPO5Psr",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "The full list of pre-existing layers can be seen in [the documentation](https://www.tensorflow.org/api_docs/python/tf/keras/layers). It includes Dense (a fully-connected layer),\n",
-        "Conv2D, LSTM, BatchNormalization, Dropout, and many others."
-      ]
+    "colab_type": "code",
+    "id": "N30DTXiRASlb"
+   },
+   "outputs": [],
+   "source": [
+    "class ResnetIdentityBlock(tf.keras.Model):\n",
+    "  def __init__(self, kernel_size, filters):\n",
+    "    super(ResnetIdentityBlock, self).__init__(name='')\n",
+    "    filters1, filters2, filters3 = filters\n",
+    "\n",
+    "    self.conv2a = tf.keras.layers.Conv2D(filters1, (1, 1))\n",
+    "    self.bn2a = tf.keras.layers.BatchNormalization()\n",
+    "\n",
+    "    self.conv2b = tf.keras.layers.Conv2D(filters2, kernel_size, padding='same')\n",
+    "    self.bn2b = tf.keras.layers.BatchNormalization()\n",
+    "\n",
+    "    self.conv2c = tf.keras.layers.Conv2D(filters3, (1, 1))\n",
+    "    self.bn2c = tf.keras.layers.BatchNormalization()\n",
+    "\n",
+    "  def call(self, input_tensor, training=False):\n",
+    "    x = self.conv2a(input_tensor)\n",
+    "    x = self.bn2a(x, training=training)\n",
+    "    x = tf.nn.relu(x)\n",
+    "\n",
+    "    x = self.conv2b(x)\n",
+    "    x = self.bn2b(x, training=training)\n",
+    "    x = tf.nn.relu(x)\n",
+    "\n",
+    "    x = self.conv2c(x)\n",
+    "    x = self.bn2c(x, training=training)\n",
+    "\n",
+    "    x += input_tensor\n",
+    "    return tf.nn.relu(x)\n",
+    "\n",
+    "    \n",
+    "block = ResnetIdentityBlock(1, [1, 2, 3])\n",
+    "print(block(tf.zeros([1, 2, 3, 3])))\n",
+    "print([x.name for x in block.variables])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "wYfucVw65PMj"
+   },
+   "source": [
+    "Much of the time, however, models which compose many layers simply call one layer after the other. This can be done in very little code using tf.keras.Sequential"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "autoexec": {
+      "startup": false,
+      "wait_interval": 0
+     }
     },
-    {
-      "metadata": {
-        "id": "E3XKNknP5Mhb",
-        "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "# To use a layer, simply call it.\n",
-        "layer(tf.zeros([10, 5]))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "Wt_Nsv-L5t2s",
-        "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "# Layers have many useful methods. For example, you can inspect all variables\n",
-        "# in a layer by calling layer.variables. In this case a fully-connected layer\n",
-        "# will have variables for weights and biases.\n",
-        "layer.variables"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "6ilvKjz8_4MQ",
-        "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "# The variables are also accessible through nice accessors\n",
-        "layer.kernel, layer.bias"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "O0kDbE54-5VS",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Implementing custom layers\n",
-        "The best way to implement your own layer is extending the tf.keras.Layer class and implementing:\n",
-        "  *  `__init__` , where you can do all input-independent initialization\n",
-        "  * `build`, where you know the shapes of the input tensors and can do the rest of the initialization\n",
-        "  * `call`, where you do the forward computation\n",
-        "\n",
-        "Note that you don't have to wait until `build` is called to create your variables, you can also create them in `__init__`. However, the advantage of creating them in `build` is that it enables late variable creation based on the shape of the inputs the layer will operate on. On the other hand, creating variables in `__init__` would mean that shapes required to create the variables will need to be explicitly specified."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "5Byl3n1k5kIy",
-        "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "class MyDenseLayer(tf.keras.layers.Layer):\n",
-        "  def __init__(self, num_outputs):\n",
-        "    super(MyDenseLayer, self).__init__()\n",
-        "    self.num_outputs = num_outputs\n",
-        "    \n",
-        "  def build(self, input_shape):\n",
-        "    self.kernel = self.add_variable(\"kernel\", \n",
-        "                                    shape=[input_shape[-1].value, \n",
-        "                                           self.num_outputs])\n",
-        "    \n",
-        "  def call(self, input):\n",
-        "    return tf.matmul(input, self.kernel)\n",
-        "  \n",
-        "layer = MyDenseLayer(10)\n",
-        "print(layer(tf.zeros([10, 5])))\n",
-        "print(layer.variables)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "tk8E2vY0-z4Z",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Note that you don't have to wait until `build` is called to create your variables, you can also create them in `__init__`.\n",
-        "\n",
-        "Overall code is easier to read and maintain if it uses standard layers whenever possible, as other readers will be familiar with the behavior of standard layers. If you want to use a layer which is not present in tf.keras.layers or tf.contrib.layers, consider filing a [github issue](http://github.com/tensorflow/tensorflow/issues/new) or, even better, sending us a pull request!"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "Qhg4KlbKrs3G",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Models: composing layers\n",
-        "\n",
-        "Many interesting layer-like things in machine learning models are implemented by composing existing layers. For example, each residual block in a resnet is a composition of convolutions, batch normalizations, and a shortcut.\n",
-        "\n",
-        "The main class used when creating a layer-like thing which contains other layers is tf.keras.Model. Implementing one is done by inheriting from tf.keras.Model."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "N30DTXiRASlb",
-        "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "class ResnetIdentityBlock(tf.keras.Model):\n",
-        "  def __init__(self, kernel_size, filters):\n",
-        "    super(ResnetIdentityBlock, self).__init__(name='')\n",
-        "    filters1, filters2, filters3 = filters\n",
-        "\n",
-        "    self.conv2a = tf.keras.layers.Conv2D(filters1, (1, 1))\n",
-        "    self.bn2a = tf.keras.layers.BatchNormalization()\n",
-        "\n",
-        "    self.conv2b = tf.keras.layers.Conv2D(filters2, kernel_size, padding='same')\n",
-        "    self.bn2b = tf.keras.layers.BatchNormalization()\n",
-        "\n",
-        "    self.conv2c = tf.keras.layers.Conv2D(filters3, (1, 1))\n",
-        "    self.bn2c = tf.keras.layers.BatchNormalization()\n",
-        "\n",
-        "  def call(self, input_tensor, training=False):\n",
-        "    x = self.conv2a(input_tensor)\n",
-        "    x = self.bn2a(x, training=training)\n",
-        "    x = tf.nn.relu(x)\n",
-        "\n",
-        "    x = self.conv2b(x)\n",
-        "    x = self.bn2b(x, training=training)\n",
-        "    x = tf.nn.relu(x)\n",
-        "\n",
-        "    x = self.conv2c(x)\n",
-        "    x = self.bn2c(x, training=training)\n",
-        "\n",
-        "    x += input_tensor\n",
-        "    return tf.nn.relu(x)\n",
-        "\n",
-        "    \n",
-        "block = ResnetIdentityBlock(1, [1, 2, 3])\n",
-        "print(block(tf.zeros([1, 2, 3, 3])))\n",
-        "print([x.name for x in block.variables])"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "wYfucVw65PMj",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Much of the time, however, models which compose many layers simply call one layer after the other. This can be done in very little code using tf.keras.Sequential"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "L9frk7Ur4uvJ",
-        "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        " my_seq = tf.keras.Sequential([tf.keras.layers.Conv2D(1, (1, 1)),\n",
-        "                               tf.keras.layers.BatchNormalization(),\n",
-        "                               tf.keras.layers.Conv2D(2, 1, \n",
-        "                                                      padding='same'),\n",
-        "                               tf.keras.layers.BatchNormalization(),\n",
-        "                               tf.keras.layers.Conv2D(3, (1, 1)),\n",
-        "                               tf.keras.layers.BatchNormalization()])\n",
-        "my_seq(tf.zeros([1, 2, 3, 3]))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "c5YwYcnuK-wc",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "# Next steps\n",
-        "\n",
-        "Now you can go back to the previous notebook and adapt the linear regression example to use layers and models to be better structured."
-      ]
-    }
-  ]
+    "colab_type": "code",
+    "id": "L9frk7Ur4uvJ"
+   },
+   "outputs": [],
+   "source": [
+    " my_seq = tf.keras.Sequential([tf.keras.layers.Conv2D(1, (1, 1)),\n",
+    "                               tf.keras.layers.BatchNormalization(),\n",
+    "                               tf.keras.layers.Conv2D(2, 1, \n",
+    "                                                      padding='same'),\n",
+    "                               tf.keras.layers.BatchNormalization(),\n",
+    "                               tf.keras.layers.Conv2D(3, (1, 1)),\n",
+    "                               tf.keras.layers.BatchNormalization()])\n",
+    "my_seq(tf.zeros([1, 2, 3, 3]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "c5YwYcnuK-wc"
+   },
+   "source": [
+    "# Next steps\n",
+    "\n",
+    "Now you can go back to the previous notebook and adapt the linear regression example to use layers and models to be better structured."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "default_view": {},
+   "name": "custom_layers.ipynb",
+   "private_outputs": true,
+   "provenance": [],
+   "toc_visible": true,
+   "version": "0.3.2",
+   "views": {}
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/site/en/tutorials/eager/custom_layers.ipynb
+++ b/site/en/tutorials/eager/custom_layers.ipynb
@@ -1,417 +1,358 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "tDnwEv8FtJm7"
-   },
-   "source": [
-    "##### Copyright 2018 The TensorFlow Authors."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "cellView": "form",
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
     "colab": {
-     "autoexec": {
-      "startup": false,
-      "wait_interval": 0
-     }
+      "name": "custom_layers.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true
     },
-    "colab_type": "code",
-    "id": "JlknJBWQtKkI"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "# https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "60RdWsg1tETW"
-   },
-   "source": [
-    "# Custom layers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "BcJg7Enms86w"
-   },
-   "source": [
-    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/eager/custom_layers\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/eager/custom_layers.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/eager/custom_layers.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "UEu3q4jmpKVT"
-   },
-   "source": [
-    "We recommend using `tf.keras` as a high-level API for building neural networks. That said, most TensorFlow APIs are usable with eager execution.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "autoexec": {
-      "startup": false,
-      "wait_interval": 0
-     }
+  "cells": [
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "tDnwEv8FtJm7"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "##### Copyright 2018 The TensorFlow Authors."
+      ]
     },
-    "colab_type": "code",
-    "id": "pwX7Fii1rwsJ"
-   },
-   "outputs": [],
-   "source": [
-    "import tensorflow as tf\n",
-    "\n",
-    "tf.enable_eager_execution()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "zSFfVVjkrrsI"
-   },
-   "source": [
-    "## Layers: common sets of useful operations\n",
-    "\n",
-    "Most of the time when writing code for machine learning models you want to operate at a higher level of abstraction than individual operations and manipulation of individual variables.\n",
-    "\n",
-    "Many machine learning models are expressible as the composition and stacking of relatively simple layers, and TensorFlow provides both a set of many common layers as a well as easy ways for you to write your own application-specific layers either from scratch or as the composition of existing layers.\n",
-    "\n",
-    "TensorFlow includes the full [Keras](https://keras.io) API in the tf.keras package, and the Keras layers are very useful when building your own models.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "autoexec": {
-      "startup": false,
-      "wait_interval": 0
-     }
+    {
+      "metadata": {
+        "cellView": "form",
+        "colab_type": "code",
+        "id": "JlknJBWQtKkI",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
-    "colab_type": "code",
-    "id": "8PyXlPl-4TzQ"
-   },
-   "outputs": [],
-   "source": [
-    "# In the tf.keras.layers package, layers are objects. To construct a layer,\n",
-    "# simply construct the object. Most layers take as a first argument the number\n",
-    "# of output dimensions / channels.\n",
-    "layer = tf.keras.layers.Dense(100)\n",
-    "# The number of input dimensions is often unnecessary, as it can be inferred\n",
-    "# the first time the layer is used, but it can be provided if you want to \n",
-    "# specify it manually, which is useful in some complex models.\n",
-    "layer = tf.keras.layers.Dense(10, input_shape=(None, 5))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Fn69xxPO5Psr"
-   },
-   "source": [
-    "The full list of pre-existing layers can be seen in [the documentation](https://www.tensorflow.org/api_docs/python/tf/keras/layers). It includes Dense (a fully-connected layer),\n",
-    "Conv2D, LSTM, BatchNormalization, Dropout, and many others."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "autoexec": {
-      "startup": false,
-      "wait_interval": 0
-     }
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "60RdWsg1tETW"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "# Custom layers"
+      ]
     },
-    "colab_type": "code",
-    "id": "E3XKNknP5Mhb"
-   },
-   "outputs": [],
-   "source": [
-    "# To use a layer, simply call it.\n",
-    "layer(tf.zeros([10, 5]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "autoexec": {
-      "startup": false,
-      "wait_interval": 0
-     }
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "BcJg7Enms86w"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/eager/custom_layers\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/eager/custom_layers.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/eager/custom_layers.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
     },
-    "colab_type": "code",
-    "id": "Wt_Nsv-L5t2s"
-   },
-   "outputs": [],
-   "source": [
-    "# Layers have many useful methods. For example, you can inspect all variables\n",
-    "# in a layer by calling layer.variables. In this case a fully-connected layer\n",
-    "# will have variables for weights and biases.\n",
-    "layer.variables"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "autoexec": {
-      "startup": false,
-      "wait_interval": 0
-     }
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "UEu3q4jmpKVT"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "We recommend using `tf.keras` as a high-level API for building neural networks. That said, most TensorFlow APIs are usable with eager execution.\n"
+      ]
     },
-    "colab_type": "code",
-    "id": "6ilvKjz8_4MQ"
-   },
-   "outputs": [],
-   "source": [
-    "# The variables are also accessible through nice accessors\n",
-    "layer.kernel, layer.bias"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "O0kDbE54-5VS"
-   },
-   "source": [
-    "## Implementing custom layers\n",
-    "The best way to implement your own layer is extending the tf.keras.Layer class and implementing:\n",
-    "  *  `__init__` , where you can do all input-independent initialization\n",
-    "  * `build`, where you know the shapes of the input tensors and can do the rest of the initialization\n",
-    "  * `call`, where you do the forward computation\n",
-    "\n",
-    "Note that you don't have to wait until `build` is called to create your variables, you can also create them in `__init__`. However, the advantage of creating them in `build` is that it enables late variable creation based on the shape of the inputs the layer will operate on. On the other hand, creating variables in `__init__` would mean that shapes required to create the variables will need to be explicitly specified."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "autoexec": {
-      "startup": false,
-      "wait_interval": 0
-     }
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "pwX7Fii1rwsJ",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "import tensorflow as tf\n",
+        "\n",
+        "tf.enable_eager_execution()"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
-    "colab_type": "code",
-    "id": "5Byl3n1k5kIy"
-   },
-   "outputs": [],
-   "source": [
-    "class MyDenseLayer(tf.keras.layers.Layer):\n",
-    "  def __init__(self, num_outputs):\n",
-    "    super(MyDenseLayer, self).__init__()\n",
-    "    self.num_outputs = num_outputs\n",
-    "    \n",
-    "  def build(self, input_shape):\n",
-    "    self.kernel = self.add_variable(\"kernel\", \n",
-    "                                    shape=[input_shape[-1].value, \n",
-    "                                           self.num_outputs])\n",
-    "    \n",
-    "  def call(self, input):\n",
-    "    return tf.matmul(input, self.kernel)\n",
-    "  \n",
-    "layer = MyDenseLayer(10)\n",
-    "print(layer(tf.zeros([10, 5])))\n",
-    "print(layer.variables)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "tk8E2vY0-z4Z"
-   },
-   "source": [
-    "Note that you don't have to wait until `build` is called to create your variables, you can also create them in `__init__`.\n",
-    "\n",
-    "Overall code is easier to read and maintain if it uses standard layers whenever possible, as other readers will be familiar with the behavior of standard layers. If you want to use a layer which is not present in tf.keras.layers or tf.contrib.layers, consider filing a [github issue](http://github.com/tensorflow/tensorflow/issues/new) or, even better, sending us a pull request!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Qhg4KlbKrs3G"
-   },
-   "source": [
-    "## Models: composing layers\n",
-    "\n",
-    "Many interesting layer-like things in machine learning models are implemented by composing existing layers. For example, each residual block in a resnet is a composition of convolutions, batch normalizations, and a shortcut.\n",
-    "\n",
-    "The main class used when creating a layer-like thing which contains other layers is tf.keras.Model. Implementing one is done by inheriting from tf.keras.Model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "autoexec": {
-      "startup": false,
-      "wait_interval": 0
-     }
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "zSFfVVjkrrsI"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Layers: common sets of useful operations\n",
+        "\n",
+        "Most of the time when writing code for machine learning models you want to operate at a higher level of abstraction than individual operations and manipulation of individual variables.\n",
+        "\n",
+        "Many machine learning models are expressible as the composition and stacking of relatively simple layers, and TensorFlow provides both a set of many common layers as a well as easy ways for you to write your own application-specific layers either from scratch or as the composition of existing layers.\n",
+        "\n",
+        "TensorFlow includes the full [Keras](https://keras.io) API in the tf.keras package, and the Keras layers are very useful when building your own models.\n"
+      ]
     },
-    "colab_type": "code",
-    "id": "N30DTXiRASlb"
-   },
-   "outputs": [],
-   "source": [
-    "class ResnetIdentityBlock(tf.keras.Model):\n",
-    "  def __init__(self, kernel_size, filters):\n",
-    "    super(ResnetIdentityBlock, self).__init__(name='')\n",
-    "    filters1, filters2, filters3 = filters\n",
-    "\n",
-    "    self.conv2a = tf.keras.layers.Conv2D(filters1, (1, 1))\n",
-    "    self.bn2a = tf.keras.layers.BatchNormalization()\n",
-    "\n",
-    "    self.conv2b = tf.keras.layers.Conv2D(filters2, kernel_size, padding='same')\n",
-    "    self.bn2b = tf.keras.layers.BatchNormalization()\n",
-    "\n",
-    "    self.conv2c = tf.keras.layers.Conv2D(filters3, (1, 1))\n",
-    "    self.bn2c = tf.keras.layers.BatchNormalization()\n",
-    "\n",
-    "  def call(self, input_tensor, training=False):\n",
-    "    x = self.conv2a(input_tensor)\n",
-    "    x = self.bn2a(x, training=training)\n",
-    "    x = tf.nn.relu(x)\n",
-    "\n",
-    "    x = self.conv2b(x)\n",
-    "    x = self.bn2b(x, training=training)\n",
-    "    x = tf.nn.relu(x)\n",
-    "\n",
-    "    x = self.conv2c(x)\n",
-    "    x = self.bn2c(x, training=training)\n",
-    "\n",
-    "    x += input_tensor\n",
-    "    return tf.nn.relu(x)\n",
-    "\n",
-    "    \n",
-    "block = ResnetIdentityBlock(1, [1, 2, 3])\n",
-    "print(block(tf.zeros([1, 2, 3, 3])))\n",
-    "print([x.name for x in block.variables])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "wYfucVw65PMj"
-   },
-   "source": [
-    "Much of the time, however, models which compose many layers simply call one layer after the other. This can be done in very little code using tf.keras.Sequential"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "autoexec": {
-      "startup": false,
-      "wait_interval": 0
-     }
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "8PyXlPl-4TzQ",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "# In the tf.keras.layers package, layers are objects. To construct a layer,\n",
+        "# simply construct the object. Most layers take as a first argument the number\n",
+        "# of output dimensions / channels.\n",
+        "layer = tf.keras.layers.Dense(100)\n",
+        "# The number of input dimensions is often unnecessary, as it can be inferred\n",
+        "# the first time the layer is used, but it can be provided if you want to \n",
+        "# specify it manually, which is useful in some complex models.\n",
+        "layer = tf.keras.layers.Dense(10, input_shape=(None, 5))"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
-    "colab_type": "code",
-    "id": "L9frk7Ur4uvJ"
-   },
-   "outputs": [],
-   "source": [
-    " my_seq = tf.keras.Sequential([tf.keras.layers.Conv2D(1, (1, 1)),\n",
-    "                               tf.keras.layers.BatchNormalization(),\n",
-    "                               tf.keras.layers.Conv2D(2, 1, \n",
-    "                                                      padding='same'),\n",
-    "                               tf.keras.layers.BatchNormalization(),\n",
-    "                               tf.keras.layers.Conv2D(3, (1, 1)),\n",
-    "                               tf.keras.layers.BatchNormalization()])\n",
-    "my_seq(tf.zeros([1, 2, 3, 3]))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "c5YwYcnuK-wc"
-   },
-   "source": [
-    "# Next steps\n",
-    "\n",
-    "Now you can go back to the previous notebook and adapt the linear regression example to use layers and models to be better structured."
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "collapsed_sections": [],
-   "default_view": {},
-   "name": "custom_layers.ipynb",
-   "private_outputs": true,
-   "provenance": [],
-   "toc_visible": true,
-   "version": "0.3.2",
-   "views": {}
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.2"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "Fn69xxPO5Psr"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "The full list of pre-existing layers can be seen in [the documentation](https://www.tensorflow.org/api_docs/python/tf/keras/layers). It includes Dense (a fully-connected layer),\n",
+        "Conv2D, LSTM, BatchNormalization, Dropout, and many others."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "E3XKNknP5Mhb",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "# To use a layer, simply call it.\n",
+        "layer(tf.zeros([10, 5]))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "Wt_Nsv-L5t2s",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "# Layers have many useful methods. For example, you can inspect all variables\n",
+        "# in a layer by calling layer.variables. In this case a fully-connected layer\n",
+        "# will have variables for weights and biases.\n",
+        "layer.variables"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "6ilvKjz8_4MQ",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "# The variables are also accessible through nice accessors\n",
+        "layer.kernel, layer.bias"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "O0kDbE54-5VS"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Implementing custom layers\n",
+        "The best way to implement your own layer is extending the tf.keras.Layer class and implementing:\n",
+        "  *  `__init__` , where you can do all input-independent initialization\n",
+        "  * `build`, where you know the shapes of the input tensors and can do the rest of the initialization\n",
+        "  * `call`, where you do the forward computation\n",
+        "\n",
+        "Note that you don't have to wait until `build` is called to create your variables, you can also create them in `__init__`. However, the advantage of creating them in `build` is that it enables late variable creation based on the shape of the inputs the layer will operate on. On the other hand, creating variables in `__init__` would mean that shapes required to create the variables will need to be explicitly specified."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "5Byl3n1k5kIy",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "class MyDenseLayer(tf.keras.layers.Layer):\n",
+        "  def __init__(self, num_outputs):\n",
+        "    super(MyDenseLayer, self).__init__()\n",
+        "    self.num_outputs = num_outputs\n",
+        "    \n",
+        "  def build(self, input_shape):\n",
+        "    self.kernel = self.add_variable(\"kernel\", \n",
+        "                                    shape=[input_shape[-1].value, \n",
+        "                                           self.num_outputs])\n",
+        "    \n",
+        "  def call(self, input):\n",
+        "    return tf.matmul(input, self.kernel)\n",
+        "  \n",
+        "layer = MyDenseLayer(10)\n",
+        "print(layer(tf.zeros([10, 5])))\n",
+        "print(layer.variables)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "tk8E2vY0-z4Z"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Note that you don't have to wait until `build` is called to create your variables, you can also create them in `__init__`.\n",
+        "\n",
+        "Overall code is easier to read and maintain if it uses standard layers whenever possible, as other readers will be familiar with the behavior of standard layers. If you want to use a layer which is not present in tf.keras.layers or tf.contrib.layers, consider filing a [github issue](http://github.com/tensorflow/tensorflow/issues/new) or, even better, sending us a pull request!"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "Qhg4KlbKrs3G"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Models: composing layers\n",
+        "\n",
+        "Many interesting layer-like things in machine learning models are implemented by composing existing layers. For example, each residual block in a resnet is a composition of convolutions, batch normalizations, and a shortcut.\n",
+        "\n",
+        "The main class used when creating a layer-like thing which contains other layers is tf.keras.Model. Implementing one is done by inheriting from tf.keras.Model."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "N30DTXiRASlb",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "class ResnetIdentityBlock(tf.keras.Model):\n",
+        "  def __init__(self, kernel_size, filters):\n",
+        "    super(ResnetIdentityBlock, self).__init__(name='')\n",
+        "    filters1, filters2, filters3 = filters\n",
+        "\n",
+        "    self.conv2a = tf.keras.layers.Conv2D(filters1, (1, 1))\n",
+        "    self.bn2a = tf.keras.layers.BatchNormalization()\n",
+        "\n",
+        "    self.conv2b = tf.keras.layers.Conv2D(filters2, kernel_size, padding='same')\n",
+        "    self.bn2b = tf.keras.layers.BatchNormalization()\n",
+        "\n",
+        "    self.conv2c = tf.keras.layers.Conv2D(filters3, (1, 1))\n",
+        "    self.bn2c = tf.keras.layers.BatchNormalization()\n",
+        "\n",
+        "  def call(self, input_tensor, training=False):\n",
+        "    x = self.conv2a(input_tensor)\n",
+        "    x = self.bn2a(x, training=training)\n",
+        "    x = tf.nn.relu(x)\n",
+        "\n",
+        "    x = self.conv2b(x)\n",
+        "    x = self.bn2b(x, training=training)\n",
+        "    x = tf.nn.relu(x)\n",
+        "\n",
+        "    x = self.conv2c(x)\n",
+        "    x = self.bn2c(x, training=training)\n",
+        "\n",
+        "    x += input_tensor\n",
+        "    return tf.nn.relu(x)\n",
+        "\n",
+        "    \n",
+        "block = ResnetIdentityBlock(1, [1, 2, 3])\n",
+        "print(block(tf.zeros([1, 2, 3, 3])))\n",
+        "print([x.name for x in block.variables])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "wYfucVw65PMj"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Much of the time, however, models which compose many layers simply call one layer after the other. This can be done in very little code using tf.keras.Sequential"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "L9frk7Ur4uvJ",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        " my_seq = tf.keras.Sequential([tf.keras.layers.Conv2D(1, (1, 1)),\n",
+        "                               tf.keras.layers.BatchNormalization(),\n",
+        "                               tf.keras.layers.Conv2D(2, 1, \n",
+        "                                                      padding='same'),\n",
+        "                               tf.keras.layers.BatchNormalization(),\n",
+        "                               tf.keras.layers.Conv2D(3, (1, 1)),\n",
+        "                               tf.keras.layers.BatchNormalization()])\n",
+        "my_seq(tf.zeros([1, 2, 3, 3]))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "c5YwYcnuK-wc"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "# Next steps\n",
+        "\n",
+        "Now you can go back to the previous notebook and adapt the linear regression example to use layers and models to be better structured."
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Specifically, this PR removes the gradients_function section from the eager/automatic_differentiation tutorial, and removes an unused `tfe = tf.contrib.eager` call from the eager/custom_layers tutorial.

Staging:

https://colab.sandbox.google.com/github/tomerk/docs/blob/remove-eager-contrib/site/en/tutorials/eager/automatic_differentiation.ipynb

https://colab.sandbox.google.com/github/tomerk/docs/blob/remove-eager-contrib/site/en/tutorials/eager/custom_layers.ipynb