### PR TITLE
Fix heading issue in markdown

### DIFF
--- a/site/en/tutorials/images/image_recognition.md
+++ b/site/en/tutorials/images/image_recognition.md
@@ -61,7 +61,7 @@ vision tasks.
 We're excited to see what the community will do with this model.
 
 
-##Usage with Python API
+## Usage with Python API
 
 `classify_image.py` downloads the trained model from `tensorflow.org`
 when the program is run for the first time. You'll need about 200M of free space


### PR DESCRIPTION
Due to updates in the GitHub markdown processor, the markdown for H2 headings is only rendered when there is space between `##` and the `title`. I have updated the markdown with space so that the header is rendered properly.

Previously:
![image](https://user-images.githubusercontent.com/8587189/51049968-6f4e0400-15f7-11e9-8082-c8a491fb63fc.png)


Current:
![image](https://user-images.githubusercontent.com/8587189/51049986-80971080-15f7-11e9-8ed6-4c46f21ba123.png)
