### PR TITLE
Fix Typo: likelihood spelt liklihood

### DIFF
--- a/site/en/r2/tutorials/text/text_generation.ipynb
+++ b/site/en/r2/tutorials/text/text_generation.ipynb
@@ -616,7 +616,7 @@
         "id": "RkA5upJIJ7W7"
       },
       "source": [
-        "For each character the model looks up the embedding, runs the GRU one timestep with the embedding as input, and applies the dense layer to generate logits predicting the log-liklihood of the next character:\n",
+        "For each character the model looks up the embedding, runs the GRU one timestep with the embedding as input, and applies the dense layer to generate logits predicting the log-likelihood of the next character:\n",
         "\n",
         "![A drawing of the data passing through the model](https://tensorflow.org/tutorials/beta/text/images/text_generation_training.png)"
       ]


### PR DESCRIPTION
On line 619, likelihood is spelt liklihood. This issue is not present in the tensorflow 1 equivalent of this tutorial.