### PR TITLE
Update for tensorflow.org/alpha link

### DIFF
--- a/site/ko/r2/tutorials/keras/basic_classification.ipynb
+++ b/site/ko/r2/tutorials/keras/basic_classification.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/basic_classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />TensorFlow.org에서 보기</a>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/keras/basic_classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />TensorFlow.org에서 보기</a>\n",
     "  </td>\n",
     "  <td>\n",
     "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/ko/r2/tutorials/keras/basic_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />구글 코랩(Colab)에서 실행하기</a>\n",

--- a/site/ko/r2/tutorials/keras/basic_regression.ipynb
+++ b/site/ko/r2/tutorials/keras/basic_regression.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/basic_regression\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />TensorFlow.org에서 보기</a>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/keras/basic_regression\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />TensorFlow.org에서 보기</a>\n",
     "  </td>\n",
     "  <td>\n",
     "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/ko/r2/tutorials/keras/basic_regression.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />구글 코랩(Colab)에서 실행하기</a>\n",

--- a/site/ko/r2/tutorials/keras/basic_text_classification.ipynb
+++ b/site/ko/r2/tutorials/keras/basic_text_classification.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/basic_text_classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />TensorFlow.org에서 보기</a>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/keras/basic_text_classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />TensorFlow.org에서 보기</a>\n",
     "  </td>\n",
     "  <td>\n",
     "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/ko/r2/tutorials/keras/basic_text_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />구글 코랩(Colab)에서 실행하기</a>\n",

--- a/site/ko/r2/tutorials/keras/overfit_and_underfit.ipynb
+++ b/site/ko/r2/tutorials/keras/overfit_and_underfit.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/overfit_and_underfit\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />TensorFlow.org에서 보기</a>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/keras/overfit_and_underfit\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />TensorFlow.org에서 보기</a>\n",
     "  </td>\n",
     "  <td>\n",
     "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/ko/r2/tutorials/keras/overfit_and_underfit.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />구글 코랩(Colab)에서 실행하기</a>\n",

--- a/site/ko/r2/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/ko/r2/tutorials/keras/save_and_restore_models.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/save_and_restore_models\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />TensorFlow.org에서 보기</a>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/keras/save_and_restore_models\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />TensorFlow.org에서 보기</a>\n",
     "  </td>\n",
     "  <td>\n",
     "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/ko/r2/tutorials/keras/save_and_restore_models.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />구글 코랩(Colab)에서 실행하기</a>\n",


### PR DESCRIPTION
Change `tensorflow.org/tutorials/` to `tensorflow.org/alpha/tutorials/`
Thanks.