### PR TITLE
Switched to use Keras optimizers in save_and_restore for tf v2 compatibility

### DIFF
--- a/site/en/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/tutorials/keras/save_and_restore_models.ipynb
@@ -258,7 +258,7 @@
         "    keras.layers.Dense(10, activation=tf.nn.softmax)\n",
         "  ])\n",
         "  \n",
-        "  model.compile(optimizer=tf.train.AdamOptimizer(), \n",
+        "  model.compile(optimizer='adam', \n",
         "                loss=tf.keras.losses.sparse_categorical_crossentropy,\n",
         "                metrics=['accuracy'])\n",
         "  \n",
@@ -811,7 +811,7 @@
       "cell_type": "code",
       "source": [
         "# The optimizer was not restored, re-attach a new one.\n",
-        "new_model.compile(optimizer=tf.train.AdamOptimizer(), \n",
+        "new_model.compile(optimizer='adam', \n",
         "              loss=tf.keras.losses.sparse_categorical_crossentropy,\n",
         "              metrics=['accuracy'])\n",
         "\n",

--- a/site/en/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/tutorials/keras/save_and_restore_models.ipynb
@@ -600,7 +600,7 @@
         "model = create_model()\n",
         "\n",
         "# You need to use a keras.optimizer to restore the optimizer state from an HDF5 file.\n",
-        "model.compile(optimizer=keras.optimizers.Adam(), \n",
+        "model.compile(optimizer='adam', \n",
         "              loss=tf.keras.losses.sparse_categorical_crossentropy,\n",
         "              metrics=['accuracy'])\n",
         "\n",


### PR DESCRIPTION
Note: this is slightly suboptimal for tf v1 until we activate the v2 keras optimizers even in tf v1. Until then this warning gets printed:

```
        logging.warning(
            ('This model was compiled with a Keras optimizer (%s) but is being '
             'saved in TensorFlow format with `save_weights`. The model\'s '
             'weights will be saved, but unlike with TensorFlow optimizers in '
             'the TensorFlow format the optimizer\'s state will not be '
             'saved.\n\nConsider using a TensorFlow optimizer from `tf.train`.')
            % (optimizer,))
```