### PR TITLE
Corrected typo and ommission

### DIFF
--- a/site/en/tutorials/estimators/linear.ipynb
+++ b/site/en/tutorials/estimators/linear.ipynb
@@ -93,7 +93,7 @@
         "\n",
         "## Overview\n",
         "\n",
-        "Using census data which contains data a person's age, education, marital status, and occupation (the *features*), we will try to predict whether or not the person earns more than 50,000 dollars a year (the target *label*). We will train a *logistic regression* model that, given an individual's information, outputs a number between 0 and 1—this can be interpreted as the probability that the individual has an annual income of over 50,000 dollars.\n",
+        "Using census data which contains data about a person's age, education, marital status, and occupation (the *features*), we will try to predict whether or not the person earns more than 50,000 dollars a year (the target *label*). We will train a *logistic regression* model that, given an individual's information, outputs a number between 0 and 1—this can be interpreted as the probability that the individual has an annual income of over 50,000 dollars.\n",
         "\n",
         "Key Point: As a modeler and developer, think about how this data is used and the potential benefits and harm a model's predictions can cause. A model like this could reinforce societal biases and disparities. Is each  feature relevant to the problem you want to solve or will it introduce bias? For more information, read about [ML fairness](https://developers.google.com/machine-learning/fairness-overview/).\n",
         "\n",
@@ -517,7 +517,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "Because `Estimators` expect an `input_fn` that takes no arguments, we typically wrap configurable input function into an obejct with the expected signature. For this notebook configure the `train_inpf` to iterate over the data twice:"
+        "Because `Estimators` expect an `input_fn` that takes no arguments, we typically wrap configurable input function into an object with the expected signature. For this notebook configure the `train_inpf` to iterate over the data twice:"
       ]
     },
     {


### PR DESCRIPTION
In the "Overview" section, "about" was missing in describing the data content.
In the "Converting Data into Tensors", object was wrongly spelt