### PR TITLE
Fix `Adding an op` links in the doc

### DIFF
--- a/site/en/guide/extend/bindings.md
+++ b/site/en/guide/extend/bindings.md
@@ -125,7 +125,7 @@ The `OpDef` specifies the following:
     instead of CamelCase for the op's function name.
 -   A list of inputs and outputs. The types for these may be polymorphic by
     referencing attributes, as described in the inputs and outputs section of
-    [Adding an     op](../extend/adding_an_op.md).
+    [Adding an     op](../extend/op.md).
 -   A list of attributes, along with their default values (if any). Note that
     some of these will be inferred (if they are determined by an input), some
     will be optional (if they have a default), and some will be required (no

--- a/site/en/guide/extend/filesystem.md
+++ b/site/en/guide/extend/filesystem.md
@@ -225,7 +225,7 @@ it will use the `FooBarFileSystem` implementation.
 Next, you must build a shared object containing this implementation. An example
 of doing so using bazel's `cc_binary` rule can be found
 [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/BUILD#L244),
-but you may use any build system to do so. See the section on [building the op library](../extend/adding_an_op.md#build_the_op_library) for similar
+but you may use any build system to do so. See the section on [building the op library](../extend/op.md#build_the_op_library) for similar
 instructions.
 
 The result of building this target is a `.so` shared object file.

--- a/site/en/guide/extend/formats.md
+++ b/site/en/guide/extend/formats.md
@@ -66,7 +66,7 @@ need to:
 
 You can put all the C++ code in a single file, such as
 `my_reader_dataset_op.cc`. It will help if you are
-familiar with [the adding an op how-to](../extend/adding_an_op.md). The following skeleton
+familiar with [the adding an op how-to](../extend/op.md). The following skeleton
 can be used as a starting point for your implementation:
 
 ```c++
@@ -227,7 +227,7 @@ REGISTER_KERNEL_BUILDER(Name("MyReaderDataset").Device(tensorflow::DEVICE_CPU),
 
 The last step is to build the C++ code and add a Python wrapper. The easiest way
 to do this is by [compiling a dynamic
-library](../extend/adding_an_op.md#build_the_op_library) (e.g. called `"my_reader_dataset_op.so"`), and adding a Python class
+library](../extend/op.md#build_the_op_library) (e.g. called `"my_reader_dataset_op.so"`), and adding a Python class
 that subclasses `tf.data.Dataset` to wrap it. An example Python program is
 given here:
 
@@ -284,7 +284,7 @@ You can see some examples of `Dataset` wrapper classes in
 ## Writing an Op for a record format
 
 Generally this is an ordinary op that takes a scalar string record as input, and
-so follow [the instructions to add an Op](../extend/adding_an_op.md).
+so follow [the instructions to add an Op](../extend/op.md).
 You may optionally take a scalar string key as input, and include that in error
 messages reporting improperly formatted data.  That way users can more easily
 track down where the bad data came from.

--- a/site/en/guide/faq.md
+++ b/site/en/guide/faq.md
@@ -277,7 +277,7 @@ the flag --host=localhost. This should quiet any security warnings.
 ## Extending TensorFlow
 
 See the how-to documentation for
-[adding a new operation to TensorFlow](../extend/adding_an_op.md).
+[adding a new operation to TensorFlow](../extend/op.md).
 
 #### My data is in a custom format. How do I read it using TensorFlow?
 
@@ -299,7 +299,7 @@ consider converting it, offline, to a format that is easily parsable, such
 as `tf.python_io.TFRecordWriter` format.
 
 The most efficient method to customize the parsing behavior is to
-[add a new op written in C++](../extend/adding_an_op.md) that parses your
+[add a new op written in C++](../extend/op.md) that parses your
 data format. The [guide to handling new data formats](../extend/new_data_formats.md) has
 more information about the steps for doing this.
 

--- a/site/en/guide/faq.md
+++ b/site/en/guide/faq.md
@@ -277,7 +277,7 @@ the flag --host=localhost. This should quiet any security warnings.
 ## Extending TensorFlow
 
 See the how-to documentation for
-[adding a new operation to TensorFlow](../extend/op.md).
+[adding a new operation to TensorFlow](extend/op.md).
 
 #### My data is in a custom format. How do I read it using TensorFlow?
 
@@ -299,8 +299,8 @@ consider converting it, offline, to a format that is easily parsable, such
 as `tf.python_io.TFRecordWriter` format.
 
 The most efficient method to customize the parsing behavior is to
-[add a new op written in C++](../extend/op.md) that parses your
-data format. The [guide to handling new data formats](../extend/new_data_formats.md) has
+[add a new op written in C++](extend/op.md) that parses your
+data format. The [guide to handling new data formats](extend/formats.md) has
 more information about the steps for doing this.
 
 

--- a/site/en/tutorials/representation/word2vec.md
+++ b/site/en/tutorials/representation/word2vec.md
@@ -389,7 +389,7 @@ modeling, we've actually already done this for you as an example in
 
 If your model is no longer I/O bound but you want still more performance, you
 can take things further by writing your own TensorFlow Ops, as described in
-[Adding a New Op](../../extend/adding_an_op.md).  Again we've provided an
+[Adding a New Op](../../extend/op.md).  Again we've provided an
 example of this for the Skip-Gram case
 [models/tutorials/embedding/word2vec_optimized.py](https://github.com/tensorflow/models/tree/master/tutorials/embedding/word2vec_optimized.py).
 Feel free to benchmark these against each other to measure performance


### PR DESCRIPTION
Some links were pointing to https://www.tensorflow.org/guide/extend/adding_an_op