### PR TITLE
Renaming item->object

### DIFF
--- a/site/en/guide/tensors.md
+++ b/site/en/guide/tensors.md
@@ -67,7 +67,7 @@ floating = tf.Variable(3.14159265359, tf.float64)
 its_complicated = tf.Variable(12.3 - 4.85j, tf.complex64)
 ```
 
-Note: A string is treated as a single item in TensorFlow, not as a sequence of
+Note: A string is treated as a single object in TensorFlow, not as a sequence of
 characters. It is possible to have scalar strings, vectors of strings, etc.
 
 ### Rank 1


### PR DESCRIPTION
Not sure about this as I stumbled upon the line while translating:
Would it be better to refer to a `string` as an `object` when there's only one item, e.g. not a `list` with several `items`?

If not just reject the PR, I might be sleepy :)