### PR TITLE
Does {:.external} class in ipynb neccessary?

### DIFF
--- a/site/en/guide/keras.ipynb
+++ b/site/en/guide/keras.ipynb
@@ -111,7 +111,7 @@
         "## Import tf.keras\n",
         "\n",
         "`tf.keras` is TensorFlow's implementation of the\n",
-        "[Keras API specification](https://keras.io){:.external}. This is a high-level\n",
+        "[Keras API specification](https://keras.io). This is a high-level\n",
         "API to build and train models that includes first-class support for\n",
         "TensorFlow-specific functionality, such as [eager execution](#eager_execution),\n",
         "`tf.data` pipelines, and [Estimators](./estimators.md).\n",
@@ -349,7 +349,7 @@
       "source": [
         "### Input NumPy data\n",
         "\n",
-        "For small datasets, use in-memory [NumPy](https://www.numpy.org/){:.external}\n",
+        "For small datasets, use in-memory [NumPy](https://www.numpy.org/)\n",
         "arrays to train and evaluate a model. The model is \"fit\" to the training data\n",
         "using the `fit` method:"
       ]
@@ -556,7 +556,7 @@
         "\n",
         "The `tf.keras.Sequential` model is a simple stack of layers that cannot\n",
         "represent arbitrary models. Use the\n",
-        "[Keras functional API](https://keras.io/getting-started/functional-api-guide/){:.external}\n",
+        "[Keras functional API](https://keras.io/getting-started/functional-api-guide/)\n",
         "to build complex model topologies such as:\n",
         "\n",
         "* Multi-input models,\n",


### PR DESCRIPTION
Curious if we need {:.external} in the notebooks?
Reasoning: on tensorflow.org it renders as an external link symbol, but in the text it looks a bit messy.

Met those while doing keras translation.