### PR TITLE
Fix undefined variable names in using_tpu docs.

### DIFF
--- a/site/en/guide/using_tpu.md
+++ b/site/en/guide/using_tpu.md
@@ -107,10 +107,10 @@ if FLAGS.use_tpu:
         'gcloud','config','get-value','project'])
     my_zone = subprocess.check_output([
         'gcloud','config','get-value','compute/zone'])
-    cluster_resolver = tf.contrib.cluster_resolver.TPUClusterResolver(
+    tpu_cluster_resolver = tf.contrib.cluster_resolver.TPUClusterResolver(
             tpu=[FLAGS.tpu_name],
             zone=my_zone,
-            project=my_project)
+            project=my_project_name)
     master = tpu_cluster_resolver.get_master()
 else:
     master = ''


### PR DESCRIPTION
Just a minor correction to variable names used in the example code for TPU setup.  A couple of the variables used are undefined (but clearly intended to refer to similarly-named previous variables).