### PR TITLE
Add 'squared' to L2 regularization description

### DIFF
--- a/site/en/tutorials/keras/overfit_and_underfit.ipynb
+++ b/site/en/tutorials/keras/overfit_and_underfit.ipynb
@@ -525,7 +525,7 @@
         "\n",
         "* L1 regularization, where the cost added is proportional to the absolute value of the weights coefficients (i.e. to what is called the \"L1 norm\" of the weights).\n",
         "\n",
-        "* L2 regularization, where the cost added is proportional to the square of the value of the weights coefficients (i.e. to what is called the \"L2 norm\" of the weights). L2 regularization is also called weight decay in the context of neural networks. Don't let the different name confuse you: weight decay is mathematically the exact same as L2 regularization.\n",
+        "* L2 regularization, where the cost added is proportional to the square of the value of the weights coefficients (i.e. to what is called the squared \"L2 norm\" of the weights). L2 regularization is also called weight decay in the context of neural networks. Don't let the different name confuse you: weight decay is mathematically the exact same as L2 regularization.\n",
         "\n",
         "In `tf.keras`, weight regularization is added by passing weight regularizer instances to layers as keyword arguments. Let's add L2 weight regularization now."
       ]

--- a/site/en/tutorials/keras/overfit_and_underfit.ipynb
+++ b/site/en/tutorials/keras/overfit_and_underfit.ipynb
@@ -523,9 +523,9 @@
         "\n",
         "A \"simple model\" in this context is a model where the distribution of parameter values has less entropy (or a model with fewer parameters altogether, as we saw in the section above). Thus a common way to mitigate overfitting is to put constraints on the complexity of a network by forcing its weights only to take small values, which makes the distribution of weight values more \"regular\". This is called \"weight regularization\", and it is done by adding to the loss function of the network a cost associated with having large weights. This cost comes in two flavors:\n",
         "\n",
-        "* L1 regularization, where the cost added is proportional to the absolute value of the weights coefficients (i.e. to what is called the \"L1 norm\" of the weights).\n",
+        "* [L1 regularization](https://developers.google.com/machine-learning/glossary/#L1_regularization), where the cost added is proportional to the absolute value of the weights coefficients (i.e. to what is called the \"L1 norm\" of the weights).\n",
         "\n",
-        "* L2 regularization, where the cost added is proportional to the square of the value of the weights coefficients (i.e. to what is called the squared \"L2 norm\" of the weights). L2 regularization is also called weight decay in the context of neural networks. Don't let the different name confuse you: weight decay is mathematically the exact same as L2 regularization.\n",
+        "* [L2 regularization](https://developers.google.com/machine-learning/glossary/#L2_regularization), where the cost added is proportional to the square of the value of the weights coefficients (i.e. to what is called the squared \"L2 norm\" of the weights). L2 regularization is also called weight decay in the context of neural networks. Don't let the different name confuse you: weight decay is mathematically the exact same as L2 regularization.\n",
         "\n",
         "In `tf.keras`, weight regularization is added by passing weight regularizer instances to layers as keyword arguments. Let's add L2 weight regularization now."
       ]


### PR DESCRIPTION
It is often used interchangeable, but actually L2 regularization is squared l2 norm, not l2 norm.
To avoid misunderstanding, adding 'squared' is recommended.