### PR TITLE
force eol for .ipynb

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb text eol=lf


### PR DESCRIPTION
The motivation was  [PR337](https://github.com/tensorflow/docs/pull/337), because it change end of file.