### PR TITLE
Fix typo in transfer_learning.ipynb

### DIFF
--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -802,7 +802,7 @@
         "* Using a pre-trained model for **feature extraction** - when working with a small dataset, it is common to leverage the features learned by a model trained on a larger dataset in the same domain. This is done by instantiating the pre-trained model and adding a fully connected classifier on top. The pre-trained model is \"frozen\" and only the weights of the classifier are updated during training.\n",
         "In this case, the convolutional base extracts all the features associated with each image and we train a classifier that determines, given these set of features to which class it belongs.\n",
         "* **Fine-tuning** a pre-trained model - to further improve performance, one might want to repurpose the top-level layers of the pre-trained models to the new dataset via fine-tuning.\n",
-        "In this case, we tune our weights such that we learn highly specified and high level features specific to our dataset. This only make sense when the training dataset is large and very similar to the orginial dataset that the pre-trained model was trained on.\n"
+        "In this case, we tune our weights such that we learn highly specified and high level features specific to our dataset. This only make sense when the training dataset is large and very similar to the original dataset that the pre-trained model was trained on.\n"
       ]
     }
   ],


### PR DESCRIPTION
Fix typo (orginial -> original) in the [tutorial for transfer learning](https://github.com/tensorflow/docs/blob/master/site/en/tutorials/images/transfer_learning.ipynb)