### PR TITLE
Fix typo in _image_classification.ipynb

### DIFF
--- a/site/en/r2/tutorials/images/_image_classification.ipynb
+++ b/site/en/r2/tutorials/images/_image_classification.ipynb
@@ -331,7 +331,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "Let's look at how many cats and dogs images ware in the training and validation directory:"
+        "Let's look at how many cats and dogs images were in the training and validation directory:"
       ]
     },
     {

--- a/site/en/r2/tutorials/images/_image_classification.ipynb
+++ b/site/en/r2/tutorials/images/_image_classification.ipynb
@@ -331,7 +331,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "Let's look at how many cats and dogs images were in the training and validation directory:"
+        "Let's look at how many cats and dogs images are in the training and validation directory:"
       ]
     },
     {


### PR DESCRIPTION
I found typo and fix it when I translate this document to Japanese.