### PR TITLE
change one-hot to multi-hot for consistency with overfit_and_underfit

### DIFF
--- a/site/en/tutorials/keras/basic_text_classification.ipynb
+++ b/site/en/tutorials/keras/basic_text_classification.ipynb
@@ -376,7 +376,7 @@
         "\n",
         "The reviews—the arrays of integers—must be converted to tensors before fed into the neural network. This conversion can be done a couple of ways:\n",
         "\n",
-        "* One-hot-encode the arrays to convert them into vectors of 0s and 1s. For example, the sequence  [3, 5] would become a 10,000-dimensional vector that is all zeros except for indices 3 and 5, which are ones. Then, make this the first layer in our network—a Dense layer—that can handle floating point vector data. This approach is memory intensive, though, requiring a `num_words * num_reviews` size matrix.\n",
+        "* Multi-hot-encode the arrays to convert them into vectors of 0s and 1s. For example, the sequence  [3, 5] would become a 10,000-dimensional vector that is all zeros except for indices 3 and 5, which are ones. Then, make this the first layer in our network—a Dense layer—that can handle floating point vector data. This approach is memory intensive, though, requiring a `num_words * num_reviews` size matrix.\n",
         "\n",
         "* Alternatively, we can pad the arrays so they all have the same length, then create an integer tensor of shape `max_length * num_reviews`. We can use an embedding layer capable of handling this shape as the first layer in our network.\n",
         "\n",

--- a/site/en/tutorials/keras/basic_text_classification.ipynb
+++ b/site/en/tutorials/keras/basic_text_classification.ipynb
@@ -376,7 +376,7 @@
         "\n",
         "The reviews—the arrays of integers—must be converted to tensors before fed into the neural network. This conversion can be done a couple of ways:\n",
         "\n",
-        "* Multi-hot-encode the arrays to convert them into vectors of 0s and 1s. For example, the sequence  [3, 5] would become a 10,000-dimensional vector that is all zeros except for indices 3 and 5, which are ones. Then, make this the first layer in our network—a Dense layer—that can handle floating point vector data. This approach is memory intensive, though, requiring a `num_words * num_reviews` size matrix.\n",
+        "* Convert the arrays into vectors of 0s and 1s indicating word occurrence, similar to a one-hot encoding. For example, the sequence  [3, 5] would become a 10,000-dimensional vector that is all zeros except for indices 3 and 5, which are ones. Then, make this the first layer in our network—a Dense layer—that can handle floating point vector data. This approach is memory intensive, though, requiring a `num_words * num_reviews` size matrix.\n",
         "\n",
         "* Alternatively, we can pad the arrays so they all have the same length, then create an integer tensor of shape `max_length * num_reviews`. We can use an embedding layer capable of handling this shape as the first layer in our network.\n",
         "\n",


### PR DESCRIPTION
This particular `[3, 5]` sequence is used to explain multi-hot encoding in overfit_and_underfit notebook.
To prevent confusing, I want to change one-hot-encode to multi-hot-encode in basic_text_classification notebook.
Thanks. :)
