### PR TITLE
markdown fix

### DIFF
--- a/site/en/guide/graphs.md
+++ b/site/en/guide/graphs.md
@@ -89,7 +89,7 @@ to all API functions in the same context.  For example:
 * Executing `v = tf.Variable(0)` adds to the graph a `tf.Operation` that will
   store a writeable tensor value that persists between `tf.Session.run` calls.
   The `tf.Variable` object wraps this operation, and can be used [like a
-  tensor](#tensor-like_objects), which will read the current value of the
+  tensor](#tensor-like-objects), which will read the current value of the
   stored value. The `tf.Variable` object also has methods such as
   `tf.Variable.assign` and `tf.Variable.assign_add` that
   create `tf.Operation` objects that, when executed, update the stored value.
@@ -100,7 +100,7 @@ to all API functions in the same context.  For example:
   when run, will apply those gradients to a set of variables.
 
 Most programs rely solely on the default graph. However,
-see [Dealing with multiple graphs](#programming_with_multiple_graphs) for more
+see [Dealing with multiple graphs](#programming-with-multiple-graphs) for more
 advanced use cases. High-level APIs such as the `tf.estimator.Estimator` API
 manage the default graph on your behalf, and--for example--may create different
 graphs for training and evaluation.


### PR DESCRIPTION
In-doc links now working: use` -` for word separation