### PR TITLE
Rename variable 'steps' to 'steps_per_epoch'

### DIFF
--- a/site/en/r2/tutorials/generative/style_transfer.ipynb
+++ b/site/en/r2/tutorials/generative/style_transfer.ipynb
@@ -1090,7 +1090,7 @@
         "start = time.time()\n",
         "\n",
         "epochs = 10\n",
-        "steps = 100\n",
+        "steps_per_epoch = 100\n",
         "\n",
         "step = 0\n",
         "for n in range(epochs):\n",

--- a/site/en/r2/tutorials/generative/style_transfer.ipynb
+++ b/site/en/r2/tutorials/generative/style_transfer.ipynb
@@ -389,7 +389,7 @@
         "# Content layer where will pull our feature maps\n",
         "content_layers = ['block5_conv2'] \n",
         "\n",
-        "# Style layer we are interested in\n",
+        "# Style layer of interest\n",
         "style_layers = ['block1_conv1',\n",
         "                'block2_conv1',\n",
         "                'block3_conv1', \n",
@@ -446,7 +446,7 @@
       "source": [
         "def vgg_layers(layer_names):\n",
         "  \"\"\" Creates a vgg model that returns a list of intermediate output values.\"\"\"\n",
-        "  # Load our model. We load pretrained VGG, trained on imagenet data\n",
+        "  # Load our model. Load pretrained VGG, trained on imagenet data\n",
         "  vgg = tf.keras.applications.VGG19(include_top=False, weights='imagenet')\n",
         "  vgg.trainable = False\n",
         "  \n",


### PR DESCRIPTION
The variable 'steps' should be called 'steps_per_epoch'. Probably overlooked when running the notebook since 'steps_per_epoch' had been defined before.