### PR TITLE
Fix a typo in training_and_evaluation.ipynb

### DIFF
--- a/site/en/r2/guide/keras/training_and_evaluation.ipynb
+++ b/site/en/r2/guide/keras/training_and_evaluation.ipynb
@@ -1960,7 +1960,7 @@
         "\n",
         "The easiest way to use TensorBoard with a Keras model and the `fit` method is the `TensorBoard` callback.\n",
         "\n",
-        "In the simplest case, just specify where you want te callback to write logs, and you're good to go:\n",
+        "In the simplest case, just specify where you want the callback to write logs, and you're good to go:\n",
         "\n",
         "```python\n",
         "tensorboard_cbk = keras.callbacks.TensorBoard(log_dir='/full_path_to_your_logs')\n",


### PR DESCRIPTION
Fix a typo in section "Using the TensorBoard callback".