### PR TITLE
Update custom_training.ipynb custom training basics tutorial

### DIFF
--- a/site/en/r2/tutorials/eager/custom_training.ipynb
+++ b/site/en/r2/tutorials/eager/custom_training.ipynb
@@ -263,7 +263,7 @@
       "source": [
         "### Define a loss function\n",
         "\n",
-        "A loss function measures how well the output of a model for a given input matches the target output. It is like an objective function, the quantity of which will be minimized during training. Let's use the standard L2 loss, also known as the least square errors:"
+        "A loss function measures how well the output of a model for a given input matches the target output. The goal is to minimize this difference during training. Let's use the standard L2 loss, also known as the least square errors:"
       ]
     },
     {

--- a/site/en/r2/tutorials/eager/custom_training.ipynb
+++ b/site/en/r2/tutorials/eager/custom_training.ipynb
@@ -93,7 +93,7 @@
         "In the previous tutorial, you covered the TensorFlow APIs for automatic differentiation—a basic building block for machine learning.\n",
         "In this tutorial, you will use the TensorFlow primitives introduced in the prior tutorials to do some simple machine learning.\n",
         "\n",
-        "TensorFlow also includes `tf.keras`—a high-level neural network API that provides useful abstractions to reduce boilerplate and makes TensorFlow easier to use without sacrificing flexibility and performance. We strongly recommend the [tf.Keras API](../../guide/keras/overview.ipynb) for developement. However, in this short tutorial you will learn how to train a neural network from first principles to establish a strong foundation."
+        "TensorFlow also includes `tf.keras`—a high-level neural network API that provides useful abstractions to reduce boilerplate and makes TensorFlow easier to use without sacrificing flexibility and performance. We strongly recommend the [tf.Keras API](../../guide/keras/overview.ipynb) for development. However, in this short tutorial you will learn how to train a neural network from first principles to establish a strong foundation."
       ]
     },
     {
@@ -131,7 +131,7 @@
       "source": [
         "## Variables\n",
         "\n",
-        "Tensors in TensorFlow are immutable stateless objects. Machine learning models, however, need to have changing state: as your model trains, the same code to compute predictions should behave differently over time (hopefully with a lower loss!). To represent this state, which needs to change over the course of your computation, you can choose to rely on the fact that Python is a stateful programming language:\n"
+        "Tensors in TensorFlow are immutable stateless objects. Machine learning models, however, must have changing state: as your model trains, the same code to compute predictions should behave differently over time (hopefully with a lower loss!). To represent this state, which needs to change over the course of your computation, you can choose to rely on the fact that Python is a stateful programming language:\n"
       ]
     },
     {
@@ -214,7 +214,7 @@
         "3. Obtain training data.\n",
         "4. Run through the training data and use an \"optimizer\" to adjust the variables to fit the data.\n",
         "\n",
-        "In this tutorial, you'll go through a trivial example of a simple linear model, `f(x) = x * W + b`, which has two variables: `W` (weights) and `b` (bias). Furthermore, you'll synthesize data such that a well trained model would have `W = 3.0` and `b = 2.0`."
+        "Here, you'll create a simple linear model, `f(x) = x * W + b`, which has two variables: `W` (weights) and `b` (bias). You'll synthesize data such that a well trained model would have `W = 3.0` and `b = 2.0`."
       ]
     },
     {
@@ -289,7 +289,7 @@
       "source": [
         "### Obtain training data\n",
         "\n",
-        "First, you can synthesize the training data by adding random Gaussian (Normal) noise to the inputs:"
+        "First, synthesize the training data by adding random Gaussian (Normal) noise to the inputs:"
       ]
     },
     {
@@ -318,7 +318,7 @@
         "id": "-50nq-wPBsAW"
       },
       "source": [
-        "Before training the model you can visualize where it stands right now by plotting the model's predictions in red and the training data in blue:"
+        "Before training the model, visualize the loss value by plotting the model's predictions in red and the training data in blue:"
       ]
     },
     {
@@ -349,7 +349,7 @@
       "source": [
         "### Define a training loop\n",
         "\n",
-        "With your network and your training data, you can now train the model using [gradient descent](https://en.wikipedia.org/wiki/Gradient_descent) to update the weights variable (`W`) and the bias (`b`) to reduce the loss. There are many variants of the gradient descent scheme that are captured in `tf.train.Optimizer`—our recommended implementation. But in the spirit of building from first principles, here you will implement the basic math yourself with the help of `tf.GradientTape` API for automatic differentiation and `tf.assign_sub` for decrementing a value (which combines `tf.assign` and `tf.sub`):"
+        "With the network and training data, train the model using [gradient descent](https://en.wikipedia.org/wiki/Gradient_descent) to update the weights variable (`W`) and the bias variable (`b`) to reduce the loss. There are many variants of the gradient descent scheme that are captured in `tf.train.Optimizer`—our recommended implementation. But in the spirit of building from first principles, here you will implement the basic math yourself with the help of `tf.GradientTape` for automatic differentiation and `tf.assign_sub` for decrementing a value (which combines `tf.assign` and `tf.sub`):"
       ]
     },
     {
@@ -422,10 +422,9 @@
       "source": [
         "## Next steps\n",
         "\n",
-        "In this tutorial we covered `Variable`s and built and trained a simple linear model using the TensorFlow primitives discussed so far.\n",
+        "This tutorial used `tf.Variable` to build and train a simple linear model.\n",
         "\n",
-        "In theory, this is pretty much all you need to use TensorFlow for your machine learning research.\n",
-        "In practice, particularly for neural networks, the high-level APIs, such as `tf.keras`, will be much more convenient. `tf.keras` provides higher level building blocks (called \"layers\"), utilities to save and restore state, a suite of loss functions, a suite of optimization strategies, and so on. You can start learning more about `tf.keras` in [this guide](https://www.tensorflow.org/beta/guide/keras/overview).\n"
+        "In practice, the high-level APIs—such as `tf.keras`—are much more convenient to build neural networks. `tf.keras` provides higher level building blocks (called \"layers\"), utilities to save and restore state, a suite of loss functions, a suite of optimization strategies, and more. Read the [TensorFlow Keras guide](https://www.tensorflow.org/beta/guide/keras/overview) to learn more.\n"
       ]
     }
   ]

--- a/site/en/r2/tutorials/eager/custom_training.ipynb
+++ b/site/en/r2/tutorials/eager/custom_training.ipynb
@@ -7,7 +7,7 @@
         "id": "5rmpybwysXGV"
       },
       "source": [
-        "##### Copyright 2018 The TensorFlow Authors."
+        "##### Copyright 2019 The TensorFlow Authors."
       ]
     },
     {
@@ -74,10 +74,10 @@
         "id": "k2o3TTG4TFpt"
       },
       "source": [
-        "In the previous tutorial we covered the TensorFlow APIs for automatic differentiation, a basic building block for machine learning.\n",
-        "In this tutorial we will use the TensorFlow primitives introduced in the prior tutorials to do some simple machine learning.\n",
+        "In the previous tutorial, you covered the TensorFlow APIs for automatic differentiation—a basic building block for machine learning.\n",
+        "In this tutorial, you will use the TensorFlow primitives introduced in the prior tutorials to do some simple machine learning.\n",
         "\n",
-        "TensorFlow also includes a higher-level neural networks API (`tf.keras`) which provides useful abstractions to reduce boilerplate. We strongly recommend those higher level APIs for people working with neural networks. However, in this short tutorial we cover neural network training from first principles to establish a strong foundation. "
+        "TensorFlow also includes `tf.keras`—a high-level neural network API, which provides useful abstractions to reduce boilerplate and makes TensorFlow easier to use without sacrificing flexibility and performance. We strongly recommend [this high-level API](https://www.tensorflow.org/beta/guide/keras/overview) for people working with neural networks. However, in this short tutorial you will learn how to train a neural network from first principles to establish a strong foundation."
       ]
     },
     {
@@ -115,7 +115,7 @@
       "source": [
         "## Variables\n",
         "\n",
-        "Tensors in TensorFlow are immutable stateless objects. Machine learning models, however, need to have changing state: as your model trains, the same code to compute predictions should behave differently over time (hopefully with a lower loss!). To represent this state which needs to change over the course of your computation, you can choose to rely on the fact that Python is a stateful programming language:\n"
+        "Tensors in TensorFlow are immutable stateless objects. Machine learning models, however, need to have changing state: as your model trains, the same code to compute predictions should behave differently over time (hopefully with a lower loss!). To represent this state, which needs to change over the course of your computation, you can choose to rely on the fact that Python is a stateful programming language:\n"
       ]
     },
     {
@@ -128,7 +128,7 @@
       },
       "outputs": [],
       "source": [
-        "# Using python state\n",
+        "# Using Python state\n",
         "x = tf.zeros([10, 10])\n",
         "x += 2  # This is equivalent to x = x + 2, which does not mutate the original\n",
         "        # value of x\n",
@@ -142,9 +142,9 @@
         "id": "wfneTXy7JcUz"
       },
       "source": [
-        "TensorFlow, however, has stateful operations built in, and these are often more pleasant to use than low-level Python representations of your state. To represent weights in a model, for example, it's often convenient and efficient to use TensorFlow variables.\n",
+        "TensorFlow, however, has stateful operations built in, and these are often more pleasant to use than low-level Python representations of your state. To represent weights in a model, for example, it's often convenient and efficient to use TensorFlow variables, which are manipulated via the `tf.Variable` class.\n",
         "\n",
-        "A Variable is an object which stores a value and, when used in a TensorFlow computation, will implicitly read from this stored value. There are operations (`tf.assign_sub`, `tf.scatter_update`, etc) which manipulate the value stored in a TensorFlow variable."
+        "A variable is an object, which stores a value and, when used in a TensorFlow computation via `tf.Variable`, will implicitly read from this stored value. There are operations (`tf.assign_sub`, `tf.scatter_update`, etc), which manipulate the value stored in a TensorFlow variable."
       ]
     },
     {
@@ -158,15 +158,16 @@
       "outputs": [],
       "source": [
         "v = tf.Variable(1.0)\n",
+        "# Use Python's `assert` as a debugging statement to test the condition\n",
         "assert v.numpy() == 1.0\n",
         "\n",
-        "# Re-assign the value\n",
+        "# Reassign the value `v`\n",
         "v.assign(3.0)\n",
         "assert v.numpy() == 3.0\n",
         "\n",
-        "# Use `v` in a TensorFlow operation like tf.square() and reassign\n",
+        "# Use `v` in a TensorFlow `tf.square()` operation and reassign\n",
         "v.assign(tf.square(v))\n",
-        "assert v.numpy() == 9.0"
+        "assert v.numpy() == 9.0\n"
       ]
     },
     {
@@ -176,9 +177,9 @@
         "id": "-paSaeq1JzwC"
       },
       "source": [
-        "Computations using Variables are automatically traced when computing gradients. For Variables representing embeddings TensorFlow will do sparse updates by default, which are more computation and memory efficient.\n",
+        "Computations using `tf.Variable` are automatically traced when computing gradients. For variables representing embeddings TensorFlow will do sparse updates by default, which are more computation and memory efficient.\n",
         "\n",
-        "Using Variables is also a way to quickly let a reader of your code know that this piece of state is mutable."
+        "Using TensorFlow variables is also a way to quickly let a reader of your code know that this piece of state is mutable."
       ]
     },
     {
@@ -190,14 +191,14 @@
       "source": [
         "## Example: Fitting a linear model\n",
         "\n",
-        "Let's use the concepts you have learned so far---`Tensor`, `Variable`, and `GradientTape`--- to build and train a simple model. This typically involves a few steps:\n",
+        "Let's use the concepts you have learned so far—`Tensor`, `Variable`, and `GradientTape`—to build and train a simple model. This typically involves a few steps:\n",
         "\n",
         "1. Define the model.\n",
         "2. Define a loss function.\n",
         "3. Obtain training data.\n",
         "4. Run through the training data and use an \"optimizer\" to adjust the variables to fit the data.\n",
         "\n",
-        "In this tutorial, we'll walk through a trivial example of a simple linear model: `f(x) = x * W + b`, which has two variables - `W` and `b`. Furthermore, we'll synthesize data such that a well trained model would have `W = 3.0` and `b = 2.0`."
+        "In this tutorial, you'll go through a trivial example of a simple linear model, `f(x) = x * W + b`, which has two variables: `W` (weights) and `b` (bias). Furthermore, you'll synthesize data such that a well trained model would have `W = 3.0` and `b = 2.0`."
       ]
     },
     {
@@ -209,7 +210,7 @@
       "source": [
         "### Define the model\n",
         "\n",
-        "Let's define a simple class to encapsulate the variables and the computation."
+        "Let's define a simple class to encapsulate the variables and the computation:"
       ]
     },
     {
@@ -224,8 +225,8 @@
       "source": [
         "class Model(object):\n",
         "  def __init__(self):\n",
-        "    # Initialize variable to (5.0, 0.0)\n",
-        "    # In practice, these should be initialized to random values.\n",
+        "    # Initialize the weights to `5.0` and the bias to `0.0`\n",
+        "    # In practice, these should be initialized to random values (for example, with `tf.random.normal`)\n",
         "    self.W = tf.Variable(5.0)\n",
         "    self.b = tf.Variable(0.0)\n",
         "\n",
@@ -246,7 +247,7 @@
       "source": [
         "### Define a loss function\n",
         "\n",
-        "A loss function measures how well the output of a model for a given input matches the desired output. Let's use the standard L2 loss."
+        "A loss function measures how well the output of a model for a given input matches the target output. It is like an objective function, the quantity of which will be minimized during training. Let's use the standard L2 loss, also known as the least square errors:"
       ]
     },
     {
@@ -259,8 +260,8 @@
       },
       "outputs": [],
       "source": [
-        "def loss(predicted_y, desired_y):\n",
-        "  return tf.reduce_mean(tf.square(predicted_y - desired_y))"
+        "def loss(predicted_y, target_y):\n",
+        "  return tf.reduce_mean(tf.square(predicted_y - target_y))"
       ]
     },
     {
@@ -272,7 +273,7 @@
       "source": [
         "### Obtain training data\n",
         "\n",
-        "Let's synthesize the training data with some noise."
+        "First, you can synthesize the training data by adding random Gaussian (Normal) noise to the inputs, which can make your model more robust against overfitting and thus aid generalization:"
       ]
     },
     {
@@ -301,7 +302,7 @@
         "id": "-50nq-wPBsAW"
       },
       "source": [
-        "Before we train the model let's visualize where the model stands right now. We'll plot the model's predictions in red and the training data in blue."
+        "Before training the model you can visualize where it stands right now by plotting the model's predictions in red and the training data in blue:"
       ]
     },
     {
@@ -320,8 +321,7 @@
         "plt.scatter(inputs, model(inputs), c='r')\n",
         "plt.show()\n",
         "\n",
-        "print('Current loss: '),\n",
-        "print(loss(model(inputs), outputs).numpy())"
+        "print('Current loss: %1.6f' % loss(model(inputs), outputs).numpy())",
       ]
     },
     {
@@ -333,7 +333,7 @@
       "source": [
         "### Define a training loop\n",
         "\n",
-        "We now have our network and our training data. Let's train it, i.e., use the training data to update the model's variables (`W` and `b`) so that the loss goes down using [gradient descent](https://en.wikipedia.org/wiki/Gradient_descent). There are many variants of the gradient descent scheme that are captured in `tf.train.Optimizer` implementations. We'd highly recommend using those implementations, but in the spirit of building from first principles, in this particular example we will implement the basic math ourselves."
+        "With your network and your training data you can now train the model using [gradient descent](https://en.wikipedia.org/wiki/Gradient_descent) to update the weights variable (`W`) and the bias (`b`) and reduce the loss. There are many variants of the gradient descent scheme that are captured in `tf.train.Optimizer` implementations and we highly recommend using those implementations. But in the spirit of building from first principles, in this particular example, you will implement the basic math yourself with the help of `tf.GradientTape` API for automatic differentiation and `tf.assign_sub` for decrementing a value (which combines `tf.assign` and `tf.sub`):"
       ]
     },
     {
@@ -393,7 +393,7 @@
         "         epochs, bs, 'b')\n",
         "plt.plot([TRUE_W] * len(epochs), 'r--',\n",
         "         [TRUE_b] * len(epochs), 'b--')\n",
-        "plt.legend(['W', 'b', 'true W', 'true_b'])\n",
+        "plt.legend(['W', 'b', 'True W', 'True b'])\n",
         "plt.show()\n"
       ]
     },
@@ -409,7 +409,7 @@
         "In this tutorial we covered `Variable`s and built and trained a simple linear model using the TensorFlow primitives discussed so far.\n",
         "\n",
         "In theory, this is pretty much all you need to use TensorFlow for your machine learning research.\n",
-        "In practice, particularly for neural networks, the higher level APIs like `tf.keras` will be much more convenient since it provides higher level building blocks (called \"layers\"), utilities to save and restore state, a suite of loss functions, a suite of optimization strategies etc.\n"
+        "In practice, particularly for neural networks, the high-level APIs, such as `tf.keras`, will be much more convenient. `tf.keras` provides higher level building blocks (called \"layers\"), utilities to save and restore state, a suite of loss functions, a suite of optimization strategies, and so on. You can start learning more about `tf.keras` in [this guide](https://www.tensorflow.org/beta/guide/keras/overview).\n"
       ]
     },
     {

--- a/site/en/r2/tutorials/eager/custom_training.ipynb
+++ b/site/en/r2/tutorials/eager/custom_training.ipynb
@@ -1,4 +1,20 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "custom_training.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -12,14 +28,12 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "m8y3rGtQsYP2"
+        "id": "m8y3rGtQsYP2",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -32,7 +46,9 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -51,20 +67,20 @@
         "id": "7S0BwJ_8sLu7"
       },
       "source": [
-        "\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/beta/tutorials/eager/custom_training\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/eager/custom_training.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/eager/custom_training.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003eView source on GitHub\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/r2/tutorials/eager/custom_training.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/download_logo_32px.png\" /\u003eDownload notebook\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "\u003c/table\u003e"
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/beta/tutorials/eager/custom_training\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/eager/custom_training.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/eager/custom_training.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/r2/tutorials/eager/custom_training.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
+        "</table>"
       ]
     },
     {
@@ -77,7 +93,7 @@
         "In the previous tutorial, you covered the TensorFlow APIs for automatic differentiation—a basic building block for machine learning.\n",
         "In this tutorial, you will use the TensorFlow primitives introduced in the prior tutorials to do some simple machine learning.\n",
         "\n",
-        "TensorFlow also includes `tf.keras`—a high-level neural network API, which provides useful abstractions to reduce boilerplate and makes TensorFlow easier to use without sacrificing flexibility and performance. We strongly recommend [this high-level API](../../guide/keras/overview.ipynb) for people working with neural networks. However, in this short tutorial you will learn how to train a neural network from first principles to establish a strong foundation."
+        "TensorFlow also includes `tf.keras`—a high-level neural network API that provides useful abstractions to reduce boilerplate and makes TensorFlow easier to use without sacrificing flexibility and performance. We strongly recommend the [tf.Keras API](../../guide/keras/overview.ipynb) for developement. However, in this short tutorial you will learn how to train a neural network from first principles to establish a strong foundation."
       ]
     },
     {
@@ -92,19 +108,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "NiolgWMPgpwI"
+        "id": "NiolgWMPgpwI",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "from __future__ import absolute_import, division, print_function, unicode_literals\n",
         "\n",
         "!pip install tensorflow==2.0.0-beta1\n",
         "import tensorflow as tf"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -120,20 +136,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "VkJwtLS_Jbn8"
+        "id": "VkJwtLS_Jbn8",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# Using Python state\n",
         "x = tf.zeros([10, 10])\n",
         "x += 2  # This is equivalent to x = x + 2, which does not mutate the original\n",
         "        # value of x\n",
         "print(x)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -142,20 +158,18 @@
         "id": "wfneTXy7JcUz"
       },
       "source": [
-        "TensorFlow, however, has stateful operations built in, and these are often more pleasant to use than low-level Python representations of your state. To represent weights in a model use the `tf.Variable` class.\n",
+        "TensorFlow has stateful operations built-in, and these are often easier than using low-level Python representations for your state. Use `tf.Variable` to represent weights in a model.\n",
         "\n",
-        "A `tf.Variable` is an object, which stores a value, and will implicitly read from this stored value. There are operations (`tf.assign_sub`, `tf.scatter_update`, etc), which manipulate the value stored in a TensorFlow variable."
+        "A `tf.Variable` object stores a value and implicitly reads from this stored value. There are operations (`tf.assign_sub`, `tf.scatter_update`, etc.) that manipulate the value stored in a TensorFlow variable."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "itxmrMil6DQi"
+        "id": "itxmrMil6DQi",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "v = tf.Variable(1.0)\n",
         "# Use Python's `assert` as a debugging statement to test the condition\n",
@@ -168,7 +182,9 @@
         "# Use `v` in a TensorFlow `tf.square()` operation and reassign\n",
         "v.assign(tf.square(v))\n",
         "assert v.numpy() == 9.0\n"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -177,9 +193,9 @@
         "id": "-paSaeq1JzwC"
       },
       "source": [
-        "Computations using `tf.Variable` are automatically traced when computing gradients. For variables representing embeddings TensorFlow will do sparse updates by default, which are more computation and memory efficient.\n",
+        "Computations using `tf.Variable` are automatically traced when computing gradients. For variables that represent embeddings, TensorFlow will do sparse updates by default, which are more computation and memory efficient.\n",
         "\n",
-        "Using TensorFlow variables is also a way to quickly let a reader of your code know that this piece of state is mutable."
+        "A `tf.Variable` is also a way to show a reader of yoru code that a piece of state is mutable."
       ]
     },
     {
@@ -189,7 +205,7 @@
         "id": "BMiFcDzE7Qu3"
       },
       "source": [
-        "## Example: Fitting a linear model\n",
+        "## Fit a linear model\n",
         "\n",
         "Let's use the concepts you have learned so far—`Tensor`, `Variable`, and `GradientTape`—to build and train a simple model. This typically involves a few steps:\n",
         "\n",
@@ -215,13 +231,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "_WRu7Pze7wk8"
+        "id": "_WRu7Pze7wk8",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "class Model(object):\n",
         "  def __init__(self):\n",
@@ -236,7 +250,9 @@
         "model = Model()\n",
         "\n",
         "assert model(3.0).numpy() == 15.0"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -252,17 +268,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Y0ysUFGY924U"
+        "id": "Y0ysUFGY924U",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def loss(predicted_y, target_y):\n",
         "  return tf.reduce_mean(tf.square(predicted_y - target_y))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -278,13 +294,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "gxPTb-kt_N5m"
+        "id": "gxPTb-kt_N5m",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "TRUE_W = 3.0\n",
         "TRUE_b = 2.0\n",
@@ -293,7 +307,9 @@
         "inputs  = tf.random.normal(shape=[NUM_EXAMPLES])\n",
         "noise   = tf.random.normal(shape=[NUM_EXAMPLES])\n",
         "outputs = inputs * TRUE_W + TRUE_b + noise"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -307,13 +323,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "_eb83LtrB4nt"
+        "id": "_eb83LtrB4nt",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "import matplotlib.pyplot as plt\n",
         "\n",
@@ -322,7 +336,9 @@
         "plt.show()\n",
         "\n",
         "print('Current loss: %1.6f' % loss(model(inputs), outputs).numpy())"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -333,18 +349,16 @@
       "source": [
         "### Define a training loop\n",
         "\n",
-        "With your network and your training data you can now train the model using [gradient descent](https://en.wikipedia.org/wiki/Gradient_descent) to update the weights variable (`W`) and the bias (`b`) and reduce the loss. There are many variants of the gradient descent scheme that are captured in `tf.train.Optimizer` implementations and we highly recommend using those implementations. But in the spirit of building from first principles, in this particular example, you will implement the basic math yourself with the help of `tf.GradientTape` API for automatic differentiation and `tf.assign_sub` for decrementing a value (which combines `tf.assign` and `tf.sub`):"
+        "With your network and your training data, you can now train the model using [gradient descent](https://en.wikipedia.org/wiki/Gradient_descent) to update the weights variable (`W`) and the bias (`b`) to reduce the loss. There are many variants of the gradient descent scheme that are captured in `tf.train.Optimizer`—our recommended implementation. But in the spirit of building from first principles, here you will implement the basic math yourself with the help of `tf.GradientTape` API for automatic differentiation and `tf.assign_sub` for decrementing a value (which combines `tf.assign` and `tf.sub`):"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "MBIACgdnA55X"
+        "id": "MBIACgdnA55X",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def train(model, inputs, outputs, learning_rate):\n",
         "  with tf.GradientTape() as t:\n",
@@ -352,7 +366,9 @@
         "  dW, db = t.gradient(current_loss, [model.W, model.b])\n",
         "  model.W.assign_sub(learning_rate * dW)\n",
         "  model.b.assign_sub(learning_rate * db)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -366,13 +382,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "XdfkR223D9dW"
+        "id": "XdfkR223D9dW",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "model = Model()\n",
         "\n",
@@ -395,7 +409,9 @@
         "         [TRUE_b] * len(epochs), 'b--')\n",
         "plt.legend(['W', 'b', 'True W', 'True b'])\n",
         "plt.show()\n"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -404,42 +420,13 @@
         "id": "vPnIVuaSJwWz"
       },
       "source": [
-        "## Next Steps\n",
+        "## Next steps\n",
         "\n",
         "In this tutorial we covered `Variable`s and built and trained a simple linear model using the TensorFlow primitives discussed so far.\n",
         "\n",
         "In theory, this is pretty much all you need to use TensorFlow for your machine learning research.\n",
         "In practice, particularly for neural networks, the high-level APIs, such as `tf.keras`, will be much more convenient. `tf.keras` provides higher level building blocks (called \"layers\"), utilities to save and restore state, a suite of loss functions, a suite of optimization strategies, and so on. You can start learning more about `tf.keras` in [this guide](https://www.tensorflow.org/beta/guide/keras/overview).\n"
       ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "EyUG6XGSgwhk"
-      },
-      "outputs": [],
-      "source": [
-        ""
-      ]
     }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [],
-      "name": "Custom training: basics",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }

--- a/site/en/r2/tutorials/eager/custom_training.ipynb
+++ b/site/en/r2/tutorials/eager/custom_training.ipynb
@@ -195,7 +195,7 @@
       "source": [
         "Computations using `tf.Variable` are automatically traced when computing gradients. For variables that represent embeddings, TensorFlow will do sparse updates by default, which are more computation and memory efficient.\n",
         "\n",
-        "A `tf.Variable` is also a way to show a reader of yoru code that a piece of state is mutable."
+        "A `tf.Variable` is also a way to show a reader of your code that a piece of state is mutable."
       ]
     },
     {

--- a/site/en/r2/tutorials/eager/custom_training.ipynb
+++ b/site/en/r2/tutorials/eager/custom_training.ipynb
@@ -77,7 +77,7 @@
         "In the previous tutorial, you covered the TensorFlow APIs for automatic differentiation—a basic building block for machine learning.\n",
         "In this tutorial, you will use the TensorFlow primitives introduced in the prior tutorials to do some simple machine learning.\n",
         "\n",
-        "TensorFlow also includes `tf.keras`—a high-level neural network API, which provides useful abstractions to reduce boilerplate and makes TensorFlow easier to use without sacrificing flexibility and performance. We strongly recommend [this high-level API](https://www.tensorflow.org/beta/guide/keras/overview) for people working with neural networks. However, in this short tutorial you will learn how to train a neural network from first principles to establish a strong foundation."
+        "TensorFlow also includes `tf.keras`—a high-level neural network API, which provides useful abstractions to reduce boilerplate and makes TensorFlow easier to use without sacrificing flexibility and performance. We strongly recommend [this high-level API](../../guide/keras/overview.ipynb) for people working with neural networks. However, in this short tutorial you will learn how to train a neural network from first principles to establish a strong foundation."
       ]
     },
     {
@@ -142,9 +142,9 @@
         "id": "wfneTXy7JcUz"
       },
       "source": [
-        "TensorFlow, however, has stateful operations built in, and these are often more pleasant to use than low-level Python representations of your state. To represent weights in a model, for example, it's often convenient and efficient to use TensorFlow variables, which are manipulated via the `tf.Variable` class.\n",
+        "TensorFlow, however, has stateful operations built in, and these are often more pleasant to use than low-level Python representations of your state. To represent weights in a model use the `tf.Variable` class.\n",
         "\n",
-        "A variable is an object, which stores a value and, when used in a TensorFlow computation via `tf.Variable`, will implicitly read from this stored value. There are operations (`tf.assign_sub`, `tf.scatter_update`, etc), which manipulate the value stored in a TensorFlow variable."
+        "A `tf.Variable` is an object, which stores a value, and will implicitly read from this stored value. There are operations (`tf.assign_sub`, `tf.scatter_update`, etc), which manipulate the value stored in a TensorFlow variable."
       ]
     },
     {
@@ -273,7 +273,7 @@
       "source": [
         "### Obtain training data\n",
         "\n",
-        "First, you can synthesize the training data by adding random Gaussian (Normal) noise to the inputs, which can make your model more robust against overfitting and thus aid generalization:"
+        "First, you can synthesize the training data by adding random Gaussian (Normal) noise to the inputs:"
       ]
     },
     {

--- a/site/en/r2/tutorials/eager/custom_training.ipynb
+++ b/site/en/r2/tutorials/eager/custom_training.ipynb
@@ -321,7 +321,7 @@
         "plt.scatter(inputs, model(inputs), c='r')\n",
         "plt.show()\n",
         "\n",
-        "print('Current loss: %1.6f' % loss(model(inputs), outputs).numpy())",
+        "print('Current loss: %1.6f' % loss(model(inputs), outputs).numpy())"
       ]
     },
     {


### PR DESCRIPTION
Some suggested (UX) improvements to the _'Custom training: basics'_ r2 (TensorFlow 2 Beta1) tutorial:
- Update and expand `tf.keras` paragraphs with a link to the Keras guide
- Expand the L2 loss section
- Expand the training data synthesis with Gaussian noise section
- Update the training model section
- Add a small explanation of `tf.GradientTape` and `tf.assign_sub`
- Add backticks (`tf.Variable`)
- Change Copyright to `2019`
- Use second person where applicable
- Add/replace commas/colons
- Use em dash (`—`)/replace en dash(`-`)
- Add a `tf.random.normal` reference
- Use % modulo op to print the 'Current loss' in line with the rest of the notebook's style
- Fix labels in a plot (`True W`, `True b`)
- Change "desired" to "target" (commonly used word for `y`)

As before, if you find any of it useful (or not) let me know @MarkDaoust @lamberta. Any feedback welcome. Cheers!
