### PR TITLE
Fix typo in tf_records parsing example

### DIFF
--- a/site/en/tutorials/load_data/tf_records.ipynb
+++ b/site/en/tutorials/load_data/tf_records.ipynb
@@ -762,7 +762,7 @@
       "outputs": [],
       "source": [
         "for parsed_record in parsed_dataset.take(10):\n",
-        "  print(repr(raw_record))"
+        "  print(repr(parsed_record))"
       ]
     },
     {

--- a/site/en/tutorials/load_data/tf_records.ipynb
+++ b/site/en/tutorials/load_data/tf_records.ipynb
@@ -107,9 +107,7 @@
       },
       "outputs": [],
       "source": [
-        "from __future__ import absolute_import\n",
-        "from __future__ import division\n",
-        "from __future__ import print_function\n",
+        "from __future__ import absolute_import, division, print_function\n",
         "\n",
         "import tensorflow as tf\n",
         "tf.enable_eager_execution()\n",


### PR DESCRIPTION
Printing the wrong variable after parsing a tf_record with the feature specs. This results in a raw tensor being printed multiple times instead of dicts of features as intended.

Currently printing
```shell
<tf.Tensor: id=61, shape=(), dtype=string, numpy=b'\nR\n\x11\n\x08feature0\x12\x05\x1a\x03\n\x01\x01\n\x11\n\x08feature1\x12\x05\x1a\x03\n\x01\x04\n\x14\n\x08feature2\x12\x08\n\x06\n\x04goat\n\x14\n\x08feature3\x12\x08\x12\x06\n\x04\x943\xe8\xbe'>
<tf.Tensor: id=61, shape=(), dtype=string, numpy=b'\nR\n\x11\n\x08feature0\x12\x05\x1a\x03\n\x01\x01\n\x11\n\x08feature1\x12\x05\x1a\x03\n\x01\x04\n\x14\n\x08feature2\x12\x08\n\x06\n\x04goat\n\x14\n\x08feature3\x12\x08\x12\x06\n\x04\x943\xe8\xbe'>
<tf.Tensor: id=61, shape=(), dtype=string, numpy=b'\nR\n\x11\n\x08feature0\x12\x05\x1a\x03\n\x01\x01\n\x11\n\x08feature1\x12\x05\x1a\x03\n\x01\x04\n\x14\n\x08feature2\x12\x08\n\x06\n\x04goat\n\x14\n\x08feature3\x12\x08\x12\x06\n\x04\x943\xe8\xbe'>
...
```

Instead of 
```shell
{'feature0': <tf.Tensor: id=143, shape=(), dtype=int64, numpy=1>, 'feature1': <tf.Tensor: id=144, shape=(), dtype=int64, numpy=3>, 'feature2': <tf.Tensor: id=145, shape=(), dtype=string, numpy=b'horse'>, 'feature3': <tf.Tensor: id=146, shape=(), dtype=float32, numpy=0.6552434>}
{'feature0': <tf.Tensor: id=151, shape=(), dtype=int64, numpy=1>, 'feature1': <tf.Tensor: id=152, shape=(), dtype=int64, numpy=4>, 'feature2': <tf.Tensor: id=153, shape=(), dtype=string, numpy=b'goat'>, 'feature3': <tf.Tensor: id=154, shape=(), dtype=float32, numpy=0.63477755>}
{'feature0': <tf.Tensor: id=159, shape=(), dtype=int64, numpy=1>, 'feature1': <tf.Tensor: id=160, shape=(), dtype=int64, numpy=3>, 'feature2': <tf.Tensor: id=161, shape=(), dtype=string, numpy=b'horse'>, 'feature3': <tf.Tensor: id=162, shape=(), dtype=float32, numpy=1.6285447>}
...
```