### PR TITLE
Add comments about  enable_eager_execution no longer being necessary

### DIFF
--- a/site/en/tutorials/load_data/images.ipynb
+++ b/site/en/tutorials/load_data/images.ipynb
@@ -103,7 +103,7 @@
         "from __future__ import absolute_import, division, print_function\n",
         "\n",
         "import tensorflow as tf\n",
-        "tf.enable_eager_execution()\n",
+        "tf.enable_eager_execution() # Only necessary in Tensorflow versions prior to 2.0\n",
         "tf.__version__"
       ]
     },

--- a/site/en/tutorials/load_data/tf_records.ipynb
+++ b/site/en/tutorials/load_data/tf_records.ipynb
@@ -110,7 +110,7 @@
         "from __future__ import absolute_import, division, print_function\n",
         "\n",
         "import tensorflow as tf\n",
-        "tf.enable_eager_execution()\n",
+        "tf.enable_eager_execution() # Only necessary in Tensorflow versions prior to 2.0\n",
         "\n",
         "import numpy as np\n",
         "import IPython.display as display"


### PR DESCRIPTION
Just went to work with this tutorial and the error message when you run this using TF version 2.0 is `AttributeError: module 'tensorflow' has no attribute 'enable_eager_execution'` which led me to believe I had a version problem, not that I could remove this line of code altogether.  

So this comment is to help those that are using version 2.0 know that they can just remove this line of code.