### PR TITLE
Added commands to install Nvidia driver for CUDA 9

### DIFF
--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -157,6 +157,12 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 <code class="devsite-terminal">sudo apt install ./nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb</code>
 <code class="devsite-terminal">sudo apt update</code>
 
+# Install NVIDIA Driver
+# Issue with driver install requires creating /usr/lib/nvidia
+<code class="devsite-terminal">sudo mkdir /usr/lib/nvidia</code>
+<code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-410</code>
+# Reboot. Check that GPUs are visible using the command: nvidia-smi
+
 # Install CUDA and tools. Include optional NCCL 2.x
 <code class="devsite-terminal">sudo apt install cuda9.0 cuda-cublas-9-0 cuda-cufft-9-0 cuda-curand-9-0 \
     cuda-cusolver-9-0 cuda-cusparse-9-0 libcudnn7=7.2.1.38-1+cuda9.0 \

--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -124,7 +124,7 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 <code class="devsite-terminal">sudo apt install ./nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb</code>
 <code class="devsite-terminal">sudo apt-get update</code>
 
-# Install NVIDIA Driver
+# Install NVIDIA driver
 # Issue with driver install requires creating /usr/lib/nvidia
 <code class="devsite-terminal">sudo mkdir /usr/lib/nvidia</code>
 <code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-410</code>
@@ -157,7 +157,7 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 <code class="devsite-terminal">sudo apt install ./nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb</code>
 <code class="devsite-terminal">sudo apt update</code>
 
-# Install NVIDIA Driver
+# Install the NVIDIA driver
 # Issue with driver install requires creating /usr/lib/nvidia
 <code class="devsite-terminal">sudo mkdir /usr/lib/nvidia</code>
 <code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-410</code>


### PR DESCRIPTION
The Ubuntu 16.04 (CUDA 9.0 for TensorFlow < 1.13.0) install instructions did not include commands for installing an Nvidia driver