### PR TITLE
enable v2 behavior is not available

### DIFF
--- a/site/en/tutorials/images/hub_with_keras.ipynb
+++ b/site/en/tutorials/images/hub_with_keras.ipynb
@@ -102,7 +102,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -U https://storage.googleapis.com/download.tensorflow.org/data/tensorflow_hub-0.4.0.dev0-py2.py3-none-any.whl\n",
+        "!pip install -U tensorflow_hub\n",
         "!pip install tf-nightly-gpu"
       ]
     },
@@ -120,7 +120,7 @@
         "\n",
         "import matplotlib.pylab as plt\n",
         "\n",
-        "import tensorflow as tf\n",
+        "import tensorflow as tf\n"
       ]
     },
     {

--- a/site/en/tutorials/images/hub_with_keras.ipynb
+++ b/site/en/tutorials/images/hub_with_keras.ipynb
@@ -121,7 +121,6 @@
         "import matplotlib.pylab as plt\n",
         "\n",
         "import tensorflow as tf\n",
-        "tf.enable_v2_behavior()"
       ]
     },
     {


### PR DESCRIPTION
enable_v2_behavior is not available in the latest builds.
Calling it produces:
AttributeError: module 'tensorflow' has no attribute 'enable_v2_behavior'