### PR TITLE
Updated install documentation for TF 2.0.

### DIFF
--- a/site/en/install/pip.html
+++ b/site/en/install/pip.html
@@ -293,7 +293,7 @@
   <li><code>tf-nightly</code> —Preview nightly build for CPU-only <em>(unstable)</em></li>
   <li><code>tf-nightly-gpu</code> —Preview nightly build with <a href="./gpu">GPU support</a> <em>(unstable, Ubuntu and Windows)</em></li>
 	<li><code>tensorflow==2.0.0-alpha0</code> —Preview TF 2.0 Alpha build for CPU-only <em>(unstable)</em></li>
-  <li><code>tensorflow==2.0.0-alpha0-gpu</code> —Preview TF 2.0 Alpha build with <a href="./gpu">GPU support</a> <em>(unstable, Ubuntu and Windows)</em></li>
+  <li><code>tensorflow==2.0.0-alpha0</code> —Preview TF 2.0 Alpha build with <a href="./gpu">GPU support</a> <em>(unstable, Ubuntu and Windows)</em></li>
 </ul>
 
 <aside class="note">

--- a/site/en/install/pip.html
+++ b/site/en/install/pip.html
@@ -292,8 +292,8 @@
   <li><code>tensorflow-gpu</code> —Latest stable release with <a href="./gpu">GPU support</a> <em>(Ubuntu and Windows)</em></li>
   <li><code>tf-nightly</code> —Preview nightly build for CPU-only <em>(unstable)</em></li>
   <li><code>tf-nightly-gpu</code> —Preview nightly build with <a href="./gpu">GPU support</a> <em>(unstable, Ubuntu and Windows)</em></li>
-	<li><code>tensorflow==2.0.0-alpha0</code> —Preview TF 2.0 Alpha build for CPU-only <em>(unstable)</em></li>
-  <li><code>tensorflow==2.0.0-alpha0</code> —Preview TF 2.0 Alpha build with <a href="./gpu">GPU support</a> <em>(unstable, Ubuntu and Windows)</em></li>
+  <li><code>tensorflow==2.0.0-alpha0</code> —Preview TF 2.0 Alpha build for CPU-only <em>(unstable)</em></li>
+  <li><code>tensorflow-gpu==2.0.0-alpha0</code> —Preview TF 2.0 Alpha build with <a href="./gpu">GPU support</a> <em>(unstable, Ubuntu and Windows)</em></li>
 </ul>
 
 <aside class="note">


### PR DESCRIPTION
Reference to #26937.

Changed to `tensorflow-gpu==2.0.0-alpha0` rather than `tensorflow==2.0.0-alpha0-gpu`.