### PR TITLE
Fixes display issues in tutorials/images/transfer_learning.ipynb

### DIFF
--- a/site/en/tutorials/_toc.yaml
+++ b/site/en/tutorials/_toc.yaml
@@ -71,8 +71,10 @@ toc:
 - title: Images
   style: accordion
   section:
-  - title: Image recognition
+  - title: Transfer learning with TFHub
     path: /tutorials/images/hub_with_keras
+  - title: Transfer learning with pretrained CNNs
+    path: /tutorials/images/transfer_learning
   - title: Pix2Pix
     path: https://github.com/tensorflow/tensorflow/blob/r1.13/tensorflow/contrib/eager/python/examples/pix2pix/pix2pix_eager.ipynb
     status: external

--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -520,7 +520,7 @@
       "source": [
         "If you train to convergence (`epochs=50`) the resulting graph should look like this:\n",
         "\n",
-        "![Before fine tuning, the model reaches 96% accuracy](images/before_fine_tuning.pnd)"
+        "![Before fine tuning, the model reaches 96% accuracy](./images/before_fine_tuning.png)"
       ]
     },
     {
@@ -742,7 +742,7 @@
       "source": [
         "If you train to convergence (`epochs=50`) the resulting graph should look like this:\n",
         "\n",
-        "![After fine tuning the model nearly reaches 98% accuracy](images/fine_tuning.pnd)"
+        "![After fine tuning the model nearly reaches 98% accuracy](./images/fine_tuning.png)"
       ]
     },
     {


### PR DESCRIPTION
This PR is intended to fix displaying of 2 plots (images) in the tutorials/images/transfer_learning.

The graphs for the following were not rendered in the **Transfer Learning Using Pretrained ConvNets** tutorial:

- Validation, Test Accuracies
- Effect of Fine Tuning

The same tutorial is unavailable on the tensorflow.org website. Feature Extraction from Pretrained networks and Fine Tuning have been explained very well in this tutorial so it should be added to the links in the official website tutorials.

![Transfer Learning Not Showing](https://user-images.githubusercontent.com/10649800/59551465-8a061980-8f97-11e9-8282-afca326258a8.png)
