### PR TITLE
Update nmt_with_attention.ipynb: Fix ticker position in attention plo…

### DIFF
--- a/site/en/r2/tutorials/text/nmt_with_attention.ipynb
+++ b/site/en/r2/tutorials/text/nmt_with_attention.ipynb
@@ -122,6 +122,7 @@
         "import tensorflow as tf\n",
         "\n",
         "import matplotlib.pyplot as plt\n",
+        "import matplotlib.ticker as ticker\n",
         "from sklearn.model_selection import train_test_split\n",
         "\n",
         "import unicodedata\n",
@@ -896,6 +897,9 @@
         "\n",
         "    ax.set_xticklabels([''] + sentence, fontdict=fontdict, rotation=90)\n",
         "    ax.set_yticklabels([''] + predicted_sentence, fontdict=fontdict)\n",
+        "\n",
+        "    ax.xaxis.set_major_locator(ticker.MultipleLocator(1))\n",
+        "    ax.yaxis.set_major_locator(ticker.MultipleLocator(1))\n",
         "\n",
         "    plt.show()"
       ],


### PR DESCRIPTION
…t due to long sentences

Try translating this sentence 'Me temo que no se llevan muy bien ayer.'

Problem: Tickers will display every 2 blocks when displaying the sentence above.
Solution: Display ticker every block

Note: There are no copies of this notebook in other languages.