### PR TITLE
Fix concat str to bytes TypeError in word_embeddings.ipynb

### DIFF
--- a/site/en/r2/tutorials/sequences/word_embeddings.ipynb
+++ b/site/en/r2/tutorials/sequences/word_embeddings.ipynb
@@ -1,584 +1,597 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "GE91qWZkm8ZQ"
-      },
-      "source": [
-        "##### Copyright 2019 The TensorFlow Authors."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
-        "id": "YS3NA-i6nAFC"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "7SN5USFEIIK3"
-      },
-      "source": [
-        "# Word embeddings"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Aojnnc7sXrab"
-      },
-      "source": [
-        "\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/sequences/word_embeddings.ipynb\"\u003e\n",
-        "    \u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003e\n",
-        "    View on TensorFlow.org\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/word_embeddings.ipynb\"\u003e\n",
-        "    \u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003e\n",
-        "    Run in Google Colab\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/word_embeddings.ipynb\"\u003e\n",
-        "    \u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003e\n",
-        "    View source on GitHub\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "\u003c/table\u003e"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Q6mJg1g3apaz"
-      },
-      "source": [
-        "This tutorial introduces word embeddings. It contains complete code to train word embeddings from scratch on a small dataset, and to visualize these embeddings using the [Embedding Projector](http://projector.tensorflow.org) (shown in the image below). \n",
-        "\n",
-        "\u003cimg src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding.jpg?raw=1\" alt=\"Screenshot of the embedding projector\" width=\"400\"/\u003e\n",
-        "\n",
-        "## Representing text as numbers\n",
-        "\n",
-        "Machine learning models take vectors (arrays of numbers) as input. When working with text, the first thing we must do come up with a strategy to convert strings to numbers (or to \"vectorize\" the text) before feeding it to the model. In this section, we will look at three strategies for doing so.\n",
-        "\n",
-        "### One-hot encodings\n",
-        "\n",
-        "As a first idea, we might \"one-hot\" encode each word in our vocabulary. Consider the sentence \"The cat sat on the mat\". The vocabulary (or unique words) in this sentence is (cat, mat, on, sat, the). To represent each word, we will create a zero vector with length equal to the vocabulary, then place a one in the index that corresponds to the word. This approach is shown in the following diagram. \n",
-        "\n",
-        "\u003cimg src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/one-hot.png?raw=1\" alt=\"Diagram of one-hot encodings\" width=\"400\" /\u003e\n",
-        "\n",
-        "To create a vector that contains the encoding of the sentence, we could then concatenate the one-hot vectors for each word. \n",
-        "\n",
-        "Key point: This approach is inefficient. A one-hot encoded vector is sparse (meaning, most indicices are zero). Imagine we have 10,000 words in the vocabulary. To one-hot encode each word, we would create a vector where 99.99% of the elements are zero.\n",
-        "\n",
-        "### Encode each word with a unique number\n",
-        "\n",
-        "A second approach we might try is to encode each word using a unique number. Continuing the example above, we could assign 1 to \"cat\", 2 to \"mat\", and so on. We could then encode the sentence \"The cat sat on the mat\" as a dense vector like [5, 1, 4, 3, 5, 2]. This appoach is efficient. Instead of a sparse vector, we now have a dense one (where all elements are full). \n",
-        "\n",
-        "There are two downsides to this approach, however:\n",
-        "\n",
-        "* The integer-encoding is arbitrary (it does not capture any relationship between words).\n",
-        "\n",
-        "* An integer-encoding can be challenging for a model to interpret. A linear classifier, for example, learns a single weight for each feature. Because different words may have a similar encoding, this feature-weight combination is not meaningful.\n",
-        "\n",
-        "### Word embeddings\n",
-        "\n",
-        "Word embeddings give us a way to use an efficient, dense representation in which similar words have a similar encoding. Importantly, we do not have to specify this encoding by hand. An embedding is a dense vector of floating point values (the length of the vector is a parameter you specify). Instead of specifying the values for the embedding manually, they are traininable parameters (weights learned by the model during training, in the same way a model learns weights for a dense layer). It is common to see word embeddings that 8-dimensional (for small datasets), up to 1024-dimensions when working with large datasets. A higher dimensional embedding can capture fine-grained relationships between words, but takes more data to learn.\n",
-        "\n",
-        "\u003cimg src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding2.png?raw=1\" alt=\"Diagram of an embedding\" width=\"400\"/\u003e\n",
-        "\n",
-        "Above is a diagram for a word embedding. Each word is represented as a 4-dimensional vector of floating point values. Another way to think of an embedding is as \"lookup table\". After these weights have been learned, we can encode each word by looking up the dense vector it corresponds to in the table."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "eqBazMiVQkj1"
-      },
-      "source": [
-        "## Using the Embedding layer\n",
-        "\n",
-        "Keras makes it easy to use word embeddings. Let's take a look at the [Embedding](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Embedding) layer."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "SIXEk5ON5P7h"
-      },
-      "outputs": [],
-      "source": [
-        "from __future__ import absolute_import, division, print_function\n",
-        "\n",
-        "!pip install tensorflow==2.0.0-alpha0\n",
-        "import tensorflow as tf\n",
-        "\n",
-        "from tensorflow import keras\n",
-        "from tensorflow.keras import layers\n",
-        "\n",
-        "# The Embedding layer takes at least two arguments:\n",
-        "# the number of possible words in the vocabulary, here 1000 (1 + maximum word index),\n",
-        "# and the dimensionality of the embeddings, here 32.\n",
-        "embedding_layer = layers.Embedding(1000, 32)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "2dKKV1L2Rk7e"
-      },
-      "source": [
-        "The Embedding layer can be understood as a lookup table that maps from integer indices (which stand for specific words) to dense vectors (their embeddings). The dimensionality (or width) of the embedding is a parameter you can experiment with to see what works well for your problem, much in the same way you would experiment with the number of neurons in a Dense layer.\n",
-        "\n",
-        "When you create an Embedding layer, the weights for the embedding are randomly initialized (just like any other layer). During training, they are gradually adjusted via backpropagation. Once trained, the learned word embeddings will roughly encode similarities between words (as they were learned for the specific problem your model is trained on).\n",
-        "\n",
-        "As input, the Embedding layer takes a 2D tensor of integers, of shape `(samples, sequence_length)`, where each entry is a sequence of integers. It can embed sequences of variable lengths. You could feed into the embedding layer above batches with shapes `(32, 10)` (batch of 32 sequences of length 10) or `(64, 15)` (batch of 64 sequences of length 15). All sequences in a batch must have the same length, so sequences that are shorter than others should be padded with zeros, and sequences that are longer should be truncated.\n",
-        "\n",
-        "As output, the embedding layer returns a 3D floating point tensor, of shape `(samples, sequence_length, embedding_dimensionality)`. Such a 3D tensor can then be processed by a RNN layer, or can simply be flattened or pooled and processed by a Dense layer. We will show the first approach in this tutorial, and you can refer to the [Text Classification with an RNN](https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/text_classification_rnn.ipynb) to learn the second."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "aGicgV5qT0wh"
-      },
-      "source": [
-        "## Learning embeddings from scratch"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "_Bh8B1TUT6mV"
-      },
-      "source": [
-        "We will train a sentiment classifier on IMDB movie reviews. In the process, we will learn embeddings from scratch. We will move quickly through the code that downloads and preprocesses the dataset (see this [tutorial](https://www.tensorflow.org/tutorials/keras/basic_text_classification) for more details)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "cQrYYEvvUuV7"
-      },
-      "outputs": [],
-      "source": [
-        "vocab_size = 10000\n",
-        "imdb = keras.datasets.imdb\n",
-        "(train_data, train_labels), (test_data, test_labels) = imdb.load_data(num_words=vocab_size)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "dF8ORMt2U9lj"
-      },
-      "source": [
-        "As imported, the text of reviews is integer-encoded (each integer represents a specific word in a dictionary)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "yueILuntVEhr"
-      },
-      "outputs": [],
-      "source": [
-        "print(train_data[0])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "A2DzUyaXVMR1"
-      },
-      "source": [
-        "### Convert the integers back to words\n",
-        "\n",
-        "It may be useful to know how to convert integers back to text. Here, we'll create a helper function to query a dictionary object that contains the integer to string mapping:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "9axf0uIXVMhO"
-      },
-      "outputs": [],
-      "source": [
-        "# A dictionary mapping words to an integer index\n",
-        "word_index = imdb.get_word_index()\n",
-        "\n",
-        "# The first indices are reserved\n",
-        "word_index = {k:(v+3) for k,v in word_index.items()} \n",
-        "word_index[\"\u003cPAD\u003e\"] = 0\n",
-        "word_index[\"\u003cSTART\u003e\"] = 1\n",
-        "word_index[\"\u003cUNK\u003e\"] = 2  # unknown\n",
-        "word_index[\"\u003cUNUSED\u003e\"] = 3\n",
-        "\n",
-        "reverse_word_index = dict([(value, key) for (key, value) in word_index.items()])\n",
-        "\n",
-        "def decode_review(text):\n",
-        "    return ' '.join([reverse_word_index.get(i, '?') for i in text])\n",
-        "  \n",
-        "decode_review(train_data[0])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "47oPVxgUVd7g"
-      },
-      "source": [
-        "Movie reviews can be different lengths. We will use the `pad_sequences` function to standardize the lengths of the reviews."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "0Ejbvj8mVbIE"
-      },
-      "outputs": [],
-      "source": [
-        "maxlen = 500\n",
-        "\n",
-        "train_data = keras.preprocessing.sequence.pad_sequences(train_data,\n",
-        "                                                        value=word_index[\"\u003cPAD\u003e\"],\n",
-        "                                                        padding='post',\n",
-        "                                                        maxlen=maxlen)\n",
-        "\n",
-        "test_data = keras.preprocessing.sequence.pad_sequences(test_data,\n",
-        "                                                       value=word_index[\"\u003cPAD\u003e\"],\n",
-        "                                                       padding='post',\n",
-        "                                                       maxlen=maxlen)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "meWp84bPV0pu"
-      },
-      "source": [
-        "Let's inspect the first padded review."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "T7Tef4XhV2u9"
-      },
-      "outputs": [],
-      "source": [
-        "print(train_data[0])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "zI9_wLIiWO8Z"
-      },
-      "source": [
-        "### Create a simple model\n",
-        "\n",
-        "We will use the [Keras Sequential API](https://www.tensorflow.org/guide/keras) to define our model. \n",
-        "\n",
-        "* The first layer is an Embedding layer. This layer takes the integer-encoded vocabulary and looks up the embedding vector for each word-index. These vectors are learned as the model trains. The vectors add a dimension to the output array. The resulting dimensions are: `(batch, sequence, embedding)``.\n",
-        "\n",
-        "* Next, a GlobalAveragePooling1D layer returns a fixed-length output vector for each example by averaging over the sequence dimension. This allows the model to handle input of variable length, in the simplest way possible.\n",
-        "\n",
-        "* This fixed-length output vector is piped through a fully-connected (Dense) layer with 16 hidden units.\n",
-        "\n",
-        "* The last layer is densely connected with a single output node. Using the sigmoid activation function, this value is a float between 0 and 1, representing a probability (or confidence level) that the review is positive."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "pHLcFtn5Wsqj"
-      },
-      "outputs": [],
-      "source": [
-        "embedding_dim=16\n",
-        "\n",
-        "model = keras.Sequential([\n",
-        "  layers.Embedding(vocab_size, embedding_dim, input_length=maxlen),\n",
-        "  layers.GlobalAveragePooling1D(),\n",
-        "  layers.Dense(16, activation='relu'),\n",
-        "  layers.Dense(1, activation='sigmoid')\n",
-        "])\n",
-        "\n",
-        "model.summary()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "JjLNgKO7W2fe"
-      },
-      "source": [
-        "### Compile and train the model"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "lCUgdP69Wzix"
-      },
-      "outputs": [],
-      "source": [
-        "model.compile(optimizer='adam',\n",
-        "              loss='binary_crossentropy',\n",
-        "              metrics=['accuracy'])\n",
-        "\n",
-        "history = model.fit(\n",
-        "    train_data,\n",
-        "    train_labels,\n",
-        "    epochs=30,\n",
-        "    batch_size=512,\n",
-        "    validation_split=0.2)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "LQjpKVYTXU-1"
-      },
-      "source": [
-        "With this approach our model reaches a validation accuracy of around 88% (note the model is overfitting, training accuracy is significantly higher)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "0D3OTmOT1z1O"
-      },
-      "outputs": [],
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "acc = history.history['accuracy']\n",
-        "val_acc = history.history['val_accuracy']\n",
-        "\n",
-        "epochs = range(1, len(acc) + 1)\n",
-        "\n",
-        "plt.plot(epochs, acc, 'bo', label='Training acc')\n",
-        "plt.plot(epochs, val_acc, 'b', label='Validation acc')\n",
-        "plt.title('Training and validation accuracy')\n",
-        "plt.xlabel('Epochs')\n",
-        "plt.ylabel('Accuracy')\n",
-        "plt.legend(loc='lower right')\n",
-        "plt.figure(figsize=(16,9))\n",
-        "\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "KCoA6qwqP836"
-      },
-      "source": [
-        "## Retrieve the learned embeddings\n",
-        "\n",
-        "Next, let's retrieve the word embeddings learned during training. This will be a matrix of shape `(vocab_size,embedding-dimension)`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "t8WwbsXCXtpa"
-      },
-      "outputs": [],
-      "source": [
-        "e = model.layers[0]\n",
-        "weights = e.get_weights()[0]\n",
-        "print(weights.shape) # shape: (vocab_size, embedding_dim)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "J8MiCA77X8B8"
-      },
-      "source": [
-        "We will now write the weights to disk. To use the [Embedding Projector](http://projector.tensorflow.org), we will upload two files in tab separated format: a file of vectors (containing the embedding), and a file of meta data (containing the words)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "GsjempweP9Lq"
-      },
-      "outputs": [],
-      "source": [
-        "out_v = open('vecs.tsv', 'w')\n",
-        "out_m = open('meta.tsv', 'w')\n",
-        "for word_num in range(vocab_size):\n",
-        "  word = reverse_word_index[word_num].encode('utf-8')\n",
-        "  embeddings = weights[word_num]\n",
-        "  out_m.write(word + \"\\n\")\n",
-        "  out_v.write('\\t'.join([str(x) for x in embeddings]) + \"\\n\")\n",
-        "out_v.close()\n",
-        "out_m.close()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "JQyMZWyxYjMr"
-      },
-      "source": [
-        "If you are running this tutorial in [Colaboratory](https://colab.research.google.com), you can use the following snippet to download these files to your local machine (or use the file browser, *View -\u003e Table of contents -\u003e File browser*)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "-gFbbMmvYvhp"
-      },
-      "outputs": [],
-      "source": [
-        "# from google.colab import files\n",
-        "# files.download('vecs.tsv')\n",
-        "# files.download('meta.tsv')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "PXLfFA54Yz-o"
-      },
-      "source": [
-        "## Visualize the embeddings\n",
-        "\n",
-        "To visualize our embeddings we will upload them to the embedding projector.\n",
-        "\n",
-        "Open the [Embedding Projector](http://projector.tensorflow.org/). \n",
-        "\n",
-        "* Click on \"Load data\". \n",
-        "\n",
-        "* Upload the two files we created above: ```vecs.tsv``` and ```meta.tsv```. T\n",
-        "\n",
-        "The embeddings you have trained will now be displayed. You can search for words to find their closest neighbors. For example, try searching for \"beautiful\". You may see neighbors like \"wonderful\". Note: your results may be a bit different, depending on how weights were randomly initialized before training the embedding layer.\n",
-        "\n",
-        "Note: experimentally, you may be able to produce more interpretable embeddings by using a simpler model. Try deleting the `Dense(16)` layer, retraining the model, and visualizing the embeddings again.\n",
-        "\n",
-        "\u003cimg src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding.jpg?raw=1\" alt=\"Screenshot of the embedding projector\" width=\"400\"/\u003e\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "iS_uMeMw3Xpj"
-      },
-      "source": [
-        "## Next steps\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "BSgAZpwF5xF_"
-      },
-      "source": [
-        "This tutorial has show you how to train and visualize word embeddings from scratch on a small dataset. \n",
-        "\n",
-        "* To learn more about embeddings in Keras we recommend these [notebooks](https://github.com/fchollet/deep-learning-with-python-notebooks/blob/master/6.2-understanding-recurrent-neural-networks.ipynb) by François Chollet. \n",
-        "\n",
-        "* To learn more about text classification (including the overall workflow, and if you're curious about when to use embeddings vs one-hot encodings) we recommend this practical text classification [guide](https://developers.google.com/machine-learning/guides/text-classification/step-2-5)."
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [],
-      "name": "word_embeddings.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "GE91qWZkm8ZQ"
+   },
+   "source": [
+    "##### Copyright 2019 The TensorFlow Authors."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "cellView": "form",
+    "colab": {},
+    "colab_type": "code",
+    "id": "YS3NA-i6nAFC"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "7SN5USFEIIK3"
+   },
+   "source": [
+    "# Word embeddings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Aojnnc7sXrab"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/sequences/word_embeddings.ipynb\">\n",
+    "    <img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />\n",
+    "    View on TensorFlow.org</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/word_embeddings.ipynb\">\n",
+    "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />\n",
+    "    Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/word_embeddings.ipynb\">\n",
+    "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
+    "    View source on GitHub</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Q6mJg1g3apaz"
+   },
+   "source": [
+    "This tutorial introduces word embeddings. It contains complete code to train word embeddings from scratch on a small dataset, and to visualize these embeddings using the [Embedding Projector](http://projector.tensorflow.org) (shown in the image below). \n",
+    "\n",
+    "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding.jpg?raw=1\" alt=\"Screenshot of the embedding projector\" width=\"400\"/>\n",
+    "\n",
+    "## Representing text as numbers\n",
+    "\n",
+    "Machine learning models take vectors (arrays of numbers) as input. When working with text, the first thing we must do come up with a strategy to convert strings to numbers (or to \"vectorize\" the text) before feeding it to the model. In this section, we will look at three strategies for doing so.\n",
+    "\n",
+    "### One-hot encodings\n",
+    "\n",
+    "As a first idea, we might \"one-hot\" encode each word in our vocabulary. Consider the sentence \"The cat sat on the mat\". The vocabulary (or unique words) in this sentence is (cat, mat, on, sat, the). To represent each word, we will create a zero vector with length equal to the vocabulary, then place a one in the index that corresponds to the word. This approach is shown in the following diagram. \n",
+    "\n",
+    "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/one-hot.png?raw=1\" alt=\"Diagram of one-hot encodings\" width=\"400\" />\n",
+    "\n",
+    "To create a vector that contains the encoding of the sentence, we could then concatenate the one-hot vectors for each word. \n",
+    "\n",
+    "Key point: This approach is inefficient. A one-hot encoded vector is sparse (meaning, most indicices are zero). Imagine we have 10,000 words in the vocabulary. To one-hot encode each word, we would create a vector where 99.99% of the elements are zero.\n",
+    "\n",
+    "### Encode each word with a unique number\n",
+    "\n",
+    "A second approach we might try is to encode each word using a unique number. Continuing the example above, we could assign 1 to \"cat\", 2 to \"mat\", and so on. We could then encode the sentence \"The cat sat on the mat\" as a dense vector like [5, 1, 4, 3, 5, 2]. This appoach is efficient. Instead of a sparse vector, we now have a dense one (where all elements are full). \n",
+    "\n",
+    "There are two downsides to this approach, however:\n",
+    "\n",
+    "* The integer-encoding is arbitrary (it does not capture any relationship between words).\n",
+    "\n",
+    "* An integer-encoding can be challenging for a model to interpret. A linear classifier, for example, learns a single weight for each feature. Because different words may have a similar encoding, this feature-weight combination is not meaningful.\n",
+    "\n",
+    "### Word embeddings\n",
+    "\n",
+    "Word embeddings give us a way to use an efficient, dense representation in which similar words have a similar encoding. Importantly, we do not have to specify this encoding by hand. An embedding is a dense vector of floating point values (the length of the vector is a parameter you specify). Instead of specifying the values for the embedding manually, they are traininable parameters (weights learned by the model during training, in the same way a model learns weights for a dense layer). It is common to see word embeddings that 8-dimensional (for small datasets), up to 1024-dimensions when working with large datasets. A higher dimensional embedding can capture fine-grained relationships between words, but takes more data to learn.\n",
+    "\n",
+    "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding2.png?raw=1\" alt=\"Diagram of an embedding\" width=\"400\"/>\n",
+    "\n",
+    "Above is a diagram for a word embedding. Each word is represented as a 4-dimensional vector of floating point values. Another way to think of an embedding is as \"lookup table\". After these weights have been learned, we can encode each word by looking up the dense vector it corresponds to in the table."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "eqBazMiVQkj1"
+   },
+   "source": [
+    "## Using the Embedding layer\n",
+    "\n",
+    "Keras makes it easy to use word embeddings. Let's take a look at the [Embedding](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Embedding) layer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "SIXEk5ON5P7h"
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import absolute_import, division, print_function\n",
+    "\n",
+    "!pip install tensorflow==2.0.0-alpha0\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "from tensorflow import keras\n",
+    "from tensorflow.keras import layers\n",
+    "\n",
+    "# The Embedding layer takes at least two arguments:\n",
+    "# the number of possible words in the vocabulary, here 1000 (1 + maximum word index),\n",
+    "# and the dimensionality of the embeddings, here 32.\n",
+    "embedding_layer = layers.Embedding(1000, 32)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "2dKKV1L2Rk7e"
+   },
+   "source": [
+    "The Embedding layer can be understood as a lookup table that maps from integer indices (which stand for specific words) to dense vectors (their embeddings). The dimensionality (or width) of the embedding is a parameter you can experiment with to see what works well for your problem, much in the same way you would experiment with the number of neurons in a Dense layer.\n",
+    "\n",
+    "When you create an Embedding layer, the weights for the embedding are randomly initialized (just like any other layer). During training, they are gradually adjusted via backpropagation. Once trained, the learned word embeddings will roughly encode similarities between words (as they were learned for the specific problem your model is trained on).\n",
+    "\n",
+    "As input, the Embedding layer takes a 2D tensor of integers, of shape `(samples, sequence_length)`, where each entry is a sequence of integers. It can embed sequences of variable lengths. You could feed into the embedding layer above batches with shapes `(32, 10)` (batch of 32 sequences of length 10) or `(64, 15)` (batch of 64 sequences of length 15). All sequences in a batch must have the same length, so sequences that are shorter than others should be padded with zeros, and sequences that are longer should be truncated.\n",
+    "\n",
+    "As output, the embedding layer returns a 3D floating point tensor, of shape `(samples, sequence_length, embedding_dimensionality)`. Such a 3D tensor can then be processed by a RNN layer, or can simply be flattened or pooled and processed by a Dense layer. We will show the first approach in this tutorial, and you can refer to the [Text Classification with an RNN](https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/text_classification_rnn.ipynb) to learn the second."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "aGicgV5qT0wh"
+   },
+   "source": [
+    "## Learning embeddings from scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "_Bh8B1TUT6mV"
+   },
+   "source": [
+    "We will train a sentiment classifier on IMDB movie reviews. In the process, we will learn embeddings from scratch. We will move quickly through the code that downloads and preprocesses the dataset (see this [tutorial](https://www.tensorflow.org/tutorials/keras/basic_text_classification) for more details)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "cQrYYEvvUuV7"
+   },
+   "outputs": [],
+   "source": [
+    "vocab_size = 10000\n",
+    "imdb = keras.datasets.imdb\n",
+    "(train_data, train_labels), (test_data, test_labels) = imdb.load_data(num_words=vocab_size)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "dF8ORMt2U9lj"
+   },
+   "source": [
+    "As imported, the text of reviews is integer-encoded (each integer represents a specific word in a dictionary)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "yueILuntVEhr"
+   },
+   "outputs": [],
+   "source": [
+    "print(train_data[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "A2DzUyaXVMR1"
+   },
+   "source": [
+    "### Convert the integers back to words\n",
+    "\n",
+    "It may be useful to know how to convert integers back to text. Here, we'll create a helper function to query a dictionary object that contains the integer to string mapping:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "9axf0uIXVMhO"
+   },
+   "outputs": [],
+   "source": [
+    "# A dictionary mapping words to an integer index\n",
+    "word_index = imdb.get_word_index()\n",
+    "\n",
+    "# The first indices are reserved\n",
+    "word_index = {k:(v+3) for k,v in word_index.items()} \n",
+    "word_index[\"<PAD>\"] = 0\n",
+    "word_index[\"<START>\"] = 1\n",
+    "word_index[\"<UNK>\"] = 2  # unknown\n",
+    "word_index[\"<UNUSED>\"] = 3\n",
+    "\n",
+    "reverse_word_index = dict([(value, key) for (key, value) in word_index.items()])\n",
+    "\n",
+    "def decode_review(text):\n",
+    "    return ' '.join([reverse_word_index.get(i, '?') for i in text])\n",
+    "  \n",
+    "decode_review(train_data[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "47oPVxgUVd7g"
+   },
+   "source": [
+    "Movie reviews can be different lengths. We will use the `pad_sequences` function to standardize the lengths of the reviews."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "0Ejbvj8mVbIE"
+   },
+   "outputs": [],
+   "source": [
+    "maxlen = 500\n",
+    "\n",
+    "train_data = keras.preprocessing.sequence.pad_sequences(train_data,\n",
+    "                                                        value=word_index[\"<PAD>\"],\n",
+    "                                                        padding='post',\n",
+    "                                                        maxlen=maxlen)\n",
+    "\n",
+    "test_data = keras.preprocessing.sequence.pad_sequences(test_data,\n",
+    "                                                       value=word_index[\"<PAD>\"],\n",
+    "                                                       padding='post',\n",
+    "                                                       maxlen=maxlen)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "meWp84bPV0pu"
+   },
+   "source": [
+    "Let's inspect the first padded review."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "T7Tef4XhV2u9"
+   },
+   "outputs": [],
+   "source": [
+    "print(train_data[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "zI9_wLIiWO8Z"
+   },
+   "source": [
+    "### Create a simple model\n",
+    "\n",
+    "We will use the [Keras Sequential API](https://www.tensorflow.org/guide/keras) to define our model. \n",
+    "\n",
+    "* The first layer is an Embedding layer. This layer takes the integer-encoded vocabulary and looks up the embedding vector for each word-index. These vectors are learned as the model trains. The vectors add a dimension to the output array. The resulting dimensions are: `(batch, sequence, embedding)``.\n",
+    "\n",
+    "* Next, a GlobalAveragePooling1D layer returns a fixed-length output vector for each example by averaging over the sequence dimension. This allows the model to handle input of variable length, in the simplest way possible.\n",
+    "\n",
+    "* This fixed-length output vector is piped through a fully-connected (Dense) layer with 16 hidden units.\n",
+    "\n",
+    "* The last layer is densely connected with a single output node. Using the sigmoid activation function, this value is a float between 0 and 1, representing a probability (or confidence level) that the review is positive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "pHLcFtn5Wsqj"
+   },
+   "outputs": [],
+   "source": [
+    "embedding_dim=16\n",
+    "\n",
+    "model = keras.Sequential([\n",
+    "  layers.Embedding(vocab_size, embedding_dim, input_length=maxlen),\n",
+    "  layers.GlobalAveragePooling1D(),\n",
+    "  layers.Dense(16, activation='relu'),\n",
+    "  layers.Dense(1, activation='sigmoid')\n",
+    "])\n",
+    "\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "JjLNgKO7W2fe"
+   },
+   "source": [
+    "### Compile and train the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "lCUgdP69Wzix"
+   },
+   "outputs": [],
+   "source": [
+    "model.compile(optimizer='adam',\n",
+    "              loss='binary_crossentropy',\n",
+    "              metrics=['accuracy'])\n",
+    "\n",
+    "history = model.fit(\n",
+    "    train_data,\n",
+    "    train_labels,\n",
+    "    epochs=30,\n",
+    "    batch_size=512,\n",
+    "    validation_split=0.2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "LQjpKVYTXU-1"
+   },
+   "source": [
+    "With this approach our model reaches a validation accuracy of around 88% (note the model is overfitting, training accuracy is significantly higher)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "0D3OTmOT1z1O"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "acc = history.history['accuracy']\n",
+    "val_acc = history.history['val_accuracy']\n",
+    "\n",
+    "epochs = range(1, len(acc) + 1)\n",
+    "\n",
+    "plt.plot(epochs, acc, 'bo', label='Training acc')\n",
+    "plt.plot(epochs, val_acc, 'b', label='Validation acc')\n",
+    "plt.title('Training and validation accuracy')\n",
+    "plt.xlabel('Epochs')\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.legend(loc='lower right')\n",
+    "plt.figure(figsize=(16,9))\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "KCoA6qwqP836"
+   },
+   "source": [
+    "## Retrieve the learned embeddings\n",
+    "\n",
+    "Next, let's retrieve the word embeddings learned during training. This will be a matrix of shape `(vocab_size,embedding-dimension)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "t8WwbsXCXtpa"
+   },
+   "outputs": [],
+   "source": [
+    "e = model.layers[0]\n",
+    "weights = e.get_weights()[0]\n",
+    "print(weights.shape) # shape: (vocab_size, embedding_dim)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "J8MiCA77X8B8"
+   },
+   "source": [
+    "We will now write the weights to disk. To use the [Embedding Projector](http://projector.tensorflow.org), we will upload two files in tab separated format: a file of vectors (containing the embedding), and a file of meta data (containing the words)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "GsjempweP9Lq"
+   },
+   "outputs": [],
+   "source": [
+    "out_v = open('vecs.tsv', 'w')\n",
+    "out_m = open('meta.tsv', 'w')\n",
+    "for word_num in range(vocab_size):\n",
+    "  word = reverse_word_index[word_num]\n",
+    "  embeddings = weights[word_num]\n",
+    "  out_m.write(word + \"\\n\")\n",
+    "  out_v.write('\\t'.join([str(x) for x in embeddings]) + \"\\n\")\n",
+    "out_v.close()\n",
+    "out_m.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "JQyMZWyxYjMr"
+   },
+   "source": [
+    "If you are running this tutorial in [Colaboratory](https://colab.research.google.com), you can use the following snippet to download these files to your local machine (or use the file browser, *View -> Table of contents -> File browser*)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "-gFbbMmvYvhp"
+   },
+   "outputs": [],
+   "source": [
+    "# from google.colab import files\n",
+    "# files.download('vecs.tsv')\n",
+    "# files.download('meta.tsv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "PXLfFA54Yz-o"
+   },
+   "source": [
+    "## Visualize the embeddings\n",
+    "\n",
+    "To visualize our embeddings we will upload them to the embedding projector.\n",
+    "\n",
+    "Open the [Embedding Projector](http://projector.tensorflow.org/). \n",
+    "\n",
+    "* Click on \"Load data\". \n",
+    "\n",
+    "* Upload the two files we created above: ```vecs.tsv``` and ```meta.tsv```. T\n",
+    "\n",
+    "The embeddings you have trained will now be displayed. You can search for words to find their closest neighbors. For example, try searching for \"beautiful\". You may see neighbors like \"wonderful\". Note: your results may be a bit different, depending on how weights were randomly initialized before training the embedding layer.\n",
+    "\n",
+    "Note: experimentally, you may be able to produce more interpretable embeddings by using a simpler model. Try deleting the `Dense(16)` layer, retraining the model, and visualizing the embeddings again.\n",
+    "\n",
+    "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding.jpg?raw=1\" alt=\"Screenshot of the embedding projector\" width=\"400\"/>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "iS_uMeMw3Xpj"
+   },
+   "source": [
+    "## Next steps\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "BSgAZpwF5xF_"
+   },
+   "source": [
+    "This tutorial has show you how to train and visualize word embeddings from scratch on a small dataset. \n",
+    "\n",
+    "* To learn more about embeddings in Keras we recommend these [notebooks](https://github.com/fchollet/deep-learning-with-python-notebooks/blob/master/6.2-understanding-recurrent-neural-networks.ipynb) by François Chollet. \n",
+    "\n",
+    "* To learn more about text classification (including the overall workflow, and if you're curious about when to use embeddings vs one-hot encodings) we recommend this practical text classification [guide](https://developers.google.com/machine-learning/guides/text-classification/step-2-5)."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "word_embeddings.ipynb",
+   "private_outputs": true,
+   "provenance": [],
+   "toc_visible": true,
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/site/en/r2/tutorials/sequences/word_embeddings.ipynb
+++ b/site/en/r2/tutorials/sequences/word_embeddings.ipynb
@@ -1,40 +1,25 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "word_embeddings.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "accelerator": "GPU"
-  },
   "cells": [
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "GE91qWZkm8ZQ"
       },
-      "cell_type": "markdown",
       "source": [
         "##### Copyright 2019 The TensorFlow Authors."
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
         "cellView": "form",
+        "colab": {},
         "colab_type": "code",
-        "id": "YS3NA-i6nAFC",
-        "colab": {}
+        "id": "YS3NA-i6nAFC"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -47,56 +32,54 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "7SN5USFEIIK3"
       },
-      "cell_type": "markdown",
       "source": [
         "# Word embeddings"
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "Aojnnc7sXrab"
       },
-      "cell_type": "markdown",
       "source": [
-        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/sequences/word_embeddings.ipynb\">\n",
-        "    <img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />\n",
-        "    View on TensorFlow.org</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/word_embeddings.ipynb\">\n",
-        "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />\n",
-        "    Run in Google Colab</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/word_embeddings.ipynb\">\n",
-        "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
-        "    View source on GitHub</a>\n",
-        "  </td>\n",
-        "</table>"
+        "\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
+        "  \u003ctd\u003e\n",
+        "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/sequences/word_embeddings.ipynb\"\u003e\n",
+        "    \u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003e\n",
+        "    View on TensorFlow.org\u003c/a\u003e\n",
+        "  \u003c/td\u003e\n",
+        "  \u003ctd\u003e\n",
+        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/word_embeddings.ipynb\"\u003e\n",
+        "    \u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003e\n",
+        "    Run in Google Colab\u003c/a\u003e\n",
+        "  \u003c/td\u003e\n",
+        "  \u003ctd\u003e\n",
+        "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/word_embeddings.ipynb\"\u003e\n",
+        "    \u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003e\n",
+        "    View source on GitHub\u003c/a\u003e\n",
+        "  \u003c/td\u003e\n",
+        "\u003c/table\u003e"
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "Q6mJg1g3apaz"
       },
-      "cell_type": "markdown",
       "source": [
         "This tutorial introduces word embeddings. It contains complete code to train word embeddings from scratch on a small dataset, and to visualize these embeddings using the [Embedding Projector](http://projector.tensorflow.org) (shown in the image below). \n",
         "\n",
-        "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding.jpg?raw=1\" alt=\"Screenshot of the embedding projector\" width=\"400\"/>\n",
+        "\u003cimg src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding.jpg?raw=1\" alt=\"Screenshot of the embedding projector\" width=\"400\"/\u003e\n",
         "\n",
         "## Representing text as numbers\n",
         "\n",
@@ -106,7 +89,7 @@
         "\n",
         "As a first idea, we might \"one-hot\" encode each word in our vocabulary. Consider the sentence \"The cat sat on the mat\". The vocabulary (or unique words) in this sentence is (cat, mat, on, sat, the). To represent each word, we will create a zero vector with length equal to the vocabulary, then place a one in the index that corresponds to the word. This approach is shown in the following diagram. \n",
         "\n",
-        "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/one-hot.png?raw=1\" alt=\"Diagram of one-hot encodings\" width=\"400\" />\n",
+        "\u003cimg src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/one-hot.png?raw=1\" alt=\"Diagram of one-hot encodings\" width=\"400\" /\u003e\n",
         "\n",
         "To create a vector that contains the encoding of the sentence, we could then concatenate the one-hot vectors for each word. \n",
         "\n",
@@ -126,17 +109,17 @@
         "\n",
         "Word embeddings give us a way to use an efficient, dense representation in which similar words have a similar encoding. Importantly, we do not have to specify this encoding by hand. An embedding is a dense vector of floating point values (the length of the vector is a parameter you specify). Instead of specifying the values for the embedding manually, they are traininable parameters (weights learned by the model during training, in the same way a model learns weights for a dense layer). It is common to see word embeddings that 8-dimensional (for small datasets), up to 1024-dimensions when working with large datasets. A higher dimensional embedding can capture fine-grained relationships between words, but takes more data to learn.\n",
         "\n",
-        "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding2.png?raw=1\" alt=\"Diagram of an embedding\" width=\"400\"/>\n",
+        "\u003cimg src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding2.png?raw=1\" alt=\"Diagram of an embedding\" width=\"400\"/\u003e\n",
         "\n",
         "Above is a diagram for a word embedding. Each word is represented as a 4-dimensional vector of floating point values. Another way to think of an embedding is as \"lookup table\". After these weights have been learned, we can encode each word by looking up the dense vector it corresponds to in the table."
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "eqBazMiVQkj1"
       },
-      "cell_type": "markdown",
       "source": [
         "## Using the Embedding layer\n",
         "\n",
@@ -144,12 +127,14 @@
       ]
     },
     {
-      "metadata": {
-        "colab_type": "code",
-        "id": "SIXEk5ON5P7h",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "SIXEk5ON5P7h"
+      },
+      "outputs": [],
       "source": [
         "from __future__ import absolute_import, division, print_function\n",
         "\n",
@@ -163,16 +148,14 @@
         "# the number of possible words in the vocabulary, here 1000 (1 + maximum word index),\n",
         "# and the dimensionality of the embeddings, here 32.\n",
         "embedding_layer = layers.Embedding(1000, 32)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "2dKKV1L2Rk7e"
       },
-      "cell_type": "markdown",
       "source": [
         "The Embedding layer can be understood as a lookup table that maps from integer indices (which stand for specific words) to dense vectors (their embeddings). The dimensionality (or width) of the embedding is a parameter you can experiment with to see what works well for your problem, much in the same way you would experiment with the number of neurons in a Dense layer.\n",
         "\n",
@@ -184,69 +167,69 @@
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "aGicgV5qT0wh"
       },
-      "cell_type": "markdown",
       "source": [
         "## Learning embeddings from scratch"
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "_Bh8B1TUT6mV"
       },
-      "cell_type": "markdown",
       "source": [
         "We will train a sentiment classifier on IMDB movie reviews. In the process, we will learn embeddings from scratch. We will move quickly through the code that downloads and preprocesses the dataset (see this [tutorial](https://www.tensorflow.org/tutorials/keras/basic_text_classification) for more details)."
       ]
     },
     {
-      "metadata": {
-        "colab_type": "code",
-        "id": "cQrYYEvvUuV7",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "cQrYYEvvUuV7"
+      },
+      "outputs": [],
       "source": [
         "vocab_size = 10000\n",
         "imdb = keras.datasets.imdb\n",
         "(train_data, train_labels), (test_data, test_labels) = imdb.load_data(num_words=vocab_size)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "dF8ORMt2U9lj"
       },
-      "cell_type": "markdown",
       "source": [
         "As imported, the text of reviews is integer-encoded (each integer represents a specific word in a dictionary)."
       ]
     },
     {
-      "metadata": {
-        "colab_type": "code",
-        "id": "yueILuntVEhr",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "yueILuntVEhr"
+      },
+      "outputs": [],
       "source": [
         "print(train_data[0])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "A2DzUyaXVMR1"
       },
-      "cell_type": "markdown",
       "source": [
         "### Convert the integers back to words\n",
         "\n",
@@ -254,22 +237,24 @@
       ]
     },
     {
-      "metadata": {
-        "colab_type": "code",
-        "id": "9axf0uIXVMhO",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "9axf0uIXVMhO"
+      },
+      "outputs": [],
       "source": [
         "# A dictionary mapping words to an integer index\n",
         "word_index = imdb.get_word_index()\n",
         "\n",
         "# The first indices are reserved\n",
         "word_index = {k:(v+3) for k,v in word_index.items()} \n",
-        "word_index[\"<PAD>\"] = 0\n",
-        "word_index[\"<START>\"] = 1\n",
-        "word_index[\"<UNK>\"] = 2  # unknown\n",
-        "word_index[\"<UNUSED>\"] = 3\n",
+        "word_index[\"\u003cPAD\u003e\"] = 0\n",
+        "word_index[\"\u003cSTART\u003e\"] = 1\n",
+        "word_index[\"\u003cUNK\u003e\"] = 2  # unknown\n",
+        "word_index[\"\u003cUNUSED\u003e\"] = 3\n",
         "\n",
         "reverse_word_index = dict([(value, key) for (key, value) in word_index.items()])\n",
         "\n",
@@ -277,72 +262,70 @@
         "    return ' '.join([reverse_word_index.get(i, '?') for i in text])\n",
         "  \n",
         "decode_review(train_data[0])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "47oPVxgUVd7g"
       },
-      "cell_type": "markdown",
       "source": [
         "Movie reviews can be different lengths. We will use the `pad_sequences` function to standardize the lengths of the reviews."
       ]
     },
     {
-      "metadata": {
-        "colab_type": "code",
-        "id": "0Ejbvj8mVbIE",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "0Ejbvj8mVbIE"
+      },
+      "outputs": [],
       "source": [
         "maxlen = 500\n",
         "\n",
         "train_data = keras.preprocessing.sequence.pad_sequences(train_data,\n",
-        "                                                        value=word_index[\"<PAD>\"],\n",
+        "                                                        value=word_index[\"\u003cPAD\u003e\"],\n",
         "                                                        padding='post',\n",
         "                                                        maxlen=maxlen)\n",
         "\n",
         "test_data = keras.preprocessing.sequence.pad_sequences(test_data,\n",
-        "                                                       value=word_index[\"<PAD>\"],\n",
+        "                                                       value=word_index[\"\u003cPAD\u003e\"],\n",
         "                                                       padding='post',\n",
         "                                                       maxlen=maxlen)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "meWp84bPV0pu"
       },
-      "cell_type": "markdown",
       "source": [
         "Let's inspect the first padded review."
       ]
     },
     {
-      "metadata": {
-        "colab_type": "code",
-        "id": "T7Tef4XhV2u9",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "T7Tef4XhV2u9"
+      },
+      "outputs": [],
       "source": [
         "print(train_data[0])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "zI9_wLIiWO8Z"
       },
-      "cell_type": "markdown",
       "source": [
         "### Create a simple model\n",
         "\n",
@@ -358,12 +341,14 @@
       ]
     },
     {
-      "metadata": {
-        "colab_type": "code",
-        "id": "pHLcFtn5Wsqj",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "pHLcFtn5Wsqj"
+      },
+      "outputs": [],
       "source": [
         "embedding_dim=16\n",
         "\n",
@@ -375,27 +360,27 @@
         "])\n",
         "\n",
         "model.summary()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "JjLNgKO7W2fe"
       },
-      "cell_type": "markdown",
       "source": [
         "### Compile and train the model"
       ]
     },
     {
-      "metadata": {
-        "colab_type": "code",
-        "id": "lCUgdP69Wzix",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "lCUgdP69Wzix"
+      },
+      "outputs": [],
       "source": [
         "model.compile(optimizer='adam',\n",
         "              loss='binary_crossentropy',\n",
@@ -407,27 +392,27 @@
         "    epochs=30,\n",
         "    batch_size=512,\n",
         "    validation_split=0.2)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "LQjpKVYTXU-1"
       },
-      "cell_type": "markdown",
       "source": [
         "With this approach our model reaches a validation accuracy of around 88% (note the model is overfitting, training accuracy is significantly higher)."
       ]
     },
     {
-      "metadata": {
-        "colab_type": "code",
-        "id": "0D3OTmOT1z1O",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "0D3OTmOT1z1O"
+      },
+      "outputs": [],
       "source": [
         "import matplotlib.pyplot as plt\n",
         "\n",
@@ -445,16 +430,14 @@
         "plt.figure(figsize=(16,9))\n",
         "\n",
         "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "KCoA6qwqP836"
       },
-      "cell_type": "markdown",
       "source": [
         "## Retrieve the learned embeddings\n",
         "\n",
@@ -462,37 +445,39 @@
       ]
     },
     {
-      "metadata": {
-        "colab_type": "code",
-        "id": "t8WwbsXCXtpa",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "t8WwbsXCXtpa"
+      },
+      "outputs": [],
       "source": [
         "e = model.layers[0]\n",
         "weights = e.get_weights()[0]\n",
         "print(weights.shape) # shape: (vocab_size, embedding_dim)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "J8MiCA77X8B8"
       },
-      "cell_type": "markdown",
       "source": [
         "We will now write the weights to disk. To use the [Embedding Projector](http://projector.tensorflow.org), we will upload two files in tab separated format: a file of vectors (containing the embedding), and a file of meta data (containing the words)."
       ]
     },
     {
-      "metadata": {
-        "colab_type": "code",
-        "id": "GsjempweP9Lq",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "GsjempweP9Lq"
+      },
+      "outputs": [],
       "source": [
         "out_v = open('vecs.tsv', 'w')\n",
         "out_m = open('meta.tsv', 'w')\n",
@@ -503,41 +488,39 @@
         "  out_v.write('\\t'.join([str(x) for x in embeddings]) + \"\\n\")\n",
         "out_v.close()\n",
         "out_m.close()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "JQyMZWyxYjMr"
       },
-      "cell_type": "markdown",
       "source": [
-        "If you are running this tutorial in [Colaboratory](https://colab.research.google.com), you can use the following snippet to download these files to your local machine (or use the file browser, *View -> Table of contents -> File browser*)."
+        "If you are running this tutorial in [Colaboratory](https://colab.research.google.com), you can use the following snippet to download these files to your local machine (or use the file browser, *View -\u003e Table of contents -\u003e File browser*)."
       ]
     },
     {
-      "metadata": {
-        "colab_type": "code",
-        "id": "-gFbbMmvYvhp",
-        "colab": {}
-      },
       "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "-gFbbMmvYvhp"
+      },
+      "outputs": [],
       "source": [
         "# from google.colab import files\n",
         "# files.download('vecs.tsv')\n",
         "# files.download('meta.tsv')"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "PXLfFA54Yz-o"
       },
-      "cell_type": "markdown",
       "source": [
         "## Visualize the embeddings\n",
         "\n",
@@ -553,25 +536,25 @@
         "\n",
         "Note: experimentally, you may be able to produce more interpretable embeddings by using a simpler model. Try deleting the `Dense(16)` layer, retraining the model, and visualizing the embeddings again.\n",
         "\n",
-        "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding.jpg?raw=1\" alt=\"Screenshot of the embedding projector\" width=\"400\"/>\n"
+        "\u003cimg src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding.jpg?raw=1\" alt=\"Screenshot of the embedding projector\" width=\"400\"/\u003e\n"
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "iS_uMeMw3Xpj"
       },
-      "cell_type": "markdown",
       "source": [
         "## Next steps\n"
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "BSgAZpwF5xF_"
       },
-      "cell_type": "markdown",
       "source": [
         "This tutorial has show you how to train and visualize word embeddings from scratch on a small dataset. \n",
         "\n",
@@ -580,5 +563,22 @@
         "* To learn more about text classification (including the overall workflow, and if you're curious about when to use embeddings vs one-hot encodings) we recommend this practical text classification [guide](https://developers.google.com/machine-learning/guides/text-classification/step-2-5)."
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "word_embeddings.ipynb",
+      "private_outputs": true,
+      "provenance": [],
+      "toc_visible": true,
+      "version": "0.3.2"
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/site/en/r2/tutorials/sequences/word_embeddings.ipynb
+++ b/site/en/r2/tutorials/sequences/word_embeddings.ipynb
@@ -1,597 +1,584 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "GE91qWZkm8ZQ"
-   },
-   "source": [
-    "##### Copyright 2019 The TensorFlow Authors."
-   ]
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "word_embeddings.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "accelerator": "GPU"
   },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "cellView": "form",
-    "colab": {},
-    "colab_type": "code",
-    "id": "YS3NA-i6nAFC"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "# https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "7SN5USFEIIK3"
-   },
-   "source": [
-    "# Word embeddings"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Aojnnc7sXrab"
-   },
-   "source": [
-    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/sequences/word_embeddings.ipynb\">\n",
-    "    <img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />\n",
-    "    View on TensorFlow.org</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/word_embeddings.ipynb\">\n",
-    "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />\n",
-    "    Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/word_embeddings.ipynb\">\n",
-    "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
-    "    View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Q6mJg1g3apaz"
-   },
-   "source": [
-    "This tutorial introduces word embeddings. It contains complete code to train word embeddings from scratch on a small dataset, and to visualize these embeddings using the [Embedding Projector](http://projector.tensorflow.org) (shown in the image below). \n",
-    "\n",
-    "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding.jpg?raw=1\" alt=\"Screenshot of the embedding projector\" width=\"400\"/>\n",
-    "\n",
-    "## Representing text as numbers\n",
-    "\n",
-    "Machine learning models take vectors (arrays of numbers) as input. When working with text, the first thing we must do come up with a strategy to convert strings to numbers (or to \"vectorize\" the text) before feeding it to the model. In this section, we will look at three strategies for doing so.\n",
-    "\n",
-    "### One-hot encodings\n",
-    "\n",
-    "As a first idea, we might \"one-hot\" encode each word in our vocabulary. Consider the sentence \"The cat sat on the mat\". The vocabulary (or unique words) in this sentence is (cat, mat, on, sat, the). To represent each word, we will create a zero vector with length equal to the vocabulary, then place a one in the index that corresponds to the word. This approach is shown in the following diagram. \n",
-    "\n",
-    "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/one-hot.png?raw=1\" alt=\"Diagram of one-hot encodings\" width=\"400\" />\n",
-    "\n",
-    "To create a vector that contains the encoding of the sentence, we could then concatenate the one-hot vectors for each word. \n",
-    "\n",
-    "Key point: This approach is inefficient. A one-hot encoded vector is sparse (meaning, most indicices are zero). Imagine we have 10,000 words in the vocabulary. To one-hot encode each word, we would create a vector where 99.99% of the elements are zero.\n",
-    "\n",
-    "### Encode each word with a unique number\n",
-    "\n",
-    "A second approach we might try is to encode each word using a unique number. Continuing the example above, we could assign 1 to \"cat\", 2 to \"mat\", and so on. We could then encode the sentence \"The cat sat on the mat\" as a dense vector like [5, 1, 4, 3, 5, 2]. This appoach is efficient. Instead of a sparse vector, we now have a dense one (where all elements are full). \n",
-    "\n",
-    "There are two downsides to this approach, however:\n",
-    "\n",
-    "* The integer-encoding is arbitrary (it does not capture any relationship between words).\n",
-    "\n",
-    "* An integer-encoding can be challenging for a model to interpret. A linear classifier, for example, learns a single weight for each feature. Because different words may have a similar encoding, this feature-weight combination is not meaningful.\n",
-    "\n",
-    "### Word embeddings\n",
-    "\n",
-    "Word embeddings give us a way to use an efficient, dense representation in which similar words have a similar encoding. Importantly, we do not have to specify this encoding by hand. An embedding is a dense vector of floating point values (the length of the vector is a parameter you specify). Instead of specifying the values for the embedding manually, they are traininable parameters (weights learned by the model during training, in the same way a model learns weights for a dense layer). It is common to see word embeddings that 8-dimensional (for small datasets), up to 1024-dimensions when working with large datasets. A higher dimensional embedding can capture fine-grained relationships between words, but takes more data to learn.\n",
-    "\n",
-    "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding2.png?raw=1\" alt=\"Diagram of an embedding\" width=\"400\"/>\n",
-    "\n",
-    "Above is a diagram for a word embedding. Each word is represented as a 4-dimensional vector of floating point values. Another way to think of an embedding is as \"lookup table\". After these weights have been learned, we can encode each word by looking up the dense vector it corresponds to in the table."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "eqBazMiVQkj1"
-   },
-   "source": [
-    "## Using the Embedding layer\n",
-    "\n",
-    "Keras makes it easy to use word embeddings. Let's take a look at the [Embedding](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Embedding) layer."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "SIXEk5ON5P7h"
-   },
-   "outputs": [],
-   "source": [
-    "from __future__ import absolute_import, division, print_function\n",
-    "\n",
-    "!pip install tensorflow==2.0.0-alpha0\n",
-    "import tensorflow as tf\n",
-    "\n",
-    "from tensorflow import keras\n",
-    "from tensorflow.keras import layers\n",
-    "\n",
-    "# The Embedding layer takes at least two arguments:\n",
-    "# the number of possible words in the vocabulary, here 1000 (1 + maximum word index),\n",
-    "# and the dimensionality of the embeddings, here 32.\n",
-    "embedding_layer = layers.Embedding(1000, 32)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "2dKKV1L2Rk7e"
-   },
-   "source": [
-    "The Embedding layer can be understood as a lookup table that maps from integer indices (which stand for specific words) to dense vectors (their embeddings). The dimensionality (or width) of the embedding is a parameter you can experiment with to see what works well for your problem, much in the same way you would experiment with the number of neurons in a Dense layer.\n",
-    "\n",
-    "When you create an Embedding layer, the weights for the embedding are randomly initialized (just like any other layer). During training, they are gradually adjusted via backpropagation. Once trained, the learned word embeddings will roughly encode similarities between words (as they were learned for the specific problem your model is trained on).\n",
-    "\n",
-    "As input, the Embedding layer takes a 2D tensor of integers, of shape `(samples, sequence_length)`, where each entry is a sequence of integers. It can embed sequences of variable lengths. You could feed into the embedding layer above batches with shapes `(32, 10)` (batch of 32 sequences of length 10) or `(64, 15)` (batch of 64 sequences of length 15). All sequences in a batch must have the same length, so sequences that are shorter than others should be padded with zeros, and sequences that are longer should be truncated.\n",
-    "\n",
-    "As output, the embedding layer returns a 3D floating point tensor, of shape `(samples, sequence_length, embedding_dimensionality)`. Such a 3D tensor can then be processed by a RNN layer, or can simply be flattened or pooled and processed by a Dense layer. We will show the first approach in this tutorial, and you can refer to the [Text Classification with an RNN](https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/text_classification_rnn.ipynb) to learn the second."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "aGicgV5qT0wh"
-   },
-   "source": [
-    "## Learning embeddings from scratch"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "_Bh8B1TUT6mV"
-   },
-   "source": [
-    "We will train a sentiment classifier on IMDB movie reviews. In the process, we will learn embeddings from scratch. We will move quickly through the code that downloads and preprocesses the dataset (see this [tutorial](https://www.tensorflow.org/tutorials/keras/basic_text_classification) for more details)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "cQrYYEvvUuV7"
-   },
-   "outputs": [],
-   "source": [
-    "vocab_size = 10000\n",
-    "imdb = keras.datasets.imdb\n",
-    "(train_data, train_labels), (test_data, test_labels) = imdb.load_data(num_words=vocab_size)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "dF8ORMt2U9lj"
-   },
-   "source": [
-    "As imported, the text of reviews is integer-encoded (each integer represents a specific word in a dictionary)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "yueILuntVEhr"
-   },
-   "outputs": [],
-   "source": [
-    "print(train_data[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "A2DzUyaXVMR1"
-   },
-   "source": [
-    "### Convert the integers back to words\n",
-    "\n",
-    "It may be useful to know how to convert integers back to text. Here, we'll create a helper function to query a dictionary object that contains the integer to string mapping:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "9axf0uIXVMhO"
-   },
-   "outputs": [],
-   "source": [
-    "# A dictionary mapping words to an integer index\n",
-    "word_index = imdb.get_word_index()\n",
-    "\n",
-    "# The first indices are reserved\n",
-    "word_index = {k:(v+3) for k,v in word_index.items()} \n",
-    "word_index[\"<PAD>\"] = 0\n",
-    "word_index[\"<START>\"] = 1\n",
-    "word_index[\"<UNK>\"] = 2  # unknown\n",
-    "word_index[\"<UNUSED>\"] = 3\n",
-    "\n",
-    "reverse_word_index = dict([(value, key) for (key, value) in word_index.items()])\n",
-    "\n",
-    "def decode_review(text):\n",
-    "    return ' '.join([reverse_word_index.get(i, '?') for i in text])\n",
-    "  \n",
-    "decode_review(train_data[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "47oPVxgUVd7g"
-   },
-   "source": [
-    "Movie reviews can be different lengths. We will use the `pad_sequences` function to standardize the lengths of the reviews."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "0Ejbvj8mVbIE"
-   },
-   "outputs": [],
-   "source": [
-    "maxlen = 500\n",
-    "\n",
-    "train_data = keras.preprocessing.sequence.pad_sequences(train_data,\n",
-    "                                                        value=word_index[\"<PAD>\"],\n",
-    "                                                        padding='post',\n",
-    "                                                        maxlen=maxlen)\n",
-    "\n",
-    "test_data = keras.preprocessing.sequence.pad_sequences(test_data,\n",
-    "                                                       value=word_index[\"<PAD>\"],\n",
-    "                                                       padding='post',\n",
-    "                                                       maxlen=maxlen)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "meWp84bPV0pu"
-   },
-   "source": [
-    "Let's inspect the first padded review."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "T7Tef4XhV2u9"
-   },
-   "outputs": [],
-   "source": [
-    "print(train_data[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "zI9_wLIiWO8Z"
-   },
-   "source": [
-    "### Create a simple model\n",
-    "\n",
-    "We will use the [Keras Sequential API](https://www.tensorflow.org/guide/keras) to define our model. \n",
-    "\n",
-    "* The first layer is an Embedding layer. This layer takes the integer-encoded vocabulary and looks up the embedding vector for each word-index. These vectors are learned as the model trains. The vectors add a dimension to the output array. The resulting dimensions are: `(batch, sequence, embedding)``.\n",
-    "\n",
-    "* Next, a GlobalAveragePooling1D layer returns a fixed-length output vector for each example by averaging over the sequence dimension. This allows the model to handle input of variable length, in the simplest way possible.\n",
-    "\n",
-    "* This fixed-length output vector is piped through a fully-connected (Dense) layer with 16 hidden units.\n",
-    "\n",
-    "* The last layer is densely connected with a single output node. Using the sigmoid activation function, this value is a float between 0 and 1, representing a probability (or confidence level) that the review is positive."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "pHLcFtn5Wsqj"
-   },
-   "outputs": [],
-   "source": [
-    "embedding_dim=16\n",
-    "\n",
-    "model = keras.Sequential([\n",
-    "  layers.Embedding(vocab_size, embedding_dim, input_length=maxlen),\n",
-    "  layers.GlobalAveragePooling1D(),\n",
-    "  layers.Dense(16, activation='relu'),\n",
-    "  layers.Dense(1, activation='sigmoid')\n",
-    "])\n",
-    "\n",
-    "model.summary()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "JjLNgKO7W2fe"
-   },
-   "source": [
-    "### Compile and train the model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "lCUgdP69Wzix"
-   },
-   "outputs": [],
-   "source": [
-    "model.compile(optimizer='adam',\n",
-    "              loss='binary_crossentropy',\n",
-    "              metrics=['accuracy'])\n",
-    "\n",
-    "history = model.fit(\n",
-    "    train_data,\n",
-    "    train_labels,\n",
-    "    epochs=30,\n",
-    "    batch_size=512,\n",
-    "    validation_split=0.2)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "LQjpKVYTXU-1"
-   },
-   "source": [
-    "With this approach our model reaches a validation accuracy of around 88% (note the model is overfitting, training accuracy is significantly higher)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "0D3OTmOT1z1O"
-   },
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "acc = history.history['accuracy']\n",
-    "val_acc = history.history['val_accuracy']\n",
-    "\n",
-    "epochs = range(1, len(acc) + 1)\n",
-    "\n",
-    "plt.plot(epochs, acc, 'bo', label='Training acc')\n",
-    "plt.plot(epochs, val_acc, 'b', label='Validation acc')\n",
-    "plt.title('Training and validation accuracy')\n",
-    "plt.xlabel('Epochs')\n",
-    "plt.ylabel('Accuracy')\n",
-    "plt.legend(loc='lower right')\n",
-    "plt.figure(figsize=(16,9))\n",
-    "\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "KCoA6qwqP836"
-   },
-   "source": [
-    "## Retrieve the learned embeddings\n",
-    "\n",
-    "Next, let's retrieve the word embeddings learned during training. This will be a matrix of shape `(vocab_size,embedding-dimension)`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "t8WwbsXCXtpa"
-   },
-   "outputs": [],
-   "source": [
-    "e = model.layers[0]\n",
-    "weights = e.get_weights()[0]\n",
-    "print(weights.shape) # shape: (vocab_size, embedding_dim)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "J8MiCA77X8B8"
-   },
-   "source": [
-    "We will now write the weights to disk. To use the [Embedding Projector](http://projector.tensorflow.org), we will upload two files in tab separated format: a file of vectors (containing the embedding), and a file of meta data (containing the words)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "GsjempweP9Lq"
-   },
-   "outputs": [],
-   "source": [
-    "out_v = open('vecs.tsv', 'w')\n",
-    "out_m = open('meta.tsv', 'w')\n",
-    "for word_num in range(vocab_size):\n",
-    "  word = reverse_word_index[word_num]\n",
-    "  embeddings = weights[word_num]\n",
-    "  out_m.write(word + \"\\n\")\n",
-    "  out_v.write('\\t'.join([str(x) for x in embeddings]) + \"\\n\")\n",
-    "out_v.close()\n",
-    "out_m.close()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "JQyMZWyxYjMr"
-   },
-   "source": [
-    "If you are running this tutorial in [Colaboratory](https://colab.research.google.com), you can use the following snippet to download these files to your local machine (or use the file browser, *View -> Table of contents -> File browser*)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "-gFbbMmvYvhp"
-   },
-   "outputs": [],
-   "source": [
-    "# from google.colab import files\n",
-    "# files.download('vecs.tsv')\n",
-    "# files.download('meta.tsv')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "PXLfFA54Yz-o"
-   },
-   "source": [
-    "## Visualize the embeddings\n",
-    "\n",
-    "To visualize our embeddings we will upload them to the embedding projector.\n",
-    "\n",
-    "Open the [Embedding Projector](http://projector.tensorflow.org/). \n",
-    "\n",
-    "* Click on \"Load data\". \n",
-    "\n",
-    "* Upload the two files we created above: ```vecs.tsv``` and ```meta.tsv```. T\n",
-    "\n",
-    "The embeddings you have trained will now be displayed. You can search for words to find their closest neighbors. For example, try searching for \"beautiful\". You may see neighbors like \"wonderful\". Note: your results may be a bit different, depending on how weights were randomly initialized before training the embedding layer.\n",
-    "\n",
-    "Note: experimentally, you may be able to produce more interpretable embeddings by using a simpler model. Try deleting the `Dense(16)` layer, retraining the model, and visualizing the embeddings again.\n",
-    "\n",
-    "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding.jpg?raw=1\" alt=\"Screenshot of the embedding projector\" width=\"400\"/>\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "iS_uMeMw3Xpj"
-   },
-   "source": [
-    "## Next steps\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "BSgAZpwF5xF_"
-   },
-   "source": [
-    "This tutorial has show you how to train and visualize word embeddings from scratch on a small dataset. \n",
-    "\n",
-    "* To learn more about embeddings in Keras we recommend these [notebooks](https://github.com/fchollet/deep-learning-with-python-notebooks/blob/master/6.2-understanding-recurrent-neural-networks.ipynb) by François Chollet. \n",
-    "\n",
-    "* To learn more about text classification (including the overall workflow, and if you're curious about when to use embeddings vs one-hot encodings) we recommend this practical text classification [guide](https://developers.google.com/machine-learning/guides/text-classification/step-2-5)."
-   ]
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "collapsed_sections": [],
-   "name": "word_embeddings.ipynb",
-   "private_outputs": true,
-   "provenance": [],
-   "toc_visible": true,
-   "version": "0.3.2"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.8"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+  "cells": [
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "GE91qWZkm8ZQ"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "##### Copyright 2019 The TensorFlow Authors."
+      ]
+    },
+    {
+      "metadata": {
+        "cellView": "form",
+        "colab_type": "code",
+        "id": "YS3NA-i6nAFC",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "7SN5USFEIIK3"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "# Word embeddings"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "Aojnnc7sXrab"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/sequences/word_embeddings.ipynb\">\n",
+        "    <img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />\n",
+        "    View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/word_embeddings.ipynb\">\n",
+        "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />\n",
+        "    Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/word_embeddings.ipynb\">\n",
+        "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
+        "    View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "Q6mJg1g3apaz"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "This tutorial introduces word embeddings. It contains complete code to train word embeddings from scratch on a small dataset, and to visualize these embeddings using the [Embedding Projector](http://projector.tensorflow.org) (shown in the image below). \n",
+        "\n",
+        "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding.jpg?raw=1\" alt=\"Screenshot of the embedding projector\" width=\"400\"/>\n",
+        "\n",
+        "## Representing text as numbers\n",
+        "\n",
+        "Machine learning models take vectors (arrays of numbers) as input. When working with text, the first thing we must do come up with a strategy to convert strings to numbers (or to \"vectorize\" the text) before feeding it to the model. In this section, we will look at three strategies for doing so.\n",
+        "\n",
+        "### One-hot encodings\n",
+        "\n",
+        "As a first idea, we might \"one-hot\" encode each word in our vocabulary. Consider the sentence \"The cat sat on the mat\". The vocabulary (or unique words) in this sentence is (cat, mat, on, sat, the). To represent each word, we will create a zero vector with length equal to the vocabulary, then place a one in the index that corresponds to the word. This approach is shown in the following diagram. \n",
+        "\n",
+        "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/one-hot.png?raw=1\" alt=\"Diagram of one-hot encodings\" width=\"400\" />\n",
+        "\n",
+        "To create a vector that contains the encoding of the sentence, we could then concatenate the one-hot vectors for each word. \n",
+        "\n",
+        "Key point: This approach is inefficient. A one-hot encoded vector is sparse (meaning, most indicices are zero). Imagine we have 10,000 words in the vocabulary. To one-hot encode each word, we would create a vector where 99.99% of the elements are zero.\n",
+        "\n",
+        "### Encode each word with a unique number\n",
+        "\n",
+        "A second approach we might try is to encode each word using a unique number. Continuing the example above, we could assign 1 to \"cat\", 2 to \"mat\", and so on. We could then encode the sentence \"The cat sat on the mat\" as a dense vector like [5, 1, 4, 3, 5, 2]. This appoach is efficient. Instead of a sparse vector, we now have a dense one (where all elements are full). \n",
+        "\n",
+        "There are two downsides to this approach, however:\n",
+        "\n",
+        "* The integer-encoding is arbitrary (it does not capture any relationship between words).\n",
+        "\n",
+        "* An integer-encoding can be challenging for a model to interpret. A linear classifier, for example, learns a single weight for each feature. Because different words may have a similar encoding, this feature-weight combination is not meaningful.\n",
+        "\n",
+        "### Word embeddings\n",
+        "\n",
+        "Word embeddings give us a way to use an efficient, dense representation in which similar words have a similar encoding. Importantly, we do not have to specify this encoding by hand. An embedding is a dense vector of floating point values (the length of the vector is a parameter you specify). Instead of specifying the values for the embedding manually, they are traininable parameters (weights learned by the model during training, in the same way a model learns weights for a dense layer). It is common to see word embeddings that 8-dimensional (for small datasets), up to 1024-dimensions when working with large datasets. A higher dimensional embedding can capture fine-grained relationships between words, but takes more data to learn.\n",
+        "\n",
+        "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding2.png?raw=1\" alt=\"Diagram of an embedding\" width=\"400\"/>\n",
+        "\n",
+        "Above is a diagram for a word embedding. Each word is represented as a 4-dimensional vector of floating point values. Another way to think of an embedding is as \"lookup table\". After these weights have been learned, we can encode each word by looking up the dense vector it corresponds to in the table."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "eqBazMiVQkj1"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Using the Embedding layer\n",
+        "\n",
+        "Keras makes it easy to use word embeddings. Let's take a look at the [Embedding](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Embedding) layer."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "SIXEk5ON5P7h",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "from __future__ import absolute_import, division, print_function\n",
+        "\n",
+        "!pip install tensorflow==2.0.0-alpha0\n",
+        "import tensorflow as tf\n",
+        "\n",
+        "from tensorflow import keras\n",
+        "from tensorflow.keras import layers\n",
+        "\n",
+        "# The Embedding layer takes at least two arguments:\n",
+        "# the number of possible words in the vocabulary, here 1000 (1 + maximum word index),\n",
+        "# and the dimensionality of the embeddings, here 32.\n",
+        "embedding_layer = layers.Embedding(1000, 32)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "2dKKV1L2Rk7e"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "The Embedding layer can be understood as a lookup table that maps from integer indices (which stand for specific words) to dense vectors (their embeddings). The dimensionality (or width) of the embedding is a parameter you can experiment with to see what works well for your problem, much in the same way you would experiment with the number of neurons in a Dense layer.\n",
+        "\n",
+        "When you create an Embedding layer, the weights for the embedding are randomly initialized (just like any other layer). During training, they are gradually adjusted via backpropagation. Once trained, the learned word embeddings will roughly encode similarities between words (as they were learned for the specific problem your model is trained on).\n",
+        "\n",
+        "As input, the Embedding layer takes a 2D tensor of integers, of shape `(samples, sequence_length)`, where each entry is a sequence of integers. It can embed sequences of variable lengths. You could feed into the embedding layer above batches with shapes `(32, 10)` (batch of 32 sequences of length 10) or `(64, 15)` (batch of 64 sequences of length 15). All sequences in a batch must have the same length, so sequences that are shorter than others should be padded with zeros, and sequences that are longer should be truncated.\n",
+        "\n",
+        "As output, the embedding layer returns a 3D floating point tensor, of shape `(samples, sequence_length, embedding_dimensionality)`. Such a 3D tensor can then be processed by a RNN layer, or can simply be flattened or pooled and processed by a Dense layer. We will show the first approach in this tutorial, and you can refer to the [Text Classification with an RNN](https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/sequences/text_classification_rnn.ipynb) to learn the second."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "aGicgV5qT0wh"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Learning embeddings from scratch"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "_Bh8B1TUT6mV"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "We will train a sentiment classifier on IMDB movie reviews. In the process, we will learn embeddings from scratch. We will move quickly through the code that downloads and preprocesses the dataset (see this [tutorial](https://www.tensorflow.org/tutorials/keras/basic_text_classification) for more details)."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "cQrYYEvvUuV7",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "vocab_size = 10000\n",
+        "imdb = keras.datasets.imdb\n",
+        "(train_data, train_labels), (test_data, test_labels) = imdb.load_data(num_words=vocab_size)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "dF8ORMt2U9lj"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "As imported, the text of reviews is integer-encoded (each integer represents a specific word in a dictionary)."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "yueILuntVEhr",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "print(train_data[0])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "A2DzUyaXVMR1"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Convert the integers back to words\n",
+        "\n",
+        "It may be useful to know how to convert integers back to text. Here, we'll create a helper function to query a dictionary object that contains the integer to string mapping:"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "9axf0uIXVMhO",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "# A dictionary mapping words to an integer index\n",
+        "word_index = imdb.get_word_index()\n",
+        "\n",
+        "# The first indices are reserved\n",
+        "word_index = {k:(v+3) for k,v in word_index.items()} \n",
+        "word_index[\"<PAD>\"] = 0\n",
+        "word_index[\"<START>\"] = 1\n",
+        "word_index[\"<UNK>\"] = 2  # unknown\n",
+        "word_index[\"<UNUSED>\"] = 3\n",
+        "\n",
+        "reverse_word_index = dict([(value, key) for (key, value) in word_index.items()])\n",
+        "\n",
+        "def decode_review(text):\n",
+        "    return ' '.join([reverse_word_index.get(i, '?') for i in text])\n",
+        "  \n",
+        "decode_review(train_data[0])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "47oPVxgUVd7g"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Movie reviews can be different lengths. We will use the `pad_sequences` function to standardize the lengths of the reviews."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "0Ejbvj8mVbIE",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "maxlen = 500\n",
+        "\n",
+        "train_data = keras.preprocessing.sequence.pad_sequences(train_data,\n",
+        "                                                        value=word_index[\"<PAD>\"],\n",
+        "                                                        padding='post',\n",
+        "                                                        maxlen=maxlen)\n",
+        "\n",
+        "test_data = keras.preprocessing.sequence.pad_sequences(test_data,\n",
+        "                                                       value=word_index[\"<PAD>\"],\n",
+        "                                                       padding='post',\n",
+        "                                                       maxlen=maxlen)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "meWp84bPV0pu"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "Let's inspect the first padded review."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "T7Tef4XhV2u9",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "print(train_data[0])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "zI9_wLIiWO8Z"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Create a simple model\n",
+        "\n",
+        "We will use the [Keras Sequential API](https://www.tensorflow.org/guide/keras) to define our model. \n",
+        "\n",
+        "* The first layer is an Embedding layer. This layer takes the integer-encoded vocabulary and looks up the embedding vector for each word-index. These vectors are learned as the model trains. The vectors add a dimension to the output array. The resulting dimensions are: `(batch, sequence, embedding)``.\n",
+        "\n",
+        "* Next, a GlobalAveragePooling1D layer returns a fixed-length output vector for each example by averaging over the sequence dimension. This allows the model to handle input of variable length, in the simplest way possible.\n",
+        "\n",
+        "* This fixed-length output vector is piped through a fully-connected (Dense) layer with 16 hidden units.\n",
+        "\n",
+        "* The last layer is densely connected with a single output node. Using the sigmoid activation function, this value is a float between 0 and 1, representing a probability (or confidence level) that the review is positive."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "pHLcFtn5Wsqj",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "embedding_dim=16\n",
+        "\n",
+        "model = keras.Sequential([\n",
+        "  layers.Embedding(vocab_size, embedding_dim, input_length=maxlen),\n",
+        "  layers.GlobalAveragePooling1D(),\n",
+        "  layers.Dense(16, activation='relu'),\n",
+        "  layers.Dense(1, activation='sigmoid')\n",
+        "])\n",
+        "\n",
+        "model.summary()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "JjLNgKO7W2fe"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Compile and train the model"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "lCUgdP69Wzix",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "model.compile(optimizer='adam',\n",
+        "              loss='binary_crossentropy',\n",
+        "              metrics=['accuracy'])\n",
+        "\n",
+        "history = model.fit(\n",
+        "    train_data,\n",
+        "    train_labels,\n",
+        "    epochs=30,\n",
+        "    batch_size=512,\n",
+        "    validation_split=0.2)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "LQjpKVYTXU-1"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "With this approach our model reaches a validation accuracy of around 88% (note the model is overfitting, training accuracy is significantly higher)."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "0D3OTmOT1z1O",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "acc = history.history['accuracy']\n",
+        "val_acc = history.history['val_accuracy']\n",
+        "\n",
+        "epochs = range(1, len(acc) + 1)\n",
+        "\n",
+        "plt.plot(epochs, acc, 'bo', label='Training acc')\n",
+        "plt.plot(epochs, val_acc, 'b', label='Validation acc')\n",
+        "plt.title('Training and validation accuracy')\n",
+        "plt.xlabel('Epochs')\n",
+        "plt.ylabel('Accuracy')\n",
+        "plt.legend(loc='lower right')\n",
+        "plt.figure(figsize=(16,9))\n",
+        "\n",
+        "plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "KCoA6qwqP836"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Retrieve the learned embeddings\n",
+        "\n",
+        "Next, let's retrieve the word embeddings learned during training. This will be a matrix of shape `(vocab_size,embedding-dimension)`."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "t8WwbsXCXtpa",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "e = model.layers[0]\n",
+        "weights = e.get_weights()[0]\n",
+        "print(weights.shape) # shape: (vocab_size, embedding_dim)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "J8MiCA77X8B8"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "We will now write the weights to disk. To use the [Embedding Projector](http://projector.tensorflow.org), we will upload two files in tab separated format: a file of vectors (containing the embedding), and a file of meta data (containing the words)."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "GsjempweP9Lq",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "out_v = open('vecs.tsv', 'w')\n",
+        "out_m = open('meta.tsv', 'w')\n",
+        "for word_num in range(vocab_size):\n",
+        "  word = reverse_word_index[word_num]\n",
+        "  embeddings = weights[word_num]\n",
+        "  out_m.write(word + \"\\n\")\n",
+        "  out_v.write('\\t'.join([str(x) for x in embeddings]) + \"\\n\")\n",
+        "out_v.close()\n",
+        "out_m.close()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "JQyMZWyxYjMr"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "If you are running this tutorial in [Colaboratory](https://colab.research.google.com), you can use the following snippet to download these files to your local machine (or use the file browser, *View -> Table of contents -> File browser*)."
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "code",
+        "id": "-gFbbMmvYvhp",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "# from google.colab import files\n",
+        "# files.download('vecs.tsv')\n",
+        "# files.download('meta.tsv')"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "PXLfFA54Yz-o"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Visualize the embeddings\n",
+        "\n",
+        "To visualize our embeddings we will upload them to the embedding projector.\n",
+        "\n",
+        "Open the [Embedding Projector](http://projector.tensorflow.org/). \n",
+        "\n",
+        "* Click on \"Load data\". \n",
+        "\n",
+        "* Upload the two files we created above: ```vecs.tsv``` and ```meta.tsv```. T\n",
+        "\n",
+        "The embeddings you have trained will now be displayed. You can search for words to find their closest neighbors. For example, try searching for \"beautiful\". You may see neighbors like \"wonderful\". Note: your results may be a bit different, depending on how weights were randomly initialized before training the embedding layer.\n",
+        "\n",
+        "Note: experimentally, you may be able to produce more interpretable embeddings by using a simpler model. Try deleting the `Dense(16)` layer, retraining the model, and visualizing the embeddings again.\n",
+        "\n",
+        "<img src=\"https://github.com/tensorflow/docs/blob/88d3b244eca8088c6c406ff9bdc8505d7fb6cbe7/site/en/r2/tutorials/sequences/images/embedding.jpg?raw=1\" alt=\"Screenshot of the embedding projector\" width=\"400\"/>\n"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "iS_uMeMw3Xpj"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Next steps\n"
+      ]
+    },
+    {
+      "metadata": {
+        "colab_type": "text",
+        "id": "BSgAZpwF5xF_"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "This tutorial has show you how to train and visualize word embeddings from scratch on a small dataset. \n",
+        "\n",
+        "* To learn more about embeddings in Keras we recommend these [notebooks](https://github.com/fchollet/deep-learning-with-python-notebooks/blob/master/6.2-understanding-recurrent-neural-networks.ipynb) by François Chollet. \n",
+        "\n",
+        "* To learn more about text classification (including the overall workflow, and if you're curious about when to use embeddings vs one-hot encodings) we recommend this practical text classification [guide](https://developers.google.com/machine-learning/guides/text-classification/step-2-5)."
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Hi,

There is already a pull request to [fix this issue](https://github.com/tensorflow/docs/pull/388), however, it has 4 `.encode` to fix a simple problem. All we need to do is to remove the redundant `.encode()` from the end of this line.

```python
 word = reverse_word_index[word_num].encode('utf-8')
```

old:

```python
out_v = open('vecs.tsv', 'w')
out_m = open('meta.tsv', 'w')
for word_num in range(vocab_size):
  word = reverse_word_index[word_num].encode('utf-8')
  embeddings = weights[word_num]
  out_m.write(word + "\n")
  out_v.write('\t'.join([str(x) for x in embeddings]) + "\n")
out_v.close()
out_m.close()
```

new:

```python
out_v = open('vecs.tsv', 'w')
out_m = open('meta.tsv', 'w')
for word_num in range(vocab_size):
  word = reverse_word_index[word_num]
  embeddings = weights[word_num]
  out_m.write(word + "\n")
  out_v.write('\t'.join([str(x) for x in embeddings]) + "\n")
out_v.close()
out_m.close()
```
This works without any problem while keeping it simple as it is already.