### PR TITLE
Correctly use one-hot-encoded matrices as label

### DIFF
--- a/site/en/guide/keras.ipynb
+++ b/site/en/guide/keras.ipynb
@@ -1,25 +1,39 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "keras.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
   "cells": [
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "CCQY7jpBfMur"
       },
+      "cell_type": "markdown",
       "source": [
         "##### Copyright 2018 The TensorFlow Authors."
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "z6X9omPnfO_h"
+        "id": "z6X9omPnfO_h",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -32,65 +46,67 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "F1xIRPtY0E1w"
       },
+      "cell_type": "markdown",
       "source": [
         "# Keras"
       ]
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "VyOjQZHhZxaA"
       },
+      "cell_type": "markdown",
       "source": [
-        "\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/guide/keras\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/guide/keras.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/guide/keras.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003eView source on GitHub\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "\u003c/table\u003e"
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/guide/keras\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/guide/keras.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/guide/keras.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
       ]
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "ViAXWoKlZ8s6"
       },
+      "cell_type": "markdown",
       "source": [
         "Keras is a high-level API to build and train deep learning models. It's used for\n",
         "fast prototyping, advanced research, and production, with three key advantages:\n",
         "\n",
-        "- *User friendly*\u003cbr\u003e\n",
+        "- *User friendly*<br>\n",
         "  Keras has a simple, consistent interface optimized for common use cases. It\n",
         "  provides clear and actionable feedback for user errors.\n",
-        "- *Modular and composable*\u003cbr\u003e\n",
+        "- *Modular and composable*<br>\n",
         "  Keras models are made by connecting configurable building blocks together,\n",
         "  with few restrictions.\n",
-        "- *Easy to extend*\u003cbr\u003e Write custom building blocks to express new ideas for\n",
+        "- *Easy to extend*<br> Write custom building blocks to express new ideas for\n",
         "  research. Create new layers, loss functions, and develop state-of-the-art\n",
         "  models."
       ]
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "IsK5aF2xZ-40"
       },
+      "cell_type": "markdown",
       "source": [
         "## Import tf.keras\n",
         "\n",
@@ -106,41 +122,41 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Qoc055N3wiUG"
+        "id": "Qoc055N3wiUG",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "!pip install -q pyyaml  # Required to save models in YAML format"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "TgPcBFru0E1z"
+        "id": "TgPcBFru0E1z",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "import tensorflow as tf\n",
         "from tensorflow.keras import layers\n",
         "\n",
         "print(tf.VERSION)\n",
         "print(tf.keras.__version__)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "lj03RamP0E13"
       },
+      "cell_type": "markdown",
       "source": [
         "`tf.keras` can run any Keras-compatible code, but keep in mind:\n",
         "\n",
@@ -152,11 +168,11 @@
       ]
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "7e1LPcXx0gR6"
       },
+      "cell_type": "markdown",
       "source": [
         "## Build a simple model\n",
         "\n",
@@ -170,14 +186,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "WM-DUVQB0E14"
+        "id": "WM-DUVQB0E14",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "model = tf.keras.Sequential()\n",
         "# Adds a densely-connected layer with 64 units to the model:\n",
@@ -186,14 +200,16 @@
         "model.add(layers.Dense(64, activation='relu'))\n",
         "# Add a softmax layer with 10 output units:\n",
         "model.add(layers.Dense(10, activation='softmax'))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "-ztyTipu0E18"
       },
+      "cell_type": "markdown",
       "source": [
         "### Configure the layers\n",
         "\n",
@@ -215,14 +231,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "MlL7PBtp0E19"
+        "id": "MlL7PBtp0E19",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "# Create a sigmoid layer:\n",
         "layers.Dense(64, activation='sigmoid')\n",
@@ -240,14 +254,16 @@
         "\n",
         "# A linear layer with a bias vector initialized to 2.0s:\n",
         "layers.Dense(64, bias_initializer=tf.keras.initializers.constant(2.0))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "9NR6reyk0E2A"
       },
+      "cell_type": "markdown",
       "source": [
         "## Train and evaluate\n",
         "\n",
@@ -258,14 +274,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "sJ4AOn090E2A"
+        "id": "sJ4AOn090E2A",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "model = tf.keras.Sequential([\n",
         "# Adds a densely-connected layer with 64 units to the model:\n",
@@ -278,14 +292,16 @@
         "model.compile(optimizer=tf.train.AdamOptimizer(0.001),\n",
         "              loss='categorical_crossentropy',\n",
         "              metrics=['accuracy'])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "HG-RAa9F0E2D"
       },
+      "cell_type": "markdown",
       "source": [
         "`tf.keras.Model.compile` takes three important arguments:\n",
         "\n",
@@ -304,14 +320,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "St4Mgdar0E2E"
+        "id": "St4Mgdar0E2E",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "# Configure a model for mean-squared error regression.\n",
         "model.compile(optimizer=tf.train.AdamOptimizer(0.01),\n",
@@ -322,14 +336,16 @@
         "model.compile(optimizer=tf.train.RMSPropOptimizer(0.01),\n",
         "              loss=tf.keras.losses.categorical_crossentropy,\n",
         "              metrics=[tf.keras.metrics.categorical_accuracy])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "yjI5rbi80E2G"
       },
+      "cell_type": "markdown",
       "source": [
         "### Input NumPy data\n",
         "\n",
@@ -339,29 +355,36 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "3CvP6L-m0E2I"
+        "id": "3CvP6L-m0E2I",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "import numpy as np\n",
         "\n",
+        "def random_one_hot_labels(shape):\n",
+        "  n, n_class = shape\n",
+        "  classes = np.random.randint(0, n_class, n)\n",
+        "  labels = np.zeros((n, n_class))\n",
+        "  labels[np.arange(n), classes] = 1\n",
+        "  return labels\n",
+        "\n",
         "data = np.random.random((1000, 32))\n",
-        "labels = np.random.random((1000, 10))\n",
+        "labels = random_one_hot_labels((1000, 10))\n",
         "\n",
         "model.fit(data, labels, epochs=10, batch_size=32)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "N-pnVaFe0E2N"
       },
+      "cell_type": "markdown",
       "source": [
         "`tf.keras.Model.fit` takes three important arguments:\n",
         "\n",
@@ -380,33 +403,33 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "gFcXzVQa0E2N"
+        "id": "gFcXzVQa0E2N",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "import numpy as np\n",
         "\n",
         "data = np.random.random((1000, 32))\n",
-        "labels = np.random.random((1000, 10))\n",
+        "labels = random_one_hot_labels((1000, 10))\n",
         "\n",
         "val_data = np.random.random((100, 32))\n",
-        "val_labels = np.random.random((100, 10))\n",
+        "val_labels = random_one_hot_labels((100, 10))\n",
         "\n",
         "model.fit(data, labels, epochs=10, batch_size=32,\n",
         "          validation_data=(val_data, val_labels))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "-6ImyXzz0E2Q"
       },
+      "cell_type": "markdown",
       "source": [
         "### Input tf.data datasets\n",
         "\n",
@@ -416,14 +439,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "OziqhpIj0E2R"
+        "id": "OziqhpIj0E2R",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "# Instantiates a toy dataset instance:\n",
         "dataset = tf.data.Dataset.from_tensor_slices((data, labels))\n",
@@ -432,14 +453,16 @@
         "\n",
         "# Don't forget to specify `steps_per_epoch` when calling `fit` on a dataset.\n",
         "model.fit(dataset, epochs=10, steps_per_epoch=30)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "I7BcMHkB0E2U"
       },
+      "cell_type": "markdown",
       "source": [
         "Here, the `fit` method uses the `steps_per_epoch` argument—this is the number of\n",
         "training steps the model runs before it moves to the next epoch. Since the\n",
@@ -449,14 +472,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "YPMb3A0N0E2V"
+        "id": "YPMb3A0N0E2V",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "dataset = tf.data.Dataset.from_tensor_slices((data, labels))\n",
         "dataset = dataset.batch(32).repeat()\n",
@@ -467,14 +488,16 @@
         "model.fit(dataset, epochs=10, steps_per_epoch=30,\n",
         "          validation_data=val_dataset,\n",
         "          validation_steps=3)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "IgGdlXso0E2X"
       },
+      "cell_type": "markdown",
       "source": [
         "### Evaluate and predict\n",
         "\n",
@@ -485,54 +508,54 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "mhDbOHEK0E2Y"
+        "id": "mhDbOHEK0E2Y",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "data = np.random.random((1000, 32))\n",
-        "labels = np.random.random((1000, 10))\n",
+        "labels = random_one_hot_labels((1000, 10))\n",
         "\n",
         "model.evaluate(data, labels, batch_size=32)\n",
         "\n",
         "model.evaluate(dataset, steps=30)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "UXUTmDfb0E2b"
       },
+      "cell_type": "markdown",
       "source": [
         "And to *predict* the output of the last layer in inference for the data provided,\n",
         "as a NumPy array:"
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "9e3JsSoQ0E2c"
+        "id": "9e3JsSoQ0E2c",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "result = model.predict(data, batch_size=32)\n",
         "print(result.shape)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "fzEOW4Cn0E2h"
       },
+      "cell_type": "markdown",
       "source": [
         "## Build advanced models\n",
         "\n",
@@ -560,14 +583,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "mROj832r0E2i"
+        "id": "mROj832r0E2i",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "inputs = tf.keras.Input(shape=(32,))  # Returns a placeholder tensor\n",
         "\n",
@@ -575,27 +596,27 @@
         "x = layers.Dense(64, activation='relu')(inputs)\n",
         "x = layers.Dense(64, activation='relu')(x)\n",
         "predictions = layers.Dense(10, activation='softmax')(x)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "AFmspHeG1_W7"
       },
+      "cell_type": "markdown",
       "source": [
         "Instantiate the model given inputs and outputs."
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "5k5uzlyu16HM"
+        "id": "5k5uzlyu16HM",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "model = tf.keras.Model(inputs=inputs, outputs=predictions)\n",
         "\n",
@@ -606,14 +627,16 @@
         "\n",
         "# Trains for 5 epochs\n",
         "model.fit(data, labels, batch_size=32, epochs=5)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "EcKSLH3i0E2k"
       },
+      "cell_type": "markdown",
       "source": [
         "### Model subclassing\n",
         "\n",
@@ -634,14 +657,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "KLiHWzcn2Fzk"
+        "id": "KLiHWzcn2Fzk",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "class MyModel(tf.keras.Model):\n",
         "\n",
@@ -665,27 +686,27 @@
         "    shape = tf.TensorShape(input_shape).as_list()\n",
         "    shape[-1] = self.num_classes\n",
         "    return tf.TensorShape(shape)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "ShDD4fv72KGc"
       },
+      "cell_type": "markdown",
       "source": [
         "Instantiate the new model class:"
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "42C-qQHm0E2l"
+        "id": "42C-qQHm0E2l",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "model = MyModel(num_classes=10)\n",
         "\n",
@@ -696,14 +717,16 @@
         "\n",
         "# Trains for 5 epochs.\n",
         "model.fit(data, labels, batch_size=32, epochs=5)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "yqRQiKj20E2o"
       },
+      "cell_type": "markdown",
       "source": [
         "### Custom layers\n",
         "\n",
@@ -723,14 +746,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "l7BFnIHr2WNc"
+        "id": "l7BFnIHr2WNc",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "class MyLayer(layers.Layer):\n",
         "\n",
@@ -764,27 +785,27 @@
         "  @classmethod\n",
         "  def from_config(cls, config):\n",
         "    return cls(**config)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "8wXDRgXV2ZrF"
       },
+      "cell_type": "markdown",
       "source": [
         "Create a model using your custom layer:"
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "uqH-cY0h0E2p"
+        "id": "uqH-cY0h0E2p",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "model = tf.keras.Sequential([\n",
         "    MyLayer(10),\n",
@@ -797,14 +818,16 @@
         "\n",
         "# Trains for 5 epochs.\n",
         "model.fit(data, labels, batch_size=32, epochs=5)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "Lu8cc3AJ0E2v"
       },
+      "cell_type": "markdown",
       "source": [
         "## Callbacks\n",
         "\n",
@@ -825,14 +848,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "rdYwzSYV0E2v"
+        "id": "rdYwzSYV0E2v",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "callbacks = [\n",
         "  # Interrupt training if `val_loss` stops improving for over 2 epochs\n",
@@ -842,25 +863,27 @@
         "]\n",
         "model.fit(data, labels, batch_size=32, epochs=5, callbacks=callbacks,\n",
         "          validation_data=(val_data, val_labels))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "ghhaGfX62abv"
       },
+      "cell_type": "markdown",
       "source": [
-        "\u003ca id='weights_only'\u003e\u003c/a\u003e\n",
+        "<a id='weights_only'></a>\n",
         "## Save and restore"
       ]
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "qnl7K-aI0E2z"
       },
+      "cell_type": "markdown",
       "source": [
         "### Weights only\n",
         "\n",
@@ -868,14 +891,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "uQIANjB94fLB"
+        "id": "uQIANjB94fLB",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "model = tf.keras.Sequential([\n",
         "layers.Dense(64, activation='relu', input_shape=(32,)),\n",
@@ -884,17 +905,17 @@
         "model.compile(optimizer=tf.train.AdamOptimizer(0.001),\n",
         "              loss='categorical_crossentropy',\n",
         "              metrics=['accuracy'])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "4eoHJ-ny0E21"
+        "id": "4eoHJ-ny0E21",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "# Save weights to a TensorFlow Checkpoint file\n",
         "model.save_weights('./weights/my_model')\n",
@@ -902,14 +923,16 @@
         "# Restore the model's state,\n",
         "# this requires a model with the same architecture.\n",
         "model.load_weights('./weights/my_model')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "u25Id3xe0E25"
       },
+      "cell_type": "markdown",
       "source": [
         "By default, this saves the model's weights in the\n",
         "[TensorFlow checkpoint](./checkpoints.md) file format. Weights can\n",
@@ -918,28 +941,28 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "JSAYoFEd0E26"
+        "id": "JSAYoFEd0E26",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "# Save weights to a HDF5 file\n",
         "model.save_weights('my_model.h5', save_format='h5')\n",
         "\n",
         "# Restore the model's state\n",
         "model.load_weights('my_model.h5')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "mje_yKL10E29"
       },
+      "cell_type": "markdown",
       "source": [
         "### Configuration only\n",
         "\n",
@@ -950,122 +973,122 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "EbET0oJTzGkq"
+        "id": "EbET0oJTzGkq",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "# Serialize a model to JSON format\n",
         "json_string = model.to_json()\n",
         "json_string"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "pX_badhH3yWV"
+        "id": "pX_badhH3yWV",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "import json\n",
         "import pprint\n",
         "pprint.pprint(json.loads(json_string))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "Q7CIa05r4yTb"
       },
+      "cell_type": "markdown",
       "source": [
         "Recreate the model (newly initialized) from the JSON:"
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "J9UFv9k00E2_"
+        "id": "J9UFv9k00E2_",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "fresh_model = tf.keras.models.model_from_json(json_string)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "t5NHtICh4uHK"
       },
+      "cell_type": "markdown",
       "source": [
         "Serializing a model to YAML format requires that you install `pyyaml` *before you import TensorFlow*:"
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "aj24KB3Z36S4"
+        "id": "aj24KB3Z36S4",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "yaml_string = model.to_yaml()\n",
         "print(yaml_string)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "O53Kerfl43v7"
       },
+      "cell_type": "markdown",
       "source": [
         "Recreate the model from the YAML:"
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "77yRuwg03_MG"
+        "id": "77yRuwg03_MG",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "fresh_model = tf.keras.models.model_from_yaml(yaml_string)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "xPvOSSzM0E3B"
       },
+      "cell_type": "markdown",
       "source": [
         "Caution: Subclassed models are not serializable because their architecture is\n",
         "defined by the Python code in the body of the `call` method."
       ]
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "iu8qMwld4-71"
       },
+      "cell_type": "markdown",
       "source": [
         "\n",
         "### Entire model\n",
@@ -1077,14 +1100,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "45oNY34Z0E3C"
+        "id": "45oNY34Z0E3C",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "# Create a trivial model\n",
         "model = tf.keras.Sequential([\n",
@@ -1102,14 +1123,16 @@
         "\n",
         "# Recreate the exact same model, including weights and optimizer.\n",
         "model = tf.keras.models.load_model('my_model.h5')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "PMOWhDOB0E3E"
       },
+      "cell_type": "markdown",
       "source": [
         "## Eager execution\n",
         "\n",
@@ -1129,11 +1152,11 @@
       ]
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "2wG3NVco5B5V"
       },
+      "cell_type": "markdown",
       "source": [
         "## Distribution\n",
         "\n",
@@ -1150,14 +1173,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "cVg0vfTO0E3E"
+        "id": "cVg0vfTO0E3E",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "model = tf.keras.Sequential([layers.Dense(10,activation='softmax'),\n",
         "                          layers.Dense(10,activation='softmax')])\n",
@@ -1167,14 +1188,16 @@
         "              metrics=['accuracy'])\n",
         "\n",
         "estimator = tf.keras.estimator.model_to_estimator(model)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "S7FKvikO0E3H"
       },
+      "cell_type": "markdown",
       "source": [
         "Note: Enable [eager execution](./eager.md) for debugging\n",
         "[Estimator input functions](./premade_estimators.md#create_input_functions)\n",
@@ -1182,11 +1205,11 @@
       ]
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "6PJZ6e9J5JHF"
       },
+      "cell_type": "markdown",
       "source": [
         "### Multiple GPUs\n",
         "\n",
@@ -1208,14 +1231,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "sbaRr7g-0E3I"
+        "id": "sbaRr7g-0E3I",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "model = tf.keras.Sequential()\n",
         "model.add(layers.Dense(16, activation='relu', input_shape=(10,)))\n",
@@ -1225,14 +1246,16 @@
         "\n",
         "model.compile(loss='binary_crossentropy', optimizer=optimizer)\n",
         "model.summary()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "yw4hSJme0E3L"
       },
+      "cell_type": "markdown",
       "source": [
         "Define an *input pipeline*. The `input_fn` returns a `tf.data.Dataset` object\n",
         "used to distribute the data across multiple devices—with each device processing\n",
@@ -1240,14 +1263,12 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "CxJW1QMH0E3L"
+        "id": "CxJW1QMH0E3L",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "def input_fn():\n",
         "  x = np.random.random((1024, 10))\n",
@@ -1257,14 +1278,16 @@
         "  dataset = dataset.repeat(10)\n",
         "  dataset = dataset.batch(32)\n",
         "  return dataset"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "rO9MiL6X0E3O"
       },
+      "cell_type": "markdown",
       "source": [
         "Next, create a `tf.estimator.RunConfig` and set the `train_distribute` argument\n",
         "to the `tf.contrib.distribute.MirroredStrategy` instance. When creating\n",
@@ -1273,84 +1296,68 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "BEwFq4PM0E3P"
+        "id": "BEwFq4PM0E3P",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "strategy = tf.contrib.distribute.MirroredStrategy()\n",
         "config = tf.estimator.RunConfig(train_distribute=strategy)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "TcnwYVun0E3R"
       },
+      "cell_type": "markdown",
       "source": [
         "Convert the Keras model to a `tf.estimator.Estimator` instance:"
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "VSvbuIID0E3S"
+        "id": "VSvbuIID0E3S",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "keras_estimator = tf.keras.estimator.model_to_estimator(\n",
         "  keras_model=model,\n",
         "  config=config,\n",
         "  model_dir='/tmp/model_dir')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "N6BXU5F90E3U"
       },
+      "cell_type": "markdown",
       "source": [
         "Finally, train the `Estimator` instance by providing the `input_fn` and `steps`\n",
         "arguments:"
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "XKoJ2wUH0E3U"
+        "id": "XKoJ2wUH0E3U",
+        "colab": {}
       },
-      "outputs": [],
+      "cell_type": "code",
       "source": [
         "keras_estimator.train(input_fn=input_fn, steps=10)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [],
-      "name": "keras.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }


### PR DESCRIPTION
The original notebook uses `np.random.random((1000, 10))` to generate the label for a classification model. This is incorrect as the correct target label should be one-hot-encoded. This commit fixes this problem.