### PR TITLE
Resolves Attribute error on colab

### DIFF
--- a/site/en/tutorials/sequences/text_generation.ipynb
+++ b/site/en/tutorials/sequences/text_generation.ipynb
@@ -745,7 +745,7 @@
       },
       "cell_type": "code",
       "source": [
-        "sampled_indices = tf.random.categorical(example_batch_predictions[0], num_samples=1)\n",
+        "sampled_indices = tf.random.multinomial(example_batch_predictions[0], num_samples=1)\n",
         "sampled_indices = tf.squeeze(sampled_indices,axis=-1).numpy()"
       ],
       "execution_count": 0,


### PR DESCRIPTION
Using **tf.random.categorical** gives the following error:

`AttributeError: module 'tensorflow._api.v1.random' has no attribute 'categorical'`

Changing it to **tf.random. multinomial** with the same parameters seems to resolve the issue and works on Colab notebooks.

Here is the [solution](https://stackoverflow.com/questions/54210128/tensorflow-text-generation).
