### PR TITLE
Update distribute_strategy.ipynb

### DIFF
--- a/site/en/guide/distribute_strategy.ipynb
+++ b/site/en/guide/distribute_strategy.ipynb
@@ -127,7 +127,7 @@
       },
       "source": [
         "### MirroredStrategy\n",
-        "`tf.distribute.MirroredStrategy` support synchronous distributed training on multiple GPUs on one machine. It creates one replica per GPU device. Each variable in the model is mirrored across all the replicas. Together, these variables form a single conceptual variable called `MirroredVariable`. These variables are kept in sync with each other by applying identical updates.\n",
+        "`tf.distribute.MirroredStrategy` support synchronous distributed training on multiple GPUs on one machine. It creates one model replica per GPU device. Each variable in the model is mirrored across all the replicas. Together, these variables form a single conceptual variable called `MirroredVariable`. These variables are kept in sync with each other by applying identical updates.\n",
         "\n",
         "Efficient all-reduce algorithms are used to communicate the variable updates across the devices.\n",
         "All-reduce aggregates tensors across all the devices by adding them up, and makes them available on each device.\n",


### PR DESCRIPTION
Added the word "model" in order to make clear that the model + variables are replicated and not the data