### PR TITLE
NVIDIA updated their machine learning repos

### DIFF
--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -98,15 +98,15 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 # Install development and runtime libraries (~4GB)
 <code class="devsite-terminal">sudo apt-get install --no-install-recommends \
     cuda-10-0 \
-    libcudnn7=7.4.1.5-1+cuda10.0  \
-    libcudnn7-dev=7.4.1.5-1+cuda10.0
+    libcudnn7=7.6.0.64-1+cuda10.1  \
+    libcudnn7-dev=7.6.0.64-1+cuda10.1
 </code>
 
 # Install TensorRT. Requires that libcudnn7 is installed above.
 <code class="devsite-terminal">sudo apt-get update && \
         sudo apt-get install nvinfer-runtime-trt-repo-ubuntu1804-5.0.2-ga-cuda10.0 \
         && sudo apt-get update \
-        && sudo apt-get install -y --no-install-recommends libnvinfer-dev=5.0.2-1+cuda10.0
+        && sudo apt-get install -y --no-install-recommends libnvinfer-dev=5.1.5-1+cuda10.0
 </code>
 </pre>
 

--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -98,8 +98,8 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 # Install development and runtime libraries (~4GB)
 <code class="devsite-terminal">sudo apt-get install --no-install-recommends \
     cuda-10-0 \
-    libcudnn7=7.6.0.64-1+cuda10.1  \
-    libcudnn7-dev=7.6.0.64-1+cuda10.1
+    libcudnn7=7.6.0.64-1+cuda10.0  \
+    libcudnn7-dev=7.6.0.64-1+cuda10.0
 </code>
 
 # Install TensorRT. Requires that libcudnn7 is installed above.

--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -103,8 +103,7 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 </code>
 
 # Install TensorRT. Requires that libcudnn7 is installed above.
-<code class="devsite-terminal">sudo apt-get update && \
-        sudo apt-get install nvinfer-runtime-trt-repo-ubuntu1804-5.0.2-ga-cuda10.0 \
+<code class="devsite-terminal">sudo apt-get update && \        
         && sudo apt-get update \
         && sudo apt-get install -y --no-install-recommends libnvinfer-dev=5.1.5-1+cuda10.0
 </code>

--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -104,7 +104,6 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 
 # Install TensorRT. Requires that libcudnn7 is installed above.
 <code class="devsite-terminal">sudo apt-get update && \        
-        && sudo apt-get update \
         && sudo apt-get install -y --no-install-recommends libnvinfer-dev=5.1.5-1+cuda10.0
 </code>
 </pre>


### PR DESCRIPTION
fix wrong version numbers - libcudnn is still working with old numbers but libnvinfer5 is not
you can also use `7.6.0.64-1+cuda10.0` for `libcudnn7` but it auto upgraded to `7.6.0.64-1+cuda10.1` - so who cares and libnvinfer5 will only install with `libnvinfer5=5.1.5-1+cuda10.0` or `libnvinfer5=5.1.2-1+cuda10.0` if you pass it the correct version number. Same for the development library. Just signed the CLA
Would be nice if I knew this earlier (using a Ubuntu  / kubuntu 19.04 disco base system with repos for LTS 18.04.2)