### PR TITLE
Remove OS for tensorflow package

### DIFF
--- a/site/en/install/pip.html
+++ b/site/en/install/pip.html
@@ -15,7 +15,7 @@
 
 <h3>Available packages</h3>
 <ul>
-  <li><code>tensorflow</code> —Latest stable release for CPU-only <em>(Ubuntu and Windows)</em></li>
+  <li><code>tensorflow</code> —Latest stable release for CPU-only</li>
   <li><code>tensorflow-gpu</code> —Latest stable release with <a href="./gpu">GPU support</a> <em>(Ubuntu and Windows)</em></li>
   <li><code>tf-nightly</code> —Preview nightly build for CPU-only <em>(unstable)</em></li>
   <li><code>tf-nightly-gpu</code> —Preview nightly build with <a href="./gpu">GPU support</a> <em>(unstable, Ubuntu and Windows)</em></li>


### PR DESCRIPTION
Commit [7256a3](https://github.com/tensorflow/docs/commit/db026698ed79472677a7b084dba111d3a27256a3) updated the Available packages section to indicate `tensorflow—Latest stable release for CPU-only` is only available for Ubuntu and Windows. This may have been true in March (I am new) but it is not the case today.