### PR TITLE
Change of the deprecated syntax 'tf.VERSION' for 'tf.version.VERSION'

### DIFF
--- a/site/en/guide/keras.ipynb
+++ b/site/en/guide/keras.ipynb
@@ -147,7 +147,7 @@
         "import tensorflow as tf\n",
         "from tensorflow.keras import layers\n",
         "\n",
-        "print(tf.VERSION)\n",
+        "print(tf.version.VERSION)\n",
         "print(tf.keras.__version__)"
       ],
       "execution_count": 0,


### PR DESCRIPTION
When starting the test after the installation of kera, this error show up: change of the deprecated syntax  'tf.VERSION' for 'tf.version.VERSION'