### PR TITLE
Remove unnecessary variables in text classification tutorial

### DIFF
--- a/site/en/tutorials/keras/basic_text_classification.ipynb
+++ b/site/en/tutorials/keras/basic_text_classification.ipynb
@@ -745,10 +745,10 @@
       "source": [
         "import matplotlib.pyplot as plt\n",
         "\n",
-        "acc = history.history['acc']\n",
-        "val_acc = history.history['val_acc']\n",
-        "loss = history.history['loss']\n",
-        "val_loss = history.history['val_loss']\n",
+        "acc = history_dict['acc']\n",
+        "val_acc = history_dict['val_acc']\n",
+        "loss = history_dict['loss']\n",
+        "val_loss = history_dict['val_loss']\n",
         "\n",
         "epochs = range(1, len(acc) + 1)\n",
         "\n",
@@ -780,8 +780,6 @@
       "cell_type": "code",
       "source": [
         "plt.clf()   # clear figure\n",
-        "acc_values = history_dict['acc']\n",
-        "val_acc_values = history_dict['val_acc']\n",
         "\n",
         "plt.plot(epochs, acc, 'bo', label='Training acc')\n",
         "plt.plot(epochs, val_acc, 'b', label='Validation acc')\n",


### PR DESCRIPTION
1. _history_dict_ variable was already declared, so there is no reason to use _history.history_ again.
2. _acc_values_ and _val_acc_values_ are not used because they are equal to _acc_ and _val_acc_.