### PR TITLE
typo: change spelling of intenral to internal

### DIFF
--- a/site/en/r2/guide/keras/rnn.ipynb
+++ b/site/en/r2/guide/keras/rnn.ipynb
@@ -160,7 +160,7 @@
         "# output embedding domain to be 64.\n",
         "model.add(layers.Embedding(input_dim=1000, output_dim=64))\n",
         "\n",
-        "# Add an LSTM layer with 128 intenral units.\n",
+        "# Add an LSTM layer with 128 internal units.\n",
         "model.add(layers.LSTM(128))\n",
         "\n",
         "# Add an Dense layer with 10 units and softmax activation.\n",
@@ -219,7 +219,7 @@
         "id": "1HagyjYos5rD"
       },
       "source": [
-        "In addition, a layer could return the final intenral state. The returned states can be used continue the RNN execution later, or to [initialize another RNN](https://arxiv.org/abs/1409.3215). This setting is commonly used in the encoder-decoder model, where the encoder final state is feed to decoder as initial state.\n",
+        "In addition, a layer could return the final internal state. The returned states can be used continue the RNN execution later, or to [initialize another RNN](https://arxiv.org/abs/1409.3215). This setting is commonly used in the encoder-decoder model, where the encoder final state is feed to decoder as initial state.\n",
         "\n",
         "To enable that, set the `return_state` parameter to `True` when creating the layer.\n",
         "\n",


### PR DESCRIPTION
This change rectifies the spelling error where internal is spelled intenral.