### PR TITLE
fix wrong hyperlink to distribute_strategy.ipynb

### DIFF
--- a/site/en/r2/guide/using_gpu.ipynb
+++ b/site/en/r2/guide/using_gpu.ipynb
@@ -70,7 +70,7 @@
         "\n",
         "Note: Use the `tf.test.is_gpu_available` function to confirm that TensorFlow is using the GPU.\n",
         "\n",
-        "The simplest way to run on multiple GPUs, on one or many machines, is using [Distribution Strategies](../guide/distribute_strategy.ipynb)\n",
+        "The simplest way to run on multiple GPUs, on one or many machines, is using [Distribution Strategies](distribute_strategy.ipynb)\n",
         "\n",
         "This guide is for users who have tried these approaches and found that they need find-grained control of how TensorFlow uses the GPU."
       ]

--- a/site/en/r2/guide/using_gpu.ipynb
+++ b/site/en/r2/guide/using_gpu.ipynb
@@ -70,7 +70,7 @@
         "\n",
         "Note: Use the `tf.test.is_gpu_available` function to confirm that TensorFlow is using the GPU.\n",
         "\n",
-        "The simplest way to run on multiple GPUs, on one or many machines, is using [Distribution Strategies](../distribute_strategy.ipynb)\n",
+        "The simplest way to run on multiple GPUs, on one or many machines, is using [Distribution Strategies](../guide/distribute_strategy.ipynb)\n",
         "\n",
         "This guide is for users who have tried these approaches and found that they need find-grained control of how TensorFlow uses the GPU."
       ]


### PR DESCRIPTION
I noticed the hyperlink was throwing a 404 on the website. This should work.