### PR TITLE
Update custom_training_walkthrough.ipynb

### DIFF
--- a/site/en/r2/tutorials/eager/custom_training_walkthrough.ipynb
+++ b/site/en/r2/tutorials/eager/custom_training_walkthrough.ipynb
@@ -89,7 +89,7 @@
         "\n",
         "This tutorial is structured like many TensorFlow programs:\n",
         "\n",
-        "1. Import and parse the data sets.\n",
+        "1. Import and parse the dataset.\n",
         "2. Select the type of model.\n",
         "3. Train the model.\n",
         "4. Evaluate the model's effectiveness.\n",
@@ -189,7 +189,7 @@
         "  \u003c/td\u003e\u003c/tr\u003e\n",
         "\u003c/table\u003e\n",
         "\n",
-        "Fortunately, someone has already created a [data set of 120 Iris flowers](https://en.wikipedia.org/wiki/Iris_flower_data_set) with the sepal and petal measurements. This is a classic dataset that is popular for beginner machine learning classification problems."
+        "Fortunately, someone has already created a [dataset of 120 Iris flowers](https://en.wikipedia.org/wiki/Iris_flower_data_set) with the sepal and petal measurements. This is a classic dataset that is popular for beginner machine learning classification problems."
       ]
     },
     {
@@ -205,7 +205,7 @@
         "\n",
         "### Download the dataset\n",
         "\n",
-        "Download the training dataset file using the [tf.keras.utils.get_file](https://www.tensorflow.org/api_docs/python/tf/keras/utils/get_file) function. This returns the file path of the downloaded file."
+        "Download the training dataset file using the [tf.keras.utils.get_file](https://www.tensorflow.org/api_docs/python/tf/keras/utils/get_file) function. This returns the file path of the downloaded file:"
       ]
     },
     {
@@ -235,7 +235,7 @@
       "source": [
         "### Inspect the data\n",
         "\n",
-        "This dataset, `iris_training.csv`, is a plain text file that stores tabular data formatted as comma-separated values (CSV). Use the `head -n5` command to take a peak at the first five entries:"
+        "This dataset, `iris_training.csv`, is a plain text file that stores tabular data formatted as comma-separated values (CSV). Use the `head -n5` command to take a peek at the first five entries:"
       ]
     },
     {
@@ -263,7 +263,7 @@
         "1. The first line is a header containing information about the dataset:\n",
         "  * There are 120 total examples. Each example has four features and one of three possible label names.\n",
         "2. Subsequent rows are data records, one *[example](https://developers.google.com/machine-learning/glossary/#example)* per line, where:\n",
-        "  * The first four fields are *[features](https://developers.google.com/machine-learning/glossary/#feature)*: these are characteristics of an example. Here, the fields hold float numbers representing flower measurements.\n",
+        "  * The first four fields are *[features](https://developers.google.com/machine-learning/glossary/#feature)*: these are the characteristics of an example. Here, the fields hold float numbers representing flower measurements.\n",
         "  * The last column is the *[label](https://developers.google.com/machine-learning/glossary/#label)*: this is the value we want to predict. For this dataset, it's an integer value of 0, 1, or 2 that corresponds to a flower name.\n",
         "\n",
         "Let's write that out in code:"
@@ -330,7 +330,7 @@
         "TensorFlow's [Dataset API](https://www.tensorflow.org/guide/datasets) handles many common cases for loading data into a model. This is a high-level API for reading data and transforming it into a form used for training. See the [Datasets Quick Start guide](https://www.tensorflow.org/get_started/datasets_quickstart) for more information.\n",
         "\n",
         "\n",
-        "Since the dataset is a CSV-formatted text file, use the [make_csv_dataset](https://www.tensorflow.org/api_docs/python/tf/data/experimental/make_csv_dataset) function to parse the data into a suitable format. Since this function generates data for training models, the default behavior is to shuffle the data (`shuffle=True, shuffle_buffer_size=10000`), and repeat the dataset forever (`num_epochs=None`). We also set the [batch_size](https://developers.google.com/machine-learning/glossary/#batch_size) parameter."
+        "Since the dataset is a CSV-formatted text file, use the [make_csv_dataset](https://www.tensorflow.org/api_docs/python/tf/data/experimental/make_csv_dataset) function to parse the data into a suitable format. Since this function generates data for training models, the default behavior is to shuffle the data (`shuffle=True, shuffle_buffer_size=10000`), and repeat the dataset forever (`num_epochs=None`). We also set the [batch_size](https://developers.google.com/machine-learning/glossary/#batch_size) parameter:"
       ]
     },
     {
@@ -421,7 +421,7 @@
       "source": [
         "To simplify the model building step, create a function to repackage the features dictionary into a single array with shape: `(batch_size, num_features)`.\n",
         "\n",
-        "This function uses the [tf.stack](https://www.tensorflow.org/api_docs/python/tf/stack) method which takes values from a list of tensors and creates a combined tensor at the specified dimension."
+        "This function uses the [tf.stack](https://www.tensorflow.org/api_docs/python/tf/stack) method which takes values from a list of tensors and creates a combined tensor at the specified dimension:"
       ]
     },
     {
@@ -531,7 +531,7 @@
         "\n",
         "The TensorFlow [tf.keras](https://www.tensorflow.org/api_docs/python/tf/keras) API is the preferred way to create models and layers. This makes it easy to build models and experiment while Keras handles the complexity of connecting everything together.\n",
         "\n",
-        "The [tf.keras.Sequential](https://www.tensorflow.org/api_docs/python/tf/keras/Sequential) model is a linear stack of layers. Its constructor takes a list of layer instances, in this case, two [Dense](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Dense) layers with 10 nodes each, and an output layer with 3 nodes representing our label predictions. The first layer's `input_shape` parameter corresponds to the number of features from the dataset, and is required."
+        "The [tf.keras.Sequential](https://www.tensorflow.org/api_docs/python/tf/keras/Sequential) model is a linear stack of layers. Its constructor takes a list of layer instances, in this case, two [Dense](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Dense) layers with 10 nodes each, and an output layer with 3 nodes representing our label predictions. The first layer's `input_shape` parameter corresponds to the number of features from the dataset, and is required:"
       ]
     },
     {
@@ -621,7 +621,7 @@
         "id": "uRZmchElo481"
       },
       "source": [
-        "Taking the `tf.argmax` across classes gives us the predicted class index. But, the model hasn't been trained yet, so these aren't good predictions."
+        "Taking the `tf.argmax` across classes gives us the predicted class index. But, the model hasn't been trained yet, so these aren't good predictions:"
       ]
     },
     {
@@ -706,7 +706,7 @@
         "id": "3IcPqA24QM6B"
       },
       "source": [
-        "Use the [tf.GradientTape](https://www.tensorflow.org/api_docs/python/tf/GradientTape) context to calculate the *[gradients](https://developers.google.com/machine-learning/crash-course/glossary#gradient)* used to optimize our model."
+        "Use the [tf.GradientTape](https://www.tensorflow.org/api_docs/python/tf/GradientTape) context to calculate the *[gradients](https://developers.google.com/machine-learning/crash-course/glossary#gradient)* used to optimize your model:"
       ]
     },
     {
@@ -821,7 +821,7 @@
         "5. Keep track of some stats for visualization.\n",
         "6. Repeat for each epoch.\n",
         "\n",
-        "The `num_epochs` variable is the number of times to loop over the dataset collection. Counter-intuitively, training a model longer does not guarantee a better model. `num_epochs` is a *[hyperparameter](https://developers.google.com/machine-learning/glossary/#hyperparameter)* that you can tune. Choosing the right number usually requires both experience and experimentation."
+        "The `num_epochs` variable is the number of times to loop over the dataset collection. Counter-intuitively, training a model longer does not guarantee a better model. `num_epochs` is a *[hyperparameter](https://developers.google.com/machine-learning/glossary/#hyperparameter)* that you can tune. Choosing the right number usually requires both experience and experimentation:"
       ]
     },
     {
@@ -836,7 +836,7 @@
       "source": [
         "## Note: Rerunning this cell uses the same model variables\n",
         "\n",
-        "# keep results for plotting\n",
+        "# Keep results for plotting\n",
         "train_loss_results = []\n",
         "train_accuracy_results = []\n",
         "\n",
@@ -853,11 +853,11 @@
         "    optimizer.apply_gradients(zip(grads, model.trainable_variables))\n",
         "\n",
         "    # Track progress\n",
-        "    epoch_loss_avg(loss_value)  # add current batch loss\n",
-        "    # compare predicted label to actual label\n",
+        "    epoch_loss_avg(loss_value)  # Add current batch loss\n",
+        "    # Compare predicted label to actual label\n",
         "    epoch_accuracy(y, model(x))\n",
         "\n",
-        "  # end epoch\n",
+        "  # End epoch\n",
         "  train_loss_results.append(epoch_loss_avg.result())\n",
         "  train_accuracy_results.append(epoch_accuracy.result())\n",
         "\n",
@@ -886,7 +886,7 @@
       "source": [
         "While it's helpful to print out the model's training progress, it's often *more* helpful to see this progress. [TensorBoard](https://www.tensorflow.org/guide/summaries_and_tensorboard) is a nice visualization tool that is packaged with TensorFlow, but we can create basic charts using the `matplotlib` module.\n",
         "\n",
-        "Interpreting these charts takes some experience, but you really want to see the *loss* go down and the *accuracy* go up."
+        "Interpreting these charts takes some experience, but you really want to see the *loss* go down and the *accuracy* go up:"
       ]
     },
     {
@@ -922,7 +922,7 @@
         "\n",
         "Now that the model is trained, we can get some statistics on its performance.\n",
         "\n",
-        "*Evaluating* means determining how effectively the model makes predictions. To determine the model's effectiveness at Iris classification, pass some sepal and petal measurements to the model and ask the model to predict what Iris species they represent. Then compare the model's prediction against the actual label.  For example, a model that picked the correct species on half the input examples has an *[accuracy](https://developers.google.com/machine-learning/glossary/#accuracy)* of `0.5`. Figure 4 shows a slightly more effective model, getting 4 out of 5 predictions correct at 80% accuracy:\n",
+        "*Evaluating* means determining how effectively the model makes predictions. To determine the model's effectiveness at Iris classification, pass some sepal and petal measurements to the model and ask the model to predict what Iris species they represent. Then compare the model's predictions against the actual label.  For example, a model that picked the correct species on half the input examples has an *[accuracy](https://developers.google.com/machine-learning/glossary/#accuracy)* of `0.5`. Figure 4 shows a slightly more effective model, getting 4 out of 5 predictions correct at 80% accuracy:\n",
         "\n",
         "\u003ctable cellpadding=\"8\" border=\"0\"\u003e\n",
         "  \u003ccolgroup\u003e\n",
@@ -1016,7 +1016,7 @@
       "source": [
         "### Evaluate the model on the test dataset\n",
         "\n",
-        "Unlike the training stage, the model only evaluates a single [epoch](https://developers.google.com/machine-learning/glossary/#epoch) of the test data. In the following code cell, we iterate over each example in the test set and compare the model's prediction against the actual label. This is used to measure the model's accuracy across the entire test set."
+        "Unlike the training stage, the model only evaluates a single [epoch](https://developers.google.com/machine-learning/glossary/#epoch) of the test data. In the following code cell, we iterate over each example in the test set and compare the model's prediction against the actual label. This is used to measure the model's accuracy across the entire test set:"
       ]
     },
     {


### PR DESCRIPTION
Small changes to a great [_Custom Training: Walkthrough_](https://www.tensorflow.org/beta/tutorials/eager/custom_training_walkthrough) TensorFlow 2 tutorial: 

1) For consistency: add colons before code samples, capitalize first letters in comments, use "dataset" (one word), swap first to second person
2) Add article "the" to "characteristics" 
3) Change "prediction" to plural
4) "Take a peek" idiom—spelling with 2 "e"s

Any feedback welcome! Cheers