### PR TITLE
Enable use of PNG input images.

### DIFF
--- a/site/en/r2/tutorials/generative/style_transfer.ipynb
+++ b/site/en/r2/tutorials/generative/style_transfer.ipynb
@@ -241,7 +241,7 @@
         "def load_img(path_to_img):\n",
         "  max_dim = 512\n",
         "  img = tf.io.read_file(path_to_img)\n",
-        "  img = tf.image.decode_jpeg(img)\n",
+        "  img = tf.image.decode_image(img, channels=3)\n",
         "  img = tf.image.convert_image_dtype(img, tf.float32)\n",
         "\n",
         "  shape = tf.cast(tf.shape(img)[:-1], tf.float32)\n",


### PR DESCRIPTION
Replacing `decode_jpeg` by the generic `decode_image` and setting up `channels=3` allows the use of this util function to work with PNG images, which come with 4 channels.