### PR TITLE
edited regex to ignore code comments in auto-linking

### DIFF
--- a/tools/tensorflow_docs/api_generator/parser.py
+++ b/tools/tensorflow_docs/api_generator/parser.py
@@ -223,9 +223,8 @@ class ReferenceResolver(object):
 
     for line in string.splitlines():
       if not line.startswith('#'):
-        line_to_replace = line
-        line = re.sub(AUTO_REFERENCE_RE, sloppy_one_ref, line)
-        string = string.replace(line_to_replace, line)
+        changed_line = re.sub(AUTO_REFERENCE_RE, sloppy_one_ref, line)
+        string = string.replace(line, changed_line)
 
     return string
 

--- a/tools/tensorflow_docs/api_generator/parser.py
+++ b/tools/tensorflow_docs/api_generator/parser.py
@@ -115,7 +115,7 @@ def _get_raw_docstring(py_object):
   else:
     return ''
 
-AUTO_REFERENCE_RE = re.compile(r'^(?!#.*$).*`([a-zA-Z0-9_.]+?)`')
+AUTO_REFERENCE_RE = re.compile(r'(^(?!#.*$).*)`([a-zA-Z0-9_.]+?)`', re.MULTILINE)
 
 
 class ReferenceResolver(object):
@@ -307,12 +307,12 @@ class ReferenceResolver(object):
 
   def _one_ref(self, match, relative_path_to_root):
     """Return a link for a single "`tf.symbol`" reference."""
-    string = match.group(1)
+    string = match.group(2)
     link_text = string
 
     if string.startswith('tensorflow::'):
       # C++ symbol
-      return self._cc_link(string, link_text, relative_path_to_root)
+      return match.group(1) + self._cc_link(string, link_text, relative_path_to_root)
 
     is_python = False
     for py_module_name in self._py_module_names:
@@ -321,7 +321,7 @@ class ReferenceResolver(object):
         break
 
     if is_python:  # Python symbol
-      return self.python_link(
+      return match.group(1) + self.python_link(
           link_text, string, relative_path_to_root, code_ref=True)
 
     # Error!

--- a/tools/tensorflow_docs/api_generator/parser.py
+++ b/tools/tensorflow_docs/api_generator/parser.py
@@ -115,7 +115,7 @@ def _get_raw_docstring(py_object):
   else:
     return ''
 
-AUTO_REFERENCE_RE = re.compile(r'`([a-zA-Z0-9_.]+?)`')
+AUTO_REFERENCE_RE = re.compile(r'^(?!#.*$).*`([a-zA-Z0-9_.]+?)`')
 
 
 class ReferenceResolver(object):

--- a/tools/tensorflow_docs/api_generator/parser.py
+++ b/tools/tensorflow_docs/api_generator/parser.py
@@ -195,7 +195,7 @@ class ReferenceResolver(object):
   def replace_references(self, string, relative_path_to_root):
     """Replace `tf.symbol` references with links to symbol's documentation page.
 
-    This functions finds all occurrences of "`tf.symbol`" in `string`
+    This function finds all occurrences of "`tf.symbol`" in `string`
     and replaces them with markdown links to the documentation page
     for "symbol".
 


### PR DESCRIPTION
This is a fix to [29339](https://github.com/tensorflow/tensorflow/issues/29339).

My tests are highlighted in the following screenshot:

<img width="567" alt="Screenshot 2019-06-08 at 01 41 52" src="https://user-images.githubusercontent.com/24234402/59139907-a8b05300-898e-11e9-83a5-8c5f2e42b15f.png">

