### PR TITLE
Use softmax as activation for the dense layer

### DIFF
--- a/site/en/tutorials/load_data/images.ipynb
+++ b/site/en/tutorials/load_data/images.ipynb
@@ -1012,7 +1012,7 @@
         "model = tf.keras.Sequential([\n",
         "  mobile_net,\n",
         "  tf.keras.layers.GlobalAveragePooling2D(),\n",
-        "  tf.keras.layers.Dense(len(label_names))])"
+        "  tf.keras.layers.Dense(len(label_names), activation = 'softmax')])"
       ]
     },
     {


### PR DESCRIPTION
It is necessary to use softmax as activation to convert raw prediction values to probability distribution.