### PR TITLE
Add plt.show() to basic classification tuturial so something appears.

### DIFF
--- a/site/en/tutorials/keras/basic_classification.ipynb
+++ b/site/en/tutorials/keras/basic_classification.ipynb
@@ -416,7 +416,8 @@
         "plt.figure()\n",
         "plt.imshow(train_images[0])\n",
         "plt.colorbar()\n",
-        "plt.grid(False)"
+        "plt.grid(False)\n",
+        "plt.show()"
       ],
       "execution_count": 0,
       "outputs": []

--- a/site/ko/tutorials/keras/basic_classification.ipynb
+++ b/site/ko/tutorials/keras/basic_classification.ipynb
@@ -402,7 +402,8 @@
     "plt.figure()\n",
     "plt.imshow(train_images[0])\n",
     "plt.colorbar()\n",
-    "plt.grid(False)"
+    "plt.grid(False)\n",
+    "plt.show()"
    ]
   },
   {

--- a/site/ru/tutorials/keras/basic_classification.ipynb
+++ b/site/ru/tutorials/keras/basic_classification.ipynb
@@ -404,7 +404,8 @@
     "plt.figure()\n",
     "plt.imshow(train_images[0])\n",
     "plt.colorbar()\n",
-    "plt.grid(False)"
+    "plt.grid(False)\n",
+    "plt.show()"
    ]
   },
   {


### PR DESCRIPTION
When I was working though the tutorial:
https://www.tensorflow.org/tutorials/keras/basic_classification
the plot window did not appear for me.
Having not used matplotlib before, I spent quite a while trying to set up different configurations before discovering that the example simply needed to call plt.show()