### PR TITLE
typo: “is [a] lightweight solution”

### DIFF
--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -115,4 +115,4 @@ landing_page:
       heading: Mobile developers
       path: /lite/
       description: >
-        TensorFlow Lite is lightweight solution for mobile and embedded devices.
+        TensorFlow Lite is a lightweight solution for mobile and embedded devices.

--- a/site/en/tutorials/_index.yaml
+++ b/site/en/tutorials/_index.yaml
@@ -148,7 +148,7 @@ landing_page:
       heading: Mobile developers
       path: /lite/
       description: >
-        TensorFlow Lite is lightweight solution for mobile and embedded devices.
+        TensorFlow Lite is a lightweight solution for mobile and embedded devices.
 
   - heading: Videos and updates
     description: >


### PR DESCRIPTION
This appears on the following live links:

  - <https://www.tensorflow.org/install>
  - <https://www.tensorflow.org/tutorials>