### PR TITLE
broken link fix

### DIFF
--- a/site/en/r2/tutorials/load_data/tf_records.ipynb
+++ b/site/en/r2/tutorials/load_data/tf_records.ipynb
@@ -176,7 +176,7 @@
       "source": [
         "Fundamentally a `tf.Example` is a `{\"string\": tf.train.Feature}` mapping.\n",
         "\n",
-        "The `tf.train.Feature` message type can accept one of the following three types (See the [`.proto` file]((https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/feature.proto) for reference). Most other generic types can be coerced into one of these.\n",
+        "The `tf.train.Feature` message type can accept one of the following three types (See the [`.proto` file](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/feature.proto) for reference). Most other generic types can be coerced into one of these.\n",
         "\n",
         "1. `tf.train.BytesList` (the following types can be coerced)\n",
         "\n",


### PR DESCRIPTION
Fix to [29352](https://github.com/tensorflow/tensorflow/issues/29352).

Seems like in TF version 2 the link is not clickable.