### PR TITLE
Fixed bug in the parse_line function example

### DIFF
--- a/site/en/tutorials/sequences/recurrent_quickdraw.md
+++ b/site/en/tutorials/sequences/recurrent_quickdraw.md
@@ -192,7 +192,8 @@ def parse_line(ndjson_line):
   scale[scale == 0] = 1
   np_ink[:, 0:2] = (np_ink[:, 0:2] - lower) / scale
   # 2. Compute deltas.
-  np_ink = np_ink[1:, 0:2] - np_ink[0:-1, 0:2]
+  np_ink[1:, 0:2] -= np_ink[0:-1, 0:2]
+  np_ink = np_ink[1:, :]
   return np_ink, class_name
 ```
 


### PR DESCRIPTION
When computing deltas the previous code was skipping the last column and hence reducing the size to [number of points , 2] instead of [number of points, 3].

Just copied the correct code from quickdraw/train_model.py