### PR TITLE
Update bib.md

### DIFF
--- a/site/en/about/bib.md
+++ b/site/en/about/bib.md
@@ -7,7 +7,7 @@ This document identifies white papers about TensorFlow.
 [Access this white paper.](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/45166.pdf)
 
 **Abstract:** TensorFlow is an interface for expressing machine learning
-algorithms, and an implementation for executing such algorithms.
+algorithms and an implementation for executing such algorithms.
 A computation expressed using TensorFlow can be
 executed with little or no change on a wide variety of heterogeneous
 systems, ranging from mobile devices such as phones


### PR DESCRIPTION
Grammatical correction. There should not be any "comma" after "and" as the next sentence after and is not independent,