### PR TITLE
Fix api_generator.parser._gen_pairs to work in Python 3.7

### DIFF
--- a/tools/tensorflow_docs/api_generator/parser.py
+++ b/tools/tensorflow_docs/api_generator/parser.py
@@ -386,9 +386,7 @@ def _gen_pairs(items):
     The original items, in pairs
   """
   assert len(items) % 2 == 0
-  items = iter(items)
-  while True:
-    yield next(items), next(items)
+  return zip(items[::2], items[1::2])
 
 
 class _FunctionDetail(


### PR DESCRIPTION
In Python 3.7 recommendation from PEP 479 was enabled. In the new
behavior StopIteration exceptions raised directly or indirectly in coroutines
and generators are transformed into RuntimeError exceptions.

https://www.python.org/dev/peps/pep-0479/