### PR TITLE
TFRecords tutorial: Switch to `py_function` and typo fixes.

### DIFF
--- a/site/en/tutorials/load_data/tf_records.ipynb
+++ b/site/en/tutorials/load_data/tf_records.ipynb
@@ -222,7 +222,7 @@
         "id": "vsMbkkC8xxtB"
       },
       "source": [
-        "Below are some examples of how these functions work. Note the varying input types and the standardizes output types. If the input type for a function does not match one of the coercible types stated above, the function will raise an exception (e.g. `_int64_feature(1.0)` will error out, since `1.0` is a float, so should be used with the `_float_feature` function instead)."
+        "Below are some examples of how these functions work. Note the varying input types and the standardized output types. If the input type for a function does not match one of the coercible types stated above, the function will raise an exception (e.g. `_int64_feature(1.0)` will error out, since `1.0` is a float, so should be used with the `_float_feature` function instead)."
       ]
     },
     {

--- a/site/en/tutorials/load_data/tf_records.ipynb
+++ b/site/en/tutorials/load_data/tf_records.ipynb
@@ -570,11 +570,7 @@
     {
       "cell_type": "code",
       "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "RTCS49Ij_kUw"
-      },
+      "metadata": {},
       "outputs": [],
       "source": [
         "def serialize_example_pyfunction(feature0, feature1, feature2, feature3):\n",

--- a/site/en/tutorials/load_data/tf_records.ipynb
+++ b/site/en/tutorials/load_data/tf_records.ipynb
@@ -562,7 +562,7 @@
         "Use the `tf.data.Dataset.map` method to apply a function to each element of a `Dataset`.\n",
         "\n",
         "The mapped function must operate in TensorFlow graph mode: It must operate on and return `tf.Tensors`. A non-tensor function, like `serialize_example`, can be wrapped with `tf.py_function` to make it compatible. \n",
-        "Note: we define a similar function `serialize_example_pyfunction` below with a minor change - converting eagerTensor objects returned by the `tf.py_function` to numpy arrays as required by our `_bytes_feature`, `_float_feature` and `_int64_feature` functions.\n",
+        "We define a similar function `serialize_example_pyfunction` below with a minor change - converting eagerTensor objects returned by the `tf.py_function` to numpy arrays as required by our `_bytes_feature`, `_float_feature` and `_int64_feature` functions.\n",
         "\n",
         "Using `tf.py_function` requires that you specify the shape and type information that is otherwise unavailable:"
       ]

--- a/site/en/tutorials/load_data/tf_records.ipynb
+++ b/site/en/tutorials/load_data/tf_records.ipynb
@@ -561,9 +561,41 @@
       "source": [
         "Use the `tf.data.Dataset.map` method to apply a function to each element of a `Dataset`.\n",
         "\n",
-        "The mapped function must operate in TensorFlow graph mode: It must operate on and return `tf.Tensors`. A non-tensor function, like `create_example`, can be wrapped with `tf.py_func` to make it compatible.\n",
+        "The mapped function must operate in TensorFlow graph mode: It must operate on and return `tf.Tensors`. A non-tensor function, like `serialize_example`, can be wrapped with `tf.py_function` to make it compatible. \n",
+        "Note: we define a similar function `serialize_example_pyfunction` below with a minor change - converting eagerTensor objects returned by the `tf.py_function` to numpy arrays as required by our `_bytes_feature`, `_float_feature` and `_int64_feature` functions.\n",
         "\n",
-        "Using `tf.py_func` requires that you specify the shape and type information that is otherwise unavailable:"
+        "Using `tf.py_function` requires that you specify the shape and type information that is otherwise unavailable:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "RTCS49Ij_kUw"
+      },
+      "outputs": [],
+      "source": [
+        "def serialize_example_pyfunction(feature0, feature1, feature2, feature3):\n",
+        "  \"\"\"\n",
+        "  Creates a tf.Example message ready to be written to a file.\n",
+        "  \"\"\"\n",
+        "  \n",
+        "  # Create a dictionary mapping the feature name to the tf.Example-compatible\n",
+        "  # data type.\n",
+        "  \n",
+        "  feature = {\n",
+        "      'feature0': _int64_feature(feature0.numpy()),\n",
+        "      'feature1': _int64_feature(feature1.numpy()),\n",
+        "      'feature2': _bytes_feature(feature2.numpy()),\n",
+        "      'feature3': _float_feature(feature3.numpy()),\n",
+        "  }\n",
+        "  \n",
+        "  # Create a Features message using tf.train.Example.\n",
+        "  \n",
+        "  example_proto = tf.train.Example(features=tf.train.Features(feature=feature))\n",
+        "  return example_proto.SerializeToString()"
       ]
     },
     {
@@ -577,8 +609,8 @@
       "outputs": [],
       "source": [
         "def tf_serialize_example(f0,f1,f2,f3):\n",
-        "  tf_string = tf.py_func(\n",
-        "    serialize_example, \n",
+        "  tf_string = tf.py_function(\n",
+        "    serialize_example_pyfunction, \n",
         "    (f0,f1,f2,f3),  # pass these args to the above function.\n",
         "    tf.string)      # the return type is `tf.string`.\n",
         "  return tf.reshape(tf_string, ()) # The result is a scalar"


### PR DESCRIPTION
This PR fixes a couple of open ends on the TF Records tutorial [page/notebook](https://github.com/tensorflow/docs/blob/master/site/en/tutorials/load_data/tf_records.ipynb).

- Fixes typos in two cells. 
- Changed the python wrapper function from `py_func` to the new `py_function` as `py_func` is deprecated and will be removed soon. Updated related functions to match return types where necessary. 