### PR TITLE
JA: translation site/ja/probability/overview.md

### DIFF
--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -43,7 +43,7 @@ TensorFlow Probability チームによりメンテナンスされていて、Ten
     プログラムとして柔軟な確率的モデルを定義するための確率的プログラミング言語
 *   *Probabilistic layers*
     ([`tfp.layers`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/layers)):
-    TensorFlow 層を拡張して、それらが表現する関数の不確実性を出力できるニューラルネットワーク層
+    TensorFlow の layers を拡張して、それらが表現する関数の不確実性を出力できるニューラルネットワーク層
 *   *Trainable distributions*
     ([`tfp.trainable_distributions`](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/trainable_distributions)):
     確率分布を出力するニューラルネットワークを構築することを簡単にする、一つの Tensor によるパラメータをもつ確率分布

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -32,7 +32,7 @@ TensorFlow Probability チームによりメンテナンスされていて、Ten
   [`tf.distributions`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/python/ops/distributions)):
   バッチや [ブロードキャスティング](https://docs.scipy.org/doc/numpy-1.14.0/user/basics.broadcasting.html)セマンティクスによる確率分布の巨大な集合や関連する統計量
 * *Bijectors* ([`tfp.bijectors`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/bijectors)):
-  ランダム変数の可逆で組み立て可能な変換. Bijectors は変換された分布の豊富なクラスを提供します。それは、古典的な
+  ランダム変数の可逆で組み立て可能な変換。 Bijectors は変換された分布の豊富なクラスを提供します。それは、古典的な
   [対数正規分布](https://en.wikipedia.org/wiki/Log-normal_distribution)から
   [masked autoregressive flows](https://arxiv.org/abs/1705.07057)のような洗練された深層学習モデルにまで及びます。
 

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -1,5 +1,14 @@
 # TensorFlow Probability
 
+
+Note: これらのドキュメントは私たちTensorFlowコミュニティが翻訳したものです。コミュニティによる
+翻訳は**ベストエフォート**であるため、この翻訳が正確であることや[英語の公式ドキュメント](https://www.tensorflow.org/?hl=en)の
+最新の状態を反映したものであることを保証することはできません。
+この翻訳の品質を向上させるためのご意見をお持ちの方は、GitHubリポジトリ[tensorflow/docs](https://github.com/tensorflow/docs)にプルリクエストをお送りください。
+\
+コミュニティによる翻訳やレビューに参加していただける方は、
+[docs-ja@tensorflow.org メーリングリスト](https://groups.google.com/a/tensorflow.org/forum/#!forum/docs-ja)にご連絡ください。  
+
 TensorFlow Probability は TensorFlow における確率的推論と統計的分析のためのライブラリです。
 TensorFlow エコシステムの一部として、TensorFlow Probability は確率的手法とさまざまな手法や機能との統合を提供します。
 たとえば、深層ネットワーク、自動微分を用いた勾配に基づく推論、GPUによるハードウェア高速化や分散計算による大きなデータセットやモデルに対するスケーラビリティなどです。

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -77,7 +77,7 @@ TensorFlow Probability は開発中であるため、インタフェースは変
   —latent code と変分推論による表現学習
 * [Vector-Quantized Autoencoder](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/vq_vae.py)
   —ベクトル量子化による離散表現学習
-* [ベイズニューラルネットワーク](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/bayesian_neural_network.py)
+* [ベイジアンニューラルネットワーク](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/bayesian_neural_network.py)
   —重みの不確実性を出力するニューラルネットワーク
 * [ベイズロジスティック回帰](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/logistic_regression.py)
   —二値分類のためのベイズ推論

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -22,7 +22,7 @@ TensorFlow Probability を始めるためには、[インストールガイド](
 
 ### Layer 0: TensorFlow
 
-*Numerical operations*—特に, `LinearOperator`
+*数値処理*—特に, `LinearOperator`
 クラスが可能にする、効率的な演算のための特定の構造(直行、低ランク)を開発できるようにする行列フリーな実装。 
 TensorFlow Probability チームによりメンテナンスされていて、TensorFlow コアの [`tf.linalg`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/python/ops/linalg) の一部です。
 
@@ -74,12 +74,12 @@ TensorFlow Probability は開発中であるため、インタフェースは変
 に加えて、いくつかのスクリプト例が利用できます:
 
 * [Variational Autoencoders](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/vae.py)
-  —Representation learning with a latent code and variational inference.
+  —latent code と変分推論による表現学習.
 * [Vector-Quantized Autoencoder](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/vq_vae.py)
   —ベクトル量子化による離散表現学習。
-* [Bayesian Neural Networks](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/bayesian_neural_network.py)
+* [ベイズニューラルネットワーク](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/bayesian_neural_network.py)
   —ウェイトの不確実性を出力するニューラルネットワーク。
-* [Bayesian Logistic Regression](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/logistic_regression.py)
+* [ベイズロジスティック回帰](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/logistic_regression.py)
   —二値分類のためのベイズ推論。
 
 ## issue の報告

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -54,7 +54,7 @@ TensorFlow Probability チームによりメンテナンスされていて、Ten
     ([`tfp.mcmc`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/mcmc)):
     サンプリングによる積分近似のためのアルゴリズム
     [ハミルトンモンテカルロ法](https://en.wikipedia.org/wiki/Hamiltonian_Monte_Carlo)、
-    ランダムウォークハミルトンヘイスティング法、カスタム遷移カーネルを構築することができる機能を含みます。
+    ランダムウォークメトロポリス・ヘイスティング法、カスタム遷移カーネルを構築することができる機能を含みます。
 *   *Variational Inference*
     ([`tfp.vi`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/vi)):
     最適化による積分近似のためのアルゴリズム
@@ -78,7 +78,7 @@ TensorFlow Probability は開発中であるため、インタフェースは変
 * [Vector-Quantized Autoencoder](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/vq_vae.py)
   —ベクトル量子化による離散表現学習
 * [ベイズニューラルネットワーク](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/bayesian_neural_network.py)
-  —ウェイトの不確実性を出力するニューラルネットワーク
+  —重みの不確実性を出力するニューラルネットワーク
 * [ベイズロジスティック回帰](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/logistic_regression.py)
   —二値分類のためのベイズ推論
 

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -34,7 +34,7 @@ TensorFlow Probability チームによりメンテナンスされていて、Ten
 * *Bijectors* ([`tfp.bijectors`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/bijectors)):
   ランダム変数の可逆で組み立て可能な変換。 Bijectors は変換された分布の豊富なクラスを提供します。それは、古典的な
   [対数正規分布](https://en.wikipedia.org/wiki/Log-normal_distribution)から
-  [masked autoregressive flows](https://arxiv.org/abs/1705.07057)のような洗練された深層学習モデルにまで及びます。
+  [masked autoregressive flows](https://arxiv.org/abs/1705.07057) のような洗練された深層学習モデルにまで及びます。
 
 ### Layer 2: モデル構築
 

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -23,7 +23,7 @@ TensorFlow Probability を始めるためには、[インストールガイド](
 ### Layer 0: TensorFlow
 
 *数値処理*—特に、`LinearOperator`
-クラスが可能にする、効率的な演算のための特定の構造 (直行、低ランク) を開発できるようにする行列フリーな実装。 
+クラスが可能にする、効率的な演算のための特定の構造 (対角、低ランク) を開発できるようにする行列フリーな実装。 
 TensorFlow Probability チームによりメンテナンスされていて、TensorFlow コアの [`tf.linalg`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/python/ops/linalg) の一部です。
 
 ### Layer 1: 確率的なブロックの構築

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -1,7 +1,7 @@
 # TensorFlow Probability
 
 
-`注: ` これらのドキュメントは私たちTensorFlowコミュニティが翻訳したものです。コミュニティによる
+`Note: ` これらのドキュメントは私たちTensorFlowコミュニティが翻訳したものです。コミュニティによる
 翻訳は**ベストエフォート**であるため、この翻訳が正確であることや[英語の公式ドキュメント](https://www.tensorflow.org/?hl=en)の
 最新の状態を反映したものであることを保証することはできません。
 この翻訳の品質を向上させるためのご意見をお持ちの方は、GitHubリポジトリ[tensorflow/docs](https://github.com/tensorflow/docs)にプルリクエストをお送りください。

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -1,7 +1,7 @@
 # TensorFlow Probability
 
 
-Note: これらのドキュメントは私たちTensorFlowコミュニティが翻訳したものです。コミュニティによる
+注: これらのドキュメントは私たちTensorFlowコミュニティが翻訳したものです。コミュニティによる
 翻訳は**ベストエフォート**であるため、この翻訳が正確であることや[英語の公式ドキュメント](https://www.tensorflow.org/?hl=en)の
 最新の状態を反映したものであることを保証することはできません。
 この翻訳の品質を向上させるためのご意見をお持ちの方は、GitHubリポジトリ[tensorflow/docs](https://github.com/tensorflow/docs)にプルリクエストをお送りください。

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -30,7 +30,7 @@ TensorFlow Probability チームによりメンテナンスされていて、Ten
 
 * *Distributions* ([`tfp.distributions`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/distributions),
   [`tf.distributions`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/python/ops/distributions)):
-  バッチや [ブロードキャスティング](https://docs.scipy.org/doc/numpy-1.14.0/user/basics.broadcasting.html)セマンティクスによる確率分布の巨大な集合や関連する統計量
+  バッチや[ブロードキャスティング](https://docs.scipy.org/doc/numpy-1.14.0/user/basics.broadcasting.html)の仕組みを取り入れた、多くの確率分布やそれに関連する統計量の処理
 * *Bijectors* ([`tfp.bijectors`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/bijectors)):
   ランダム変数の可逆で組み立て可能な変換。 Bijectors は変換された分布の豊富なクラスを提供します。それは、古典的な
   [対数正規分布](https://en.wikipedia.org/wiki/Log-normal_distribution)から

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -40,31 +40,31 @@ TensorFlow Probability チームによりメンテナンスされていて、Ten
 
 *   *Edward2*
     ([`tfp.edward2`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/edward2)):
-    プログラムとして柔軟な確率的モデルを定義するための確率的プログラミング言語です。
+    プログラムとして柔軟な確率的モデルを定義するための確率的プログラミング言語
 *   *Probabilistic layers*
     ([`tfp.layers`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/layers)):
-    TensorFlow 層を拡張して、それらが表現する関数の不確実性を出力できるニューラルネットワーク層です。
+    TensorFlow 層を拡張して、それらが表現する関数の不確実性を出力できるニューラルネットワーク層
 *   *Trainable distributions*
     ([`tfp.trainable_distributions`](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/trainable_distributions)):
-    確率分布を出力するニューラルネットワークを構築することを簡単にする、一つの Tensor によるパラメータをもつ確率分布です。
+    確率分布を出力するニューラルネットワークを構築することを簡単にする、一つの Tensor によるパラメータをもつ確率分布
 
 ### Layer 3: 確率的推論
 
 *   *Markov chain Monte Carlo*
     ([`tfp.mcmc`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/mcmc)):
-    サンプリングによる積分近似のためのアルゴリズム。
+    サンプリングによる積分近似のためのアルゴリズム
     [ハミルトンモンテカルロ法](https://en.wikipedia.org/wiki/Hamiltonian_Monte_Carlo),
     ランダムウォークハミルトンヘイスティング法、カスタム遷移カーネルを構築することができる機能を含みます。
 *   *Variational Inference*
     ([`tfp.vi`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/vi)):
-    最適化による積分近似のためのアルゴリズム。
+    最適化による積分近似のためのアルゴリズム
 *   *Optimizers*
     ([`tfp.optimizer`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/optimizer)):
-    TensorFlow Optimizers を拡張した、確率的最適化手法。
+    TensorFlow Optimizers を拡張した、確率的最適化手法
     [Stochastic Gradient Langevin Dynamics](http://www.icml-2011.org/papers/398_icmlpaper.pdf) を含みます。
 *   *Monte Carlo*
     ([`tfp.monte_carlo`](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/monte_carlo)):
-    モンテカルロ法を用いたツール群。
+    モンテカルロ法を用いたツール群
 
 TensorFlow Probability は開発中であるため、インタフェースは変更される可能性があります。
 
@@ -74,13 +74,13 @@ TensorFlow Probability は開発中であるため、インタフェースは変
 に加えて、いくつかのスクリプト例が利用できます:
 
 * [Variational Autoencoders](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/vae.py)
-  —latent code と変分推論による表現学習.
+  —latent code と変分推論による表現学習
 * [Vector-Quantized Autoencoder](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/vq_vae.py)
-  —ベクトル量子化による離散表現学習。
+  —ベクトル量子化による離散表現学習
 * [ベイズニューラルネットワーク](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/bayesian_neural_network.py)
-  —ウェイトの不確実性を出力するニューラルネットワーク。
+  —ウェイトの不確実性を出力するニューラルネットワーク
 * [ベイズロジスティック回帰](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/logistic_regression.py)
-  —二値分類のためのベイズ推論。
+  —二値分類のためのベイズ推論
 
 ## issue の報告
 

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -53,14 +53,14 @@ TensorFlow Probability チームによりメンテナンスされていて、Ten
 *   *Markov chain Monte Carlo*
     ([`tfp.mcmc`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/mcmc)):
     サンプリングによる積分近似のためのアルゴリズム
-    [ハミルトンモンテカルロ法](https://en.wikipedia.org/wiki/Hamiltonian_Monte_Carlo),
+    [ハミルトンモンテカルロ法](https://en.wikipedia.org/wiki/Hamiltonian_Monte_Carlo)、
     ランダムウォークハミルトンヘイスティング法、カスタム遷移カーネルを構築することができる機能を含みます。
 *   *Variational Inference*
     ([`tfp.vi`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/vi)):
     最適化による積分近似のためのアルゴリズム
 *   *Optimizers*
     ([`tfp.optimizer`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/optimizer)):
-    TensorFlow Optimizers を拡張した、確率的最適化手法
+    TensorFlow Optimizers を拡張した、確率的最適化モジュール。
     [Stochastic Gradient Langevin Dynamics](http://www.icml-2011.org/papers/398_icmlpaper.pdf) を含みます。
 *   *Monte Carlo*
     ([`tfp.monte_carlo`](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/monte_carlo)):

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -1,7 +1,7 @@
 # TensorFlow Probability
 
 
-`Note: ` これらのドキュメントは私たちTensorFlowコミュニティが翻訳したものです。コミュニティによる
+Note: これらのドキュメントは私たちTensorFlowコミュニティが翻訳したものです。コミュニティによる
 翻訳は**ベストエフォート**であるため、この翻訳が正確であることや[英語の公式ドキュメント](https://www.tensorflow.org/?hl=en)の
 最新の状態を反映したものであることを保証することはできません。
 この翻訳の品質を向上させるためのご意見をお持ちの方は、GitHubリポジトリ[tensorflow/docs](https://github.com/tensorflow/docs)にプルリクエストをお送りください。

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -11,7 +11,7 @@
 
 TensorFlow Probability は TensorFlow における確率的推論と統計的分析のためのライブラリです。
 TensorFlow エコシステムの一部として、TensorFlow Probability は確率的手法とさまざまな手法や機能との統合を提供します。
-たとえば、深層ネットワーク、自動微分を用いた勾配に基づく推論、GPUによるハードウェア高速化や分散計算による大きなデータセットやモデルに対するスケーラビリティなどです。
+たとえば、深層ネットワークを用いた確率的な手法、自動微分を用いた勾配に基づく推論、GPUによるハードウェア高速化や分散計算による大きなデータセットやモデルに対するスケーラビリティなどです。
 
 TensorFlow Probability を始めるためには、[インストールガイド](./install) や
 [Python notebook チュートリアル](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/examples/jupyter_notebooks/)を参照してください。

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -46,7 +46,7 @@ TensorFlow Probability チームによりメンテナンスされていて、Ten
     TensorFlow の layers を拡張して、それらが表現する関数の不確実性を出力できるニューラルネットワーク層
 *   *Trainable distributions*
     ([`tfp.trainable_distributions`](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/trainable_distributions)):
-    確率分布を出力するニューラルネットワークを構築することを簡単にする、一つの Tensor によるパラメータをもつ確率分布
+    確率分布を出力するニューラルネットワークを構築することを簡単にする、1つの Tensor によるパラメータをもつ確率分布
 
 ### Layer 3: 確率的推論
 

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -1,7 +1,7 @@
 # TensorFlow Probability
 
 
-注: これらのドキュメントは私たちTensorFlowコミュニティが翻訳したものです。コミュニティによる
+`注: ` これらのドキュメントは私たちTensorFlowコミュニティが翻訳したものです。コミュニティによる
 翻訳は**ベストエフォート**であるため、この翻訳が正確であることや[英語の公式ドキュメント](https://www.tensorflow.org/?hl=en)の
 最新の状態を反映したものであることを保証することはできません。
 この翻訳の品質を向上させるためのご意見をお持ちの方は、GitHubリポジトリ[tensorflow/docs](https://github.com/tensorflow/docs)にプルリクエストをお送りください。

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -1,0 +1,86 @@
+# TensorFlow Probability
+
+TensorFlow Probability は TensorFlow における確率的推論と統計的分析のためのライブラリです. TensorFlow エコシステムの一部として, TensorFlow
+Probability は確率的手法と深層ネットワーク, 自動微分を用いた勾配に基づく推論, GPUによるハードウェア高速化や分散計算による大きなデータセットやモデルに対するスケーラビリティを提供します.
+
+TensorFlow Probability を始めるためには, [インストールガイド](./install) や
+[Python notebook チュートリアル](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/examples/jupyter_notebooks/){:.external} を参照してください.
+
+## コンポーネント
+
+我々の確率的機械学習ツール群は以下のような構造になっています:
+
+### Layer 0: TensorFlow
+
+*Numerical operations*—in particular, the `LinearOperator`
+class—enables matrix-free implementations that can exploit a particular structure
+(diagonal, low-rank, etc.) for efficient computation. It is built and maintained
+by the TensorFlow Probability team and is part of
+[`tf.linalg`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/python/ops/linalg)
+in core TensorFlow.
+
+### Layer 1: 確率的なブロックの構築
+
+* *Distributions* ([`tfp.distributions`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/distributions),
+  [`tf.distributions`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/python/ops/distributions)):
+  A large collection of probability distributions and related statistics with
+  batch and [broadcasting](https://docs.scipy.org/doc/numpy-1.14.0/user/basics.broadcasting.html){:.external}
+  semantics.
+* *Bijectors* ([`tfp.bijectors`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/bijectors)):
+  Reversible and composable transformations of random variables. Bijectors
+  provide a rich class of transformed distributions, from classical examples
+  like the
+  [log-normal distribution](https://en.wikipedia.org/wiki/Log-normal_distribution){:.external}
+  to sophisticated deep learning models such as
+  [masked autoregressive flows](https://arxiv.org/abs/1705.07057){:.external}.
+
+### Layer 2: モデル構築
+
+*   *Edward2*
+    ([`tfp.edward2`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/edward2)):
+    プログラムとして柔軟な確率的モデルを定義するための確率的プログラミング言語です.
+*   *Probabilistic layers*
+    ([`tfp.layers`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/layers)):
+    TensorFlow 層を拡張して、それらが表現する関数の不確実性を出力できるニューラルネットワーク層です.
+*   *Trainable distributions*
+    ([`tfp.trainable_distributions`](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/trainable_distributions)):
+    確率分布を出力するニューラルネットワークを構築することを簡単にする、一つの Tensor によるパラメータをもつ確率分布です.
+
+### Layer 3: 確率的推論
+
+*   *Markov chain Monte Carlo*
+    ([`tfp.mcmc`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/mcmc)):
+    サンプリングによる積分近似のためのアルゴリズム. 
+    [ハミルトンモンテカルロ法](https://en.wikipedia.org/wiki/Hamiltonian_Monte_Carlo){:.external},
+    ランダムウォークハミルトンヘイスティング法, カスタム遷移カーネルを構築することができる機能を含みます.
+*   *Variational Inference*
+    ([`tfp.vi`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/vi)):
+    最適化による積分近似のためのアルゴリズム.
+*   *Optimizers*
+    ([`tfp.optimizer`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/optimizer)):
+    TensorFlow Optimizers を拡張した, 確率的最適化手法.
+    [Stochastic Gradient Langevin Dynamics](http://www.icml-2011.org/papers/398_icmlpaper.pdf){:.external} を含みます.
+*   *Monte Carlo*
+    ([`tfp.monte_carlo`](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/monte_carlo)):
+    モンテカルロ法を用いたツール群.
+
+TensorFlow Probability は開発中であるため, インタフェースは変更される可能性があります.
+
+## 使用例
+
+ナビゲーションに載っている [Python notebook チュートリアル](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/examples/jupyter_notebooks/){:.external}
+に加えて, いくつかのスクリプト例が利用できます:
+
+* [Variational Autoencoders](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/vae.py)
+  —Representation learning with a latent code and variational inference.
+* [Vector-Quantized Autoencoder](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/vq_vae.py)
+  —ベクトル量子化による離散表現学習.
+* [Bayesian Neural Networks](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/bayesian_neural_network.py)
+  —ウェイトの不確実性を出力するニューラルネットワーク.
+* [Bayesian Logistic Regression](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/logistic_regression.py)
+  —二値分類のためのベイズ推論.
+
+## Report issues
+
+バグ報告や機能要望は
+[TensorFlow Probability issue tracker](https://github.com/tensorflow/probability/issues) を使用してください.

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -1,10 +1,11 @@
 # TensorFlow Probability
 
-TensorFlow Probability は TensorFlow における確率的推論と統計的分析のためのライブラリです. TensorFlow エコシステムの一部として, TensorFlow
-Probability は確率的手法と深層ネットワーク, 自動微分を用いた勾配に基づく推論, GPUによるハードウェア高速化や分散計算による大きなデータセットやモデルに対するスケーラビリティを提供します.
+TensorFlow Probability は TensorFlow における確率的推論と統計的分析のためのライブラリです。
+TensorFlow エコシステムの一部として、TensorFlow Probability は確率的手法とさまざまな手法や機能との統合を提供します。
+たとえば、深層ネットワーク、自動微分を用いた勾配に基づく推論、GPUによるハードウェア高速化や分散計算による大きなデータセットやモデルに対するスケーラビリティなどです。
 
-TensorFlow Probability を始めるためには, [インストールガイド](./install) や
-[Python notebook チュートリアル](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/examples/jupyter_notebooks/){:.external} を参照してください.
+TensorFlow Probability を始めるためには、[インストールガイド](./install) や
+[Python notebook チュートリアル](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/examples/jupyter_notebooks/)を参照してください。
 
 ## コンポーネント
 
@@ -12,75 +13,67 @@ TensorFlow Probability を始めるためには, [インストールガイド](.
 
 ### Layer 0: TensorFlow
 
-*Numerical operations*—in particular, the `LinearOperator`
-class—enables matrix-free implementations that can exploit a particular structure
-(diagonal, low-rank, etc.) for efficient computation. It is built and maintained
-by the TensorFlow Probability team and is part of
-[`tf.linalg`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/python/ops/linalg)
-in core TensorFlow.
+*Numerical operations*—特に, `LinearOperator`
+クラスが可能にする、効率的な演算のための特定の構造(直行、低ランク)を開発できるようにする行列フリーな実装。 
+TensorFlow Probability チームによりメンテナンスされていて、TensorFlow コアの [`tf.linalg`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/python/ops/linalg) の一部です。
 
 ### Layer 1: 確率的なブロックの構築
 
 * *Distributions* ([`tfp.distributions`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/distributions),
   [`tf.distributions`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/python/ops/distributions)):
-  A large collection of probability distributions and related statistics with
-  batch and [broadcasting](https://docs.scipy.org/doc/numpy-1.14.0/user/basics.broadcasting.html){:.external}
-  semantics.
+  バッチや [ブロードキャスティング](https://docs.scipy.org/doc/numpy-1.14.0/user/basics.broadcasting.html)セマンティクスによる確率分布の巨大な集合や関連する統計量。
 * *Bijectors* ([`tfp.bijectors`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/bijectors)):
-  Reversible and composable transformations of random variables. Bijectors
-  provide a rich class of transformed distributions, from classical examples
-  like the
-  [log-normal distribution](https://en.wikipedia.org/wiki/Log-normal_distribution){:.external}
-  to sophisticated deep learning models such as
-  [masked autoregressive flows](https://arxiv.org/abs/1705.07057){:.external}.
+  ランダム変数の可逆で組み立て可能な変換. Bijectors は変換された分布の豊富なクラスを提供します。それは、古典的な
+  [対数正規分布](https://en.wikipedia.org/wiki/Log-normal_distribution)から
+  [masked autoregressive flows](https://arxiv.org/abs/1705.07057)のような洗練された深層学習モデルにまで及びます。
 
 ### Layer 2: モデル構築
 
 *   *Edward2*
     ([`tfp.edward2`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/edward2)):
-    プログラムとして柔軟な確率的モデルを定義するための確率的プログラミング言語です.
+    プログラムとして柔軟な確率的モデルを定義するための確率的プログラミング言語です。
 *   *Probabilistic layers*
     ([`tfp.layers`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/layers)):
-    TensorFlow 層を拡張して、それらが表現する関数の不確実性を出力できるニューラルネットワーク層です.
+    TensorFlow 層を拡張して、それらが表現する関数の不確実性を出力できるニューラルネットワーク層です。
 *   *Trainable distributions*
     ([`tfp.trainable_distributions`](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/trainable_distributions)):
-    確率分布を出力するニューラルネットワークを構築することを簡単にする、一つの Tensor によるパラメータをもつ確率分布です.
+    確率分布を出力するニューラルネットワークを構築することを簡単にする、一つの Tensor によるパラメータをもつ確率分布です。
 
 ### Layer 3: 確率的推論
 
 *   *Markov chain Monte Carlo*
     ([`tfp.mcmc`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/mcmc)):
-    サンプリングによる積分近似のためのアルゴリズム. 
-    [ハミルトンモンテカルロ法](https://en.wikipedia.org/wiki/Hamiltonian_Monte_Carlo){:.external},
-    ランダムウォークハミルトンヘイスティング法, カスタム遷移カーネルを構築することができる機能を含みます.
+    サンプリングによる積分近似のためのアルゴリズム。
+    [ハミルトンモンテカルロ法](https://en.wikipedia.org/wiki/Hamiltonian_Monte_Carlo),
+    ランダムウォークハミルトンヘイスティング法、カスタム遷移カーネルを構築することができる機能を含みます。
 *   *Variational Inference*
     ([`tfp.vi`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/vi)):
-    最適化による積分近似のためのアルゴリズム.
+    最適化による積分近似のためのアルゴリズム。
 *   *Optimizers*
     ([`tfp.optimizer`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/optimizer)):
-    TensorFlow Optimizers を拡張した, 確率的最適化手法.
-    [Stochastic Gradient Langevin Dynamics](http://www.icml-2011.org/papers/398_icmlpaper.pdf){:.external} を含みます.
+    TensorFlow Optimizers を拡張した、確率的最適化手法。
+    [Stochastic Gradient Langevin Dynamics](http://www.icml-2011.org/papers/398_icmlpaper.pdf) を含みます。
 *   *Monte Carlo*
     ([`tfp.monte_carlo`](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/monte_carlo)):
-    モンテカルロ法を用いたツール群.
+    モンテカルロ法を用いたツール群。
 
-TensorFlow Probability は開発中であるため, インタフェースは変更される可能性があります.
+TensorFlow Probability は開発中であるため、インタフェースは変更される可能性があります。
 
 ## 使用例
 
-ナビゲーションに載っている [Python notebook チュートリアル](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/examples/jupyter_notebooks/){:.external}
-に加えて, いくつかのスクリプト例が利用できます:
+ナビゲーションに載っている [Python notebook チュートリアル](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/examples/jupyter_notebooks/)
+に加えて、いくつかのスクリプト例が利用できます:
 
 * [Variational Autoencoders](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/vae.py)
   —Representation learning with a latent code and variational inference.
 * [Vector-Quantized Autoencoder](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/vq_vae.py)
-  —ベクトル量子化による離散表現学習.
+  —ベクトル量子化による離散表現学習。
 * [Bayesian Neural Networks](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/bayesian_neural_network.py)
-  —ウェイトの不確実性を出力するニューラルネットワーク.
+  —ウェイトの不確実性を出力するニューラルネットワーク。
 * [Bayesian Logistic Regression](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/examples/logistic_regression.py)
-  —二値分類のためのベイズ推論.
+  —二値分類のためのベイズ推論。
 
-## Report issues
+## issue の報告
 
 バグ報告や機能要望は
-[TensorFlow Probability issue tracker](https://github.com/tensorflow/probability/issues) を使用してください.
+[TensorFlow Probability issue tracker](https://github.com/tensorflow/probability/issues) を使用してください。

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -30,7 +30,7 @@ TensorFlow Probability チームによりメンテナンスされていて、Ten
 
 * *Distributions* ([`tfp.distributions`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/distributions),
   [`tf.distributions`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/python/ops/distributions)):
-  バッチや [ブロードキャスティング](https://docs.scipy.org/doc/numpy-1.14.0/user/basics.broadcasting.html)セマンティクスによる確率分布の巨大な集合や関連する統計量。
+  バッチや [ブロードキャスティング](https://docs.scipy.org/doc/numpy-1.14.0/user/basics.broadcasting.html)セマンティクスによる確率分布の巨大な集合や関連する統計量
 * *Bijectors* ([`tfp.bijectors`](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/bijectors)):
   ランダム変数の可逆で組み立て可能な変換. Bijectors は変換された分布の豊富なクラスを提供します。それは、古典的な
   [対数正規分布](https://en.wikipedia.org/wiki/Log-normal_distribution)から

--- a/site/ja/probability/overview.md
+++ b/site/ja/probability/overview.md
@@ -11,7 +11,7 @@
 
 TensorFlow Probability は TensorFlow における確率的推論と統計的分析のためのライブラリです。
 TensorFlow エコシステムの一部として、TensorFlow Probability は確率的手法とさまざまな手法や機能との統合を提供します。
-たとえば、深層ネットワークを用いた確率的な手法、自動微分を用いた勾配に基づく推論、GPUによるハードウェア高速化や分散計算による大きなデータセットやモデルに対するスケーラビリティなどです。
+たとえば、深層ネットワークを用いた確率的な手法、自動微分を用いた勾配に基づく推論、GPU のようなハードウェア高速化や分散処理による大きなデータセットやモデルに対するスケーラビリティなどです。
 
 TensorFlow Probability を始めるためには、[インストールガイド](./install) や
 [Python notebook チュートリアル](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/examples/jupyter_notebooks/)を参照してください。
@@ -22,8 +22,8 @@ TensorFlow Probability を始めるためには、[インストールガイド](
 
 ### Layer 0: TensorFlow
 
-*数値処理*—特に, `LinearOperator`
-クラスが可能にする、効率的な演算のための特定の構造(直行、低ランク)を開発できるようにする行列フリーな実装。 
+*数値処理*—特に、`LinearOperator`
+クラスが可能にする、効率的な演算のための特定の構造 (直行、低ランク) を開発できるようにする行列フリーな実装。 
 TensorFlow Probability チームによりメンテナンスされていて、TensorFlow コアの [`tf.linalg`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/python/ops/linalg) の一部です。
 
 ### Layer 1: 確率的なブロックの構築


### PR DESCRIPTION
I've translated https://github.com/tensorflow/probability/blob/master/tensorflow_probability/g3doc/overview.md in Japanese.