### PR TITLE
Update tf_records.pynb tutorial

### DIFF
--- a/site/en/r2/tutorials/load_data/tf_records.ipynb
+++ b/site/en/r2/tutorials/load_data/tf_records.ipynb
@@ -7,7 +7,7 @@
         "id": "pL--_KGdYoBz"
       },
       "source": [
-        "##### Copyright 2018 The TensorFlow Authors."
+        "##### Copyright 2019 The TensorFlow Authors."
       ]
     },
     {
@@ -146,9 +146,9 @@
         "id": "lZw57Qrn4CTE"
       },
       "source": [
-        "Fundamentally a `tf.Example` is a `{\"string\": tf.train.Feature}` mapping.\n",
+        "Fundamentally, a `tf.Example` is a `{\"string\": tf.train.Feature}` mapping.\n",
         "\n",
-        "The `tf.train.Feature` message type can accept one of the following three types (See the [`.proto` file](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/feature.proto) for reference). Most other generic types can be coerced into one of these.\n",
+        "The `tf.train.Feature` message type can accept one of the following three types (See the [`.proto` file](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/feature.proto) for reference). Most other generic types can be coerced into one of these:\n",
         "\n",
         "1. `tf.train.BytesList` (the following types can be coerced)\n",
         "\n",
@@ -177,9 +177,7 @@
         "id": "_e3g9ExathXP"
       },
       "source": [
-        "In order to convert a standard TensorFlow type to a `tf.Example`-compatible `tf.train.Feature`, you can use the following shortcut functions:\n",
-        "\n",
-        "Each function takes a scalar input value and returns a `tf.train.Feature` containing one of the three `list` types above."
+        "In order to convert a standard TensorFlow type to a `tf.Example`-compatible `tf.train.Feature`, you can use the shortcut functions below. Note that each function takes a scalar input value and returns a `tf.train.Feature` containing one of the three `list` types above:"
       ]
     },
     {
@@ -227,7 +225,7 @@
         "id": "vsMbkkC8xxtB"
       },
       "source": [
-        "Below are some examples of how these functions work. Note the varying input types and the standardizes output types. If the input type for a function does not match one of the coercible types stated above, the function will raise an exception (e.g. `_int64_feature(1.0)` will error out, since `1.0` is a float, so should be used with the `_float_feature` function instead)."
+        "Below are some examples of how these functions work. Note the varying input types and the standardized output types. If the input type for a function does not match one of the coercible types stated above, the function will raise an exception (e.g. `_int64_feature(1.0)` will error out, since `1.0` is a float, so should be used with the `_float_feature` function instead):"
       ]
     },
     {
@@ -256,7 +254,7 @@
         "id": "nj1qpfQU5qmi"
       },
       "source": [
-        "All proto messages can be serialized to a binary-string using the `.SerializeToString` method."
+        "All proto messages can be serialized to a binary-string using the `.SerializeToString` method:"
       ]
     },
     {
@@ -291,13 +289,13 @@
         "id": "b_MEnhxchQPC"
       },
       "source": [
-        "Suppose you want to create a `tf.Example` message from existing data. In practice, the dataset may come from anywhere, but the procedure of creating the `tf.Example` message from a single observation will be the same.\n",
+        "Suppose you want to create a `tf.Example` message from existing data. In practice, the dataset may come from anywhere, but the procedure of creating the `tf.Example` message from a single observation will be the same:\n",
         "\n",
         "1. Within each observation, each value needs to be converted to a `tf.train.Feature` containing one of the 3 compatible types, using one of the functions above.\n",
         "\n",
-        "1. We create a map (dictionary) from the feature name string to the encoded feature value produced in #1.\n",
+        "1. You create a map (dictionary) from the feature name string to the encoded feature value produced in #1.\n",
         "\n",
-        "1. The map produced in #2 is converted to a [`Features` message](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/feature.proto#L85)."
+        "1. The map produced in step 2 is converted to a [`Features` message](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/feature.proto#L85)."
       ]
     },
     {
@@ -307,15 +305,15 @@
         "id": "4EgFQ2uHtchc"
       },
       "source": [
-        "In this notebook, we will create a dataset using NumPy.\n",
+        "In this notebook, you will create a dataset using NumPy.\n",
         "\n",
-        "This dataset will have 4 features.\n",
-        "- a boolean feature, `False` or `True` with equal probability\n",
-        "- an integer feature uniformly randomly chosen from `[0, 5)`\n",
-        "- a string feature generated from a string table by using the integer feature as an index\n",
-        "- a float feature from a standard normal distribution\n",
+        "This dataset will have 4 features:\n",
+        "* a boolean feature, `False` or `True` with equal probability\n",
+        "* an integer feature uniformly randomly chosen from `[0, 5)`\n",
+        "* a string feature generated from a string table by using the integer feature as an index\n",
+        "* a float feature from a standard normal distribution\n",
         "\n",
-        "Consider a sample consisting of 10,000 independently and identically distributed observations from each of the above distributions."
+        "Consider a sample consisting of 10,000 independently and identically distributed observations from each of the above distributions:"
       ]
     },
     {
@@ -328,20 +326,20 @@
       },
       "outputs": [],
       "source": [
-        "# the number of observations in the dataset\n",
+        "# The number of observations in the dataset.\n",
         "n_observations = int(1e4)\n",
         "\n",
-        "# boolean feature, encoded as False or True\n",
+        "# Boolean feature, encoded as False or True.\n",
         "feature0 = np.random.choice([False, True], n_observations)\n",
         "\n",
-        "# integer feature, random from 0 .. 4\n",
+        "# Integer feature, random from 0 to 4.\n",
         "feature1 = np.random.randint(0, 5, n_observations)\n",
         "\n",
-        "# string feature\n",
+        "# String feature\n",
         "strings = np.array([b'cat', b'dog', b'chicken', b'horse', b'goat'])\n",
         "feature2 = strings[feature1]\n",
         "\n",
-        "# float feature, from a standard normal distribution\n",
+        "# Float feature, from a standard normal distribution\n",
         "feature3 = np.random.randn(n_observations)"
       ]
     },
@@ -352,7 +350,7 @@
         "id": "aGrscehJr7Jd"
       },
       "source": [
-        "Each of these features can be coerced into a `tf.Example`-compatible type using one of `_bytes_feature`, `_float_feature`, `_int64_feature`. We can then create a `tf.Example` message from these encoded features."
+        "Each of these features can be coerced into a `tf.Example`-compatible type using one of `_bytes_feature`, `_float_feature`, `_int64_feature`. You can then create a `tf.Example` message from these encoded features:"
       ]
     },
     {
@@ -391,7 +389,7 @@
         "id": "XftzX9CN_uGT"
       },
       "source": [
-        "For example, suppose we have a single observation from the dataset, `[False, 4, bytes('goat'), 0.9876]`. We can create and print the `tf.Example` message for this observation using `create_message()`. Each single observation will be written as a `Features` message as per the above. Note that the `tf.Example` [message](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/example.proto#L88) is just a wrapper around the `Features` message."
+        "For example, suppose you have a single observation from the dataset, `[False, 4, bytes('goat'), 0.9876]`. You can create and print the `tf.Example` message for this observation using `create_message()`. Each single observation will be written as a `Features` message as per the above. Note that the `tf.Example` [message](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/example.proto#L88) is just a wrapper around the `Features` message:"
       ]
     },
     {
@@ -483,7 +481,7 @@
         "id": "GmehkCCT81Ez"
       },
       "source": [
-        "The `tf.data` module also provides tools for reading and writing data in tensorflow."
+        "The `tf.data` module also provides tools for reading and writing data in TensorFlow."
       ]
     },
     {
@@ -497,7 +495,7 @@
         "\n",
         "The easiest way to get the data into a dataset is to use the `from_tensor_slices` method.\n",
         "\n",
-        "Applied to an array, it returns a dataset of scalars."
+        "Applied to an array, it returns a dataset of scalars:"
       ]
     },
     {
@@ -564,7 +562,7 @@
       "source": [
         "Use the `tf.data.Dataset.map` method to apply a function to each element of a `Dataset`.\n",
         "\n",
-        "The mapped function must operate in TensorFlow graph mode: It must operate on and return `tf.Tensors`. A non-tensor function, like `create_example`, can be wrapped with `tf.py_function` to make it compatible.\n",
+        "The mapped function must operate in TensorFlow graph mode—it must operate on and return `tf.Tensors`. A non-tensor function, like `create_example`, can be wrapped with `tf.py_function` to make it compatible.\n",
         "\n",
         "Using `tf.py_function` requires that you specify the shape and type information that is otherwise unavailable:"
       ]
@@ -708,7 +706,7 @@
         "id": "o3J5D4gcSy8N"
       },
       "source": [
-        "We can also read the TFRecord file using the `tf.data.TFRecordDataset` class.\n",
+        "You can also read the TFRecord file using the `tf.data.TFRecordDataset` class.\n",
         "\n",
         "More information on consuming TFRecord files using `tf.data` can be found [here](https://www.tensorflow.org/guide/datasets#consuming_tfrecord_data).\n",
         "\n",
@@ -765,7 +763,7 @@
         "id": "W-6oNzM4luFQ"
       },
       "source": [
-        "These tensors can be parsed using the function below.\n",
+        "These tensors can be parsed using the function below:\n",
         "\n",
         "Note: The `feature_description` is necessary here because datasets use graph-execution, and need this description to build their shape and type signature."
       ]
@@ -789,7 +787,7 @@
         "}\n",
         "\n",
         "def _parse_function(example_proto):\n",
-        "  # Parse the input tf.Example proto using the dictionary above.\n",
+        "  # Parse the input `tf.Example` proto using the dictionary above.\n",
         "  return tf.io.parse_single_example(example_proto, feature_description)"
       ]
     },
@@ -810,7 +808,7 @@
         "id": "AH73hav6Bnmg"
       },
       "source": [
-        "Apply this finction to each item in the dataset using the `tf.data.Dataset.map` method:"
+        "Apply this function to each item in the dataset using the `tf.data.Dataset.map` method:"
       ]
     },
     {
@@ -834,7 +832,7 @@
         "id": "sNV-XclGnOvn"
       },
       "source": [
-        "Use eager execution to display the observations in the dataset. There are 10,000 observations in this dataset, but we only display the first 10. The data is displayed as a dictionary of features. Each item is a `tf.Tensor`, and the `numpy` element of this tensor displays the value of the feature."
+        "Use eager execution to display the observations in the dataset. There are 10,000 observations in this dataset, but you will only display the first 10. The data is displayed as a dictionary of features. Each item is a `tf.Tensor`, and the `numpy` element of this tensor displays the value of the feature:"
       ]
     },
     {
@@ -898,7 +896,7 @@
         "id": "LNW_FA-GQWXs"
       },
       "source": [
-        "Now write the 10,000 observations to the file `test.tfrecords`. Each observation is converted to a `tf.Example` message, then written to file. We can then verify that the file `test.tfrecords` has been created."
+        "Now write the 10,000 observations to the file `test.tfrecord`. Each observation is converted to a `tf.Example` message, then written to file. You can then verify that the file `test.tfrecord` has been created."
       ]
     },
     {
@@ -1067,7 +1065,7 @@
         "id": "Azx83ryQEU6T"
       },
       "source": [
-        "As we did earlier, we can now encode the features as types compatible with `tf.Example`. In this case, we will not only store the raw image string as a feature, but we will store the height, width, depth, and an arbitrary `label` feature, which is used when we write the file to distinguish between the cat image and the bridge image. We will use `0` for the cat image, and `1` for the bridge image."
+        "As you did earlier, you can now encode the features as types compatible with `tf.Example`. In this case, you will store the raw image string feature, as well as the height, width, depth, and arbitrary `label` feature. The latter is used when you write the file to distinguish between the cat image and the bridge image. Use `0` for the cat image, and `1` for the bridge image:"
       ]
     },
     {
@@ -1127,7 +1125,7 @@
         "id": "2G_o3O9MN0Qx"
       },
       "source": [
-        "We see that all of the features are now stores in the `tf.Example` message. Now, we functionalize the code above and write the example messages to a file, `images.tfrecords`."
+        "Notice that all of the features are now stored in the `tf.Example` message. Next, functionalize the code above and write the example messages to a file named `images.tfrecords`:"
       ]
     },
     {
@@ -1140,9 +1138,9 @@
       },
       "outputs": [],
       "source": [
-        "# Write the raw image files to images.tfrecords.\n",
-        "# First, process the two images into tf.Example messages.\n",
-        "# Then, write to a .tfrecords file.\n",
+        "# Write the raw image files to `images.tfrecords`.\n",
+        "# First, process the two images into `tf.Example` messages.\n",
+        "# Then, write to a `.tfrecords` file.\n",
         "record_file = 'images.tfrecords'\n",
         "with tf.io.TFRecordWriter(record_file) as writer:\n",
         "  for filename, label in image_labels.items():\n",
@@ -1173,7 +1171,7 @@
       "source": [
         "### Read the TFRecord file\n",
         "\n",
-        "We now have the file `images.tfrecords`. We can now iterate over the records in the file to read back what we wrote. Since, for our use case we will just reproduce the image, the only feature we need is the raw image string. We can extract that using the getters described above, namely `example.features.feature['image_raw'].bytes_list.value[0]`. We also use the labels to determine which record is the cat as opposed to the bridge."
+        "You now have the file—`images.tfrecords`—and can now iterate over the records in it to read back what you wrote. Given that in this example you will only reproduce the image, the only feature you will need is the raw image string. You can extract it using the getters described above, namely `example.features.feature['image_raw'].bytes_list.value[0]`. You can also use the labels to determine which record is the cat and which one is the bridge:"
       ]
     },
     {

--- a/site/en/r2/tutorials/load_data/tf_records.ipynb
+++ b/site/en/r2/tutorials/load_data/tf_records.ipynb
@@ -309,7 +309,7 @@
         "\n",
         "This dataset will have 4 features:\n",
         "* a boolean feature, `False` or `True` with equal probability\n",
-        "* an integer feature uniformly randomly chosen from `[0, 5)`\n",
+        "* an integer feature uniformly randomly chosen from `[0, 5]`\n",
         "* a string feature generated from a string table by using the integer feature as an index\n",
         "* a float feature from a standard normal distribution\n",
         "\n",
@@ -447,7 +447,7 @@
         "\n",
         "Each record contains a byte-string, for the data-payload, plus the data-length, and  CRC32C (32-bit CRC using the Castagnoli polynomial) hashes for integrity checking.\n",
         "\n",
-        "Each record has the format\n",
+        "Each record is stored in the following formats:\n",
         "\n",
         "    uint64 length\n",
         "    uint32 masked_crc32_of_length\n",
@@ -456,7 +456,7 @@
         "\n",
         "The records are concatenated together to produce the file. CRCs are\n",
         "[described here](https://en.wikipedia.org/wiki/Cyclic_redundancy_check), and\n",
-        "the mask of a CRC is\n",
+        "the mask of a CRC is:\n",
         "\n",
         "    masked_crc = ((crc \u003e\u003e 15) | (crc \u003c\u003c 17)) + 0xa282ead8ul\n",
         "\n",
@@ -763,9 +763,7 @@
         "id": "W-6oNzM4luFQ"
       },
       "source": [
-        "These tensors can be parsed using the function below:\n",
-        "\n",
-        "Note: The `feature_description` is necessary here because datasets use graph-execution, and need this description to build their shape and type signature."
+        "These tensors can be parsed using the function below. Note that the `feature_description` is necessary here because datasets use graph-execution, and need this description to build their shape and type signature:"
       ]
     },
     {
@@ -798,17 +796,7 @@
         "id": "gWETjUqhEQZf"
       },
       "source": [
-        "Or use `tf.parse example` to parse a whole batch at once."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "AH73hav6Bnmg"
-      },
-      "source": [
-        "Apply this function to each item in the dataset using the `tf.data.Dataset.map` method:"
+        "Alternatively, you can use `tf.parse example` to parse the whole batch at once. Apply this function to each item in the dataset using the `tf.data.Dataset.map` method:"
       ]
     },
     {
@@ -896,7 +884,7 @@
         "id": "LNW_FA-GQWXs"
       },
       "source": [
-        "Now write the 10,000 observations to the file `test.tfrecord`. Each observation is converted to a `tf.Example` message, then written to file. You can then verify that the file `test.tfrecord` has been created."
+        "Next, write the 10,000 observations to the file `test.tfrecord`. Each observation is converted to a `tf.Example` message, then written to file. You can then verify that the file `test.tfrecord` has been created:"
       ]
     },
     {
@@ -938,7 +926,7 @@
       "source": [
         "### Reading a TFRecord file\n",
         "\n",
-        "These serialized tensores can be easily parsed using `tf.train.Example.ParseFromString`"
+        "These serialized tensors can be easily parsed using `tf.train.Example.ParseFromString`:"
       ]
     },
     {

--- a/site/en/r2/tutorials/load_data/tf_records.ipynb
+++ b/site/en/r2/tutorials/load_data/tf_records.ipynb
@@ -564,7 +564,7 @@
         "\n",
         "The mapped function must operate in TensorFlow graph mode—it must operate on and return `tf.Tensors`. A non-tensor function, like `create_example`, can be wrapped with `tf.py_function` to make it compatible.\n",
         "\n",
-        "Using `tf.py_function` requires that you specify the shape and type information that is otherwise unavailable:"
+        "Using `tf.py_function` requires to specify the shape and type information that is otherwise unavailable:"
       ]
     },
     {
@@ -796,7 +796,7 @@
         "id": "gWETjUqhEQZf"
       },
       "source": [
-        "Alternatively, you can use `tf.parse example` to parse the whole batch at once. Apply this function to each item in the dataset using the `tf.data.Dataset.map` method:"
+        "Alternatively, use `tf.parse example` to parse the whole batch at once. Apply this function to each item in the dataset using the `tf.data.Dataset.map` method:"
       ]
     },
     {
@@ -1053,7 +1053,7 @@
         "id": "Azx83ryQEU6T"
       },
       "source": [
-        "As you did earlier, you can now encode the features as types compatible with `tf.Example`. In this case, you will store the raw image string feature, as well as the height, width, depth, and arbitrary `label` feature. The latter is used when you write the file to distinguish between the cat image and the bridge image. Use `0` for the cat image, and `1` for the bridge image:"
+        "As before, encode the features as types compatible with `tf.Example`. This stores the raw image string feature, as well as the height, width, depth, and arbitrary `label` feature. The latter is used when you write the file to distinguish between the cat image and the bridge image. Use `0` for the cat image, and `1` for the bridge image:"
       ]
     },
     {
@@ -1159,7 +1159,7 @@
       "source": [
         "### Read the TFRecord file\n",
         "\n",
-        "You now have the file—`images.tfrecords`—and can now iterate over the records in it to read back what you wrote. Given that in this example you will only reproduce the image, the only feature you will need is the raw image string. You can extract it using the getters described above, namely `example.features.feature['image_raw'].bytes_list.value[0]`. You can also use the labels to determine which record is the cat and which one is the bridge:"
+        "You now have the file—`images.tfrecords`—and can now iterate over the records in it to read back what you wrote. Given that in this example you will only reproduce the image, the only feature you will need is the raw image string. Extract it using the getters described above, namely `example.features.feature['image_raw'].bytes_list.value[0]`. You can also use the labels to determine which record is the cat and which one is the bridge:"
       ]
     },
     {


### PR DESCRIPTION
While studying how TensorFlow Datasets work and the TFRecord file format, I went through the [_Using TFRecords and tf.Example tutorial_](https://www.tensorflow.org/beta/tutorials/load_data/tf_records) (r2, TF2 Beta1) and made a few changes in line with the Google Docs guide.

Suggestions include: fix minor typos in a file name (`test.tfrecord` without an "s" versus `images.tfrecords` with an "s" in the end), fix bullet point representation in markdown (replace "-" with "*"), fix the tense of a few verbs to be in a passive voice ("..es" -> "..ed"), capitalize a few letters (e.g. "TensorFlow"), use second person (change from "we" and "our" to "you" and "your"), add backticks/colons/commas where needed, change the copyright year to 2019, fix the "tensors" spelling, change a few paragraph structures to make them flow

Let me know if it's alright. Cheers