### PR TITLE
Add community translation note/readme for Portuguese

### DIFF
--- a/site/pt/README.md
+++ b/site/pt/README.md
@@ -1,0 +1,30 @@
+# Community translations
+
+A nossa comunidade TensorFlow traduziu estes documentos. Como as traduções da
+comunidade são *o melhor esforço*, não há garantias de que sejam uma reflexão
+exata e atualizada da [documentação oficial em Inglês](https://www.tensorflow.org/?hl=en).
+Se tem alguma sugestão para melhorar esta tradução, por favor envie um pull
+request para o repositório do GitHub [tensorflow/docs](https://github.com/tensorflow/docs).
+Para se voluntariar para escrever ou rever as traduções da comunidade, contacte a
+[lista docs@tensorflow.org](https://groups.google.com/a/tensorflow.org/forum/#!forum/docs).
+
+# Community translations
+
+Our TensorFlow community has translated these documents. Because community
+translations are *best-effort*, there is no guarantee that this is an accurate
+and up-to-date reflection of the
+[official English documentation](https://www.tensorflow.org/?hl=en). 
+If you have suggestions to improve this translation, please send a pull request 
+to the [tensorflow/docs](https://github.com/tensorflow/docs) GitHub repository. 
+To volunteer to write or review community translations, contact the
+[docs@tensorflow.org list](https://groups.google.com/a/tensorflow.org/forum/#!forum/docs).
+
+# Portuguese translation guide
+
+Some technical words in English do not have a natural translation. Do *not*
+translate the following words:
+
+*   (mini-) batch
+*   estimator
+*   eager execution
+*   dense

--- a/site/pt/README.md
+++ b/site/pt/README.md
@@ -1,4 +1,4 @@
-# Community translations
+# Traduções da Comunidade
 
 A nossa comunidade TensorFlow traduziu estes documentos. Como as traduções da
 comunidade são *o melhor esforço*, não há garantias de que sejam uma reflexão

--- a/site/pt/tutorials/keras/basic_classification.ipynb
+++ b/site/pt/tutorials/keras/basic_classification.ipynb
@@ -116,6 +116,16 @@
     },
     {
       "metadata": {
+        "id": "UA1pKuH8wqxz",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Note: A nossa comunidade TensorFlow traduziu estes documentos. Como as traduções da comunidade são *o melhor esforço*, não há garantias de que sejam uma reflexão exata e atualizada da [documentação oficial em Inglês](https://www.tensorflow.org/?hl=en). Se tem alguma sugestão para melhorar esta tradução, por favor envie um pull request para o repositório do GitHub [tensorflow/docs](https://github.com/tensorflow/docs). Para se voluntariar para escrever ou rever as traduções da comunidade, contacte a [lista docs@tensorflow.org](https://groups.google.com/a/tensorflow.org/forum/#!forum/docs)."
+      ]
+    },
+    {
+      "metadata": {
         "id": "OezgXCpHi4v_",
         "colab_type": "text"
       },


### PR DESCRIPTION
Added note to README and notebook.

stage: https://colab.research.google.com/github/lamberta/tf-docs/blob/pt-note/site/pt/tutorials/keras/basic_classification.ipynb

Continued from https://github.com/tensorflow/docs/pull/392