### PR TITLE
Fixed typo in Tensorflow alpha docs

### DIFF
--- a/site/en/r2/tutorials/images/transfer_learning.ipynb
+++ b/site/en/r2/tutorials/images/transfer_learning.ipynb
@@ -964,7 +964,7 @@
     "id": "QBc31c4tMOdH"
    },
    "source": [
-    "To generate predictions from the block of features, average over the spatial `5x5` spatial locations, using a `tf.keras.layers.GlobalAveragePlloing2d` layer to convert the features to  a single 1280-element vector per image."
+    "To generate predictions from the block of features, average over the spatial `5x5` spatial locations, using a `tf.keras.layers.GlobalAveragePooling2D` layer to convert the features to  a single 1280-element vector per image."
    ]
   },
   {


### PR DESCRIPTION
Notebook : Transfer Learning Using Pretrained ConvNets
Heading : Add a classification head
`tf.keras.layers.GlobalAveragePlloing2d `-> `tf.keras.layers.GlobalAveragePooling2D`