### PR TITLE
Update tf_records.ipynb

### DIFF
--- a/site/en/tutorials/load_data/tf_records.ipynb
+++ b/site/en/tutorials/load_data/tf_records.ipynb
@@ -942,7 +942,7 @@
       "source": [
         "Suppose we now want to read this data back, to be input as data into a model.\n",
         "\n",
-        "The following example imports the data as is, as a `tf.Example` message. This can be useful to verify that a the file contains the data that we expect. This can also be useful if the input data is stored as TFRecords but you would prefer to input NumPy data (or some other input data type), for example [here](https://www.tensorflow.org/guide/datasets#consuming_numpy_arrays), since this example allows us to read the values themselves.\n",
+        "The following example imports the data as is, as a `tf.Example` message. This can be useful to verify that a file contains the data that we expect. This can also be useful if the input data is stored as TFRecords but you would prefer to input NumPy data (or some other input data type), for example [here](https://www.tensorflow.org/guide/datasets#consuming_numpy_arrays), since this example allows us to read the values themselves.\n",
         "\n",
         "We iterate through the TFRecords in the infile, extract the `tf.Example` message, and can read/store the values within."
       ]


### PR DESCRIPTION
"a the" -> "a" (or "the"?)

Also, I realised that the online docs don't precisely match this source - especially the end of the [Writing a TFRecord file](https://www.tensorflow.org/tutorials/load_data/tf_records#writing_a_tfrecord_file) section, where it says:
`# the return type is <a href="../../api_docs/python/tf#string"><code>tf.string</code></a>.`
instead of ```# the return type is `tf.string`.\n,```