### PR TITLE
Fix colab urls

### DIFF
--- a/site/en/r2/tutorials/estimators/boosted_trees.ipynb
+++ b/site/en/r2/tutorials/estimators/boosted_trees.ipynb
@@ -56,7 +56,7 @@
         "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/estimators/boosted_trees\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\n",
         "  \u003c/td\u003e\n",
         "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.sandbox.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/estimators/boosted_trees.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
+        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/estimators/boosted_trees.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
         "  \u003c/td\u003e\n",
         "  \u003ctd\u003e\n",
         "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/docs/tree/master/site/en/r2/tutorials/estimators/boosted_trees.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\"\u003eView source on GitHub\u003c/a\u003e\n",

--- a/site/en/r2/tutorials/images/intro_to_cnns.ipynb
+++ b/site/en/r2/tutorials/images/intro_to_cnns.ipynb
@@ -70,7 +70,7 @@
       "source": [
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/images/intro_to_cnns.ipynb\">\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/alpha/tutorials/images/intro_to_cnns\">\n",
         "    <img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />\n",
         "    View on TensorFlow.org</a>\n",
         "  </td>\n",

--- a/site/en/r2/tutorials/images/intro_to_cnns.ipynb
+++ b/site/en/r2/tutorials/images/intro_to_cnns.ipynb
@@ -75,7 +75,7 @@
         "    View on TensorFlow.org</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/tree/master/site/en/r2/tutorials/images/intro_to_cnns.ipynb\">\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/images/intro_to_cnns.ipynb\">\n",
         "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />\n",
         "    Run in Google Colab</a>\n",
         "  </td>\n",

--- a/site/en/tutorials/estimators/boosted_trees.ipynb
+++ b/site/en/tutorials/estimators/boosted_trees.ipynb
@@ -56,7 +56,7 @@
         "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/estimators/boosted_trees\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\n",
         "  \u003c/td\u003e\n",
         "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.sandbox.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/estimators/boosted_trees.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
+        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/estimators/boosted_trees.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
         "  \u003c/td\u003e\n",
         "  \u003ctd\u003e\n",
         "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/docs/tree/master/site/en/tutorials/estimators/boosted_trees.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\"\u003eView source on GitHub\u003c/a\u003e\n",

--- a/site/en/tutorials/estimators/boosted_trees_model_understanding.ipynb
+++ b/site/en/tutorials/estimators/boosted_trees_model_understanding.ipynb
@@ -56,7 +56,7 @@
         "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/estimators/boosted_trees_model_understanding\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\n",
         "  \u003c/td\u003e\n",
         "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.sandbox.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/estimators/boosted_trees_model_understanding.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
+        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/estimators/boosted_trees_model_understanding.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
         "  \u003c/td\u003e\n",
         "  \u003ctd\u003e\n",
         "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/docs/tree/master/site/en/tutorials/estimators/boosted_trees_model_understanding.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003eView source on GitHub\u003c/a\u003e\n",

--- a/tools/templates/notebook.ipynb
+++ b/tools/templates/notebook.ipynb
@@ -258,7 +258,7 @@
         "id": "g3-lzxbCZi-H"
       },
       "source": [
-        "* Publishing to tensorflow.org doesn't yet support interactive plots like altair, or the [graph embedding trick](https://colab.sandbox.google.com/github/tensorflow/tensorflow/blob/master/tensorflow/examples/tutorials/deepdream/deepdream.ipynb#scrollTo=LrucdvgyQgks).\n",
+        "* Publishing to tensorflow.org doesn't yet support interactive plots like altair, or the [graph embedding trick](https://colab.research.google.com/github/tensorflow/tensorflow/blob/master/tensorflow/examples/tutorials/deepdream/deepdream.ipynb#scrollTo=LrucdvgyQgks).\n",
         "\n",
         "* Keep examples quick. Use small datasets, or small slices of datasets. Don't train to convergence, train until it's obvious it's making progress.\n",
         "\n",


### PR DESCRIPTION
1. Set Colab url in intro_to_cnns.ipynb (It was set to github url).
2. Change colab.sandbox.google.com to colab.research.google.com in colab urls. 