### PR TITLE
Fix typos in basic_text_classification_with_tfhub.ipynb

### DIFF
--- a/site/en/r2/tutorials/keras/basic_text_classification_with_tfhub.ipynb
+++ b/site/en/r2/tutorials/keras/basic_text_classification_with_tfhub.ipynb
@@ -241,8 +241,8 @@
         "\n",
         "In this example, the input data consists of sentences. The labels to predict are either 0 or 1.\n",
         "\n",
-        "One way to represent the text is to convert sentences into embeddings vectors. We can use a pre-trained text embedding as the first layer, which will have two advantages:\n",
-        "*   we don't have to worry anout text preprocessing,\n",
+        "One way to represent the text is to convert sentences into embeddings vectors. We can use a pre-trained text embedding as the first layer, which will have three advantages:\n",
+        "*   we don't have to worry about text preprocessing,\n",
         "*   we can benefit from transfer learning,\n",
         "*   the embedding has a fixed size, so it's simpler to process.\n",
         "\n",
@@ -367,7 +367,7 @@
       "source": [
         "## Train the model\n",
         "\n",
-        "Train the model for 40 epochs in mini-batches of 512 samples. This is 40 iterations over all samples in the `x_train` and `y_train` tensors. While training, monitor the model's loss and accuracy on the 10,000 samples from the validation set:"
+        "Train the model for 20 epochs in mini-batches of 512 samples. This is 20 iterations over all samples in the `x_train` and `y_train` tensors. While training, monitor the model's loss and accuracy on the 10,000 samples from the validation set:"
       ]
     },
     {


### PR DESCRIPTION
* two --> three
* anout --> about
* 40 --> 20 (Acutally the model start overfitting in 20th epoch)

Thanks!