### PR TITLE
:heavy_minus_sign: rm__future__ no needed

### DIFF
--- a/site/en/r2/tutorials/keras/basic_classification.ipynb
+++ b/site/en/r2/tutorials/keras/basic_classification.ipynb
@@ -136,8 +136,6 @@
       },
       "outputs": [],
       "source": [
-        "from __future__ import absolute_import, division, print_function, unicode_literals\n",
-        "\n",
         "# TensorFlow and tf.keras\n",
         "import tensorflow as tf\n",
         "from tensorflow import keras\n",


### PR DESCRIPTION
rm `from __future__ import absolute_import, division, print_function, unicode_literals`