### PR TITLE
Fix basic classification tutorial

### DIFF
--- a/site/en/tutorials/keras/basic_classification.ipynb
+++ b/site/en/tutorials/keras/basic_classification.ipynb
@@ -30,8 +30,8 @@
       "metadata": {
         "id": "_ckMIh7O7s6D",
         "colab_type": "code",
-        "colab": {},
-        "cellView": "form"
+        "cellView": "form",
+        "colab": {}
       },
       "cell_type": "code",
       "source": [
@@ -54,8 +54,8 @@
       "metadata": {
         "id": "vasWnqRgy1H4",
         "colab_type": "code",
-        "colab": {},
-        "cellView": "form"
+        "cellView": "form",
+        "colab": {}
       },
       "cell_type": "code",
       "source": [
@@ -428,17 +428,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "We scale these values to a range of 0 to 1 before feeding to the neural network model. For this, cast the datatype of the image components from an integer to a float, and divide by 255. Here's the function to preprocess the images:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "3jCZdQNNCaWv",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "It's important that the *training set* and the *testing set* are preprocessed in the same way:"
+        "We scale these values to a range of 0 to 1 before feeding to the neural network model. For this, we divide the values by 255. It's important that the *training set* and the *testing set* are preprocessed in the same way:"
       ]
     },
     {


### PR DESCRIPTION
Issues fixed in this PR:
1. Casting is not done and there is no need to be done ==> removed redundant sentence.
2. There is no preprocessing function defined ==> removed redundant sentence.