### PR TITLE
colab: rendering all sections in the table of contents

### DIFF
--- a/site/en/guide/keras.ipynb
+++ b/site/en/guide/keras.ipynb
@@ -862,14 +862,22 @@
     },
     {
       "metadata": {
-        "id": "qnl7K-aI0E2z",
+        "id": "ghhaGfX62abv",
         "colab_type": "text"
       },
       "cell_type": "markdown",
       "source": [
         "<a id='weights_only'></a>\n",
-        "## Save and restore\n",
-        "\n",
+        "## Save and restore"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "qnl7K-aI0E2z",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
         "### Weights only\n",
         "\n",
         "Save and load the weights of a model using `tf.keras.Model.save_weights`:"


### PR DESCRIPTION
Name of the chapter and its sections should be in separated markdown cells in order to render each section in the table of contents in Colab.

Not necessarily a bug, but something to remember.

![fix](https://user-images.githubusercontent.com/34945393/50548986-80e1f400-0c66-11e9-9c5b-f26a273b01dd.jpg)
