### PR TITLE
Add `save_weights` in HDF5 to save_and_restore_models.ipynb and other

### DIFF
--- a/site/en/r2/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/r2/tutorials/keras/save_and_restore_models.ipynb
@@ -562,9 +562,7 @@
       "source": [
         "## Manually save weights\n",
         "\n",
-        "Above you saw how to load the weights into a model.\n",
-        "\n",
-        "Manually saving the weights is just as simple, use the `Model.save_weights` method. By default, `tf.keras`—and `save_weights` in particular—uses the TensorFlow [checkpoints](../../guide/keras/checkpoints) format with a `.ckpt` extension:"
+        "You have just learned how to load the weights into a model. Manually saving them is just as simple with the `Model.save_weights` method. By default, `tf.keras`—and `save_weights` in particular—uses the TensorFlow [checkpoints](../../guide/keras/checkpoints) format with a `.ckpt` extension (saving in [HDF5](https://js.tensorflow.org/tutorials/import-keras.html) with a `.h5` extension is covered in the [Save and serialize models](../../guide/keras/saving_and_serializing#weights-only_saving_in_savedmodel_format) guide):"
       ]
     },
     {
@@ -582,42 +580,6 @@
         "model = create_model()\n",
         "\n",
         "# Restore the weights\n",
-        "model.load_weights('./checkpoints/my_checkpoint')\n",
-        "\n",
-        "# Evaluate the model\n",
-        "loss,acc = model.evaluate(test_images, test_labels)\n",
-        "print(\"Restored model, accuracy: {:5.2f}%\".format(100*acc))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5RJstmFODBuo",
-        "colab_type": "text"
-      },
-      "source": [
-        "### As an HDF5 file\n",
-        "\n",
-        "You can also save the weights in [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) by specifying the file type to `'h5'` in in the `save_format` parameter, as demonstrated in the [Save and serialize models](../../guide/keras/saving_and_serializing) tutorial:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "_vDhOKBjDCrz",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Save the weights as an HDF5 file\n",
-        "model.save_weights('./checkpoints/my_checkpoint', save_format='h5')\n",
-        "\n",
-        "# Create a new model instance, again\n",
-        "model = create_model()\n",
-        "\n",
-        "# Restore the weights, as before\n",
         "model.load_weights('./checkpoints/my_checkpoint')\n",
         "\n",
         "# Evaluate the model\n",

--- a/site/en/r2/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/r2/tutorials/keras/save_and_restore_models.ipynb
@@ -433,7 +433,7 @@
       "source": [
         "# Include the epoch in the file name (uses `str.format`)\n",
         "checkpoint_path = \"training_2/cp-{epoch:04d}.ckpt\"\n",
-        "checkpoint_dir = os.path.dirname(checkpoint_path_2)\n",
+        "checkpoint_dir = os.path.dirname(checkpoint_path)\n",
         "\n",
         "# Create a callback that saves the model's weights every 5 epochs\n",
         "cp_callback = tf.keras.callbacks.ModelCheckpoint(\n",

--- a/site/en/r2/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/r2/tutorials/keras/save_and_restore_models.ipynb
@@ -915,7 +915,7 @@
       "source": [
         "## What's next\n",
         "\n",
-        "This was a brief guide to saving and loading in with `tf.keras`.\n",
+        "This was a brief guide to saving and loading weights using `tf.keras`.\n",
         "\n",
         "* Take a look at the [guide to tf.keras](https://www.tensorflow.org/guide/keras), which has more exaplnes of saving and loading models.\n",
         "\n",

--- a/site/en/r2/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/r2/tutorials/keras/save_and_restore_models.ipynb
@@ -1,4 +1,20 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "save_and_restore_models.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "accelerator": "GPU"
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -7,19 +23,17 @@
         "id": "g_nWetWWd_ns"
       },
       "source": [
-        "##### Copyright 2018 The TensorFlow Authors."
+        "##### Copyright 2019 The TensorFlow Authors."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "2pHVBk_seED1"
+        "id": "2pHVBk_seED1",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -32,18 +46,18 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "N_fMsQ-N8I7j"
+        "id": "N_fMsQ-N8I7j",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title MIT License\n",
         "#\n",
@@ -66,7 +80,9 @@
         "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
         "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
         "# DEALINGS IN THE SOFTWARE."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -85,20 +101,20 @@
         "id": "M4Ata7_wMul1"
       },
       "source": [
-        "\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/beta/tutorials/keras/save_and_restore_models\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/keras/save_and_restore_models.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/keras/save_and_restore_models.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003eView source on GitHub\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/r2/tutorials/keras/save_and_restore_models.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/download_logo_32px.png\" /\u003eDownload notebook\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "\u003c/table\u003e"
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/beta/tutorials/keras/save_and_restore_models\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/keras/save_and_restore_models.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/keras/save_and_restore_models.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/r2/tutorials/keras/save_and_restore_models.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
+        "</table>"
       ]
     },
     {
@@ -119,7 +135,7 @@
         "\n",
         "### Options\n",
         "\n",
-        "There are different ways to save TensorFlow models—depending on the API you're using. This guide uses [tf.keras](https://www.tensorflow.org/guide/keras), a high-level API to build and train models in TensorFlow. For other approaches, see the TensorFlow  [Save and Restore](https://www.tensorflow.org/guide/saved_model) guide or [Saving in eager](https://www.tensorflow.org/guide/eager#object-based_saving).\n"
+        "There are different ways to save TensorFlow models—depending on the API you're using. This guide uses [tf.keras](https://www.tensorflow.org/guide/keras), a high-level API to build and train models in TensorFlow. For other approaches, see the TensorFlow  [Save and Restore](https://www.tensorflow.org/guide/saved_model) guide or [Saving in eager](https://www.tensorflow.org/guide/eager#object-based_saving)."
       ]
     },
     {
@@ -141,21 +157,22 @@
         "id": "7l0MiTOrXtNv"
       },
       "source": [
-        "Install and import TensorFlow and dependencies:"
+        "Install and import TensorFlow and dependencies, including h5py required for saving models in an [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) format:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "RzIOVSdnMYyO"
+        "id": "RzIOVSdnMYyO",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
+        "!pip install tensorflow==2.0.0-beta1\n",
         "!pip install h5py pyyaml"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -166,39 +183,36 @@
       "source": [
         "### Get an example dataset\n",
         "\n",
-        "We'll use the [MNIST dataset](http://yann.lecun.com/exdb/mnist/) to train our model to demonstrate saving weights. To speed up these demonstration runs, only use the first 1000 examples:"
+        "You'll be using the [MNIST dataset](http://yann.lecun.com/exdb/mnist/) to demonstrate how to save and load weights. To speed up these runs, use the first 1000 examples:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "7Nm7Tyb-gRt-"
+        "id": "7Nm7Tyb-gRt-",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "from __future__ import absolute_import, division, print_function, unicode_literals\n",
         "\n",
         "import os\n",
         "\n",
-        "!pip install tensorflow==2.0.0-beta1\n",
         "import tensorflow as tf\n",
         "from tensorflow import keras\n",
         "\n",
         "tf.__version__"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "9rGfFwE9XVwz"
+        "id": "9rGfFwE9XVwz",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "(train_images, train_labels), (test_images, test_labels) = tf.keras.datasets.mnist.load_data()\n",
         "\n",
@@ -207,7 +221,9 @@
         "\n",
         "train_images = train_images[:1000].reshape(-1, 28 * 28) / 255.0\n",
         "test_images = test_images[:1000].reshape(-1, 28 * 28) / 255.0"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -226,20 +242,18 @@
         "id": "wynsOBfby0Pa"
       },
       "source": [
-        "Let's build a simple model we'll use to demonstrate saving and loading weights."
+        "Start with building a simple sequential model:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "0HZbJIjxyX1S"
+        "id": "0HZbJIjxyX1S",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
-        "# Returns a short sequential model\n",
+        "# Define a simple sequential model\n",
         "def create_model():\n",
         "  model = tf.keras.models.Sequential([\n",
         "    keras.layers.Dense(512, activation='relu', input_shape=(784,)),\n",
@@ -253,11 +267,14 @@
         "\n",
         "  return model\n",
         "\n",
-        "\n",
         "# Create a basic model instance\n",
         "model = create_model()\n",
+        "\n",
+        "# Display the model's architecture\n",
         "model.summary()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -276,43 +293,42 @@
         "id": "mRyd5qQQIXZm"
       },
       "source": [
-        "The primary use case is to automatically save checkpoints *during* and at *the end* of training. This way you can use a trained model without having to retrain it, or pick-up training where you left of—in case the training process was interrupted.\n",
+        "You can use a trained model without having to retrain it, or pick-up training where you left off—in case the training process was interrupted. And `tf.keras.callbacks.ModelCheckpoint` is a callback that performs this kind of task. It allows to continually save the model both *during* and at *the end* of training.\n",
         "\n",
-        "`tf.keras.callbacks.ModelCheckpoint` is a callback that performs this task. The callback takes a couple of arguments to configure checkpointing.\n",
+        "### `ModelCheckpoint` callback usage\n",
         "\n",
-        "### Checkpoint callback usage\n",
-        "\n",
-        "Train the model and pass it the `ModelCheckpoint` callback:"
+        "Create a callback that saves weights only during training:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "IFPuhwntH8VH"
+        "id": "IFPuhwntH8VH",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "checkpoint_path = \"training_1/cp.ckpt\"\n",
         "checkpoint_dir = os.path.dirname(checkpoint_path)\n",
         "\n",
-        "# Create checkpoint callback\n",
-        "cp_callback = tf.keras.callbacks.ModelCheckpoint(checkpoint_path,\n",
+        "# Create a callback that saves the model's weights\n",
+        "cp_callback = tf.keras.callbacks.ModelCheckpoint(filepath=checkpoint_path,\n",
         "                                                 save_weights_only=True,\n",
         "                                                 verbose=1)\n",
         "\n",
-        "model = create_model()\n",
-        "\n",
-        "model.fit(train_images, train_labels,  epochs = 10,\n",
-        "          validation_data = (test_images,test_labels),\n",
-        "          callbacks = [cp_callback])  # pass callback to training\n",
+        "# Train the model with the new callback\n",
+        "model.fit(train_images, \n",
+        "          train_labels,  \n",
+        "          epochs=10,\n",
+        "          validation_data=(test_images,test_labels),\n",
+        "          callbacks=[cp_callback])  # Pass callback to training\n",
         "\n",
         "# This may generate warnings related to saving the state of the optimizer.\n",
         "# These warnings (and similar warnings throughout this notebook)\n",
         "# are in place to discourage outdated usage, and can be ignored."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -326,16 +342,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "gXG5FVKFOVQ3"
+        "id": "gXG5FVKFOVQ3",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "!ls {checkpoint_dir}"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -344,26 +360,28 @@
         "id": "wlRN_f56Pqa9"
       },
       "source": [
-        "Create a new, untrained model. When restoring a model from only weights, you must have a model with the same architecture as the original model. Since it's the same model architecture, we can share weights despite that it's a different *instance* of the model.\n",
+        "Create a new, untrained model. When restoring a model from weights only, you must have a model with the same architecture as the original model. Since it's the same model architecture, we can share weights despite that it's a different *instance* of the model.\n",
         "\n",
         "Now rebuild a fresh, untrained model, and evaluate it on the test set. An untrained model will perform at chance levels (~10% accuracy):"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Fp5gbuiaPqCT"
+        "id": "Fp5gbuiaPqCT",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
+        "# Create a basic model instance\n",
         "model = create_model()\n",
         "\n",
+        "# Evaluate the model\n",
         "loss, acc = model.evaluate(test_images, test_labels)\n",
         "print(\"Untrained model, accuracy: {:5.2f}%\".format(100*acc))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -372,23 +390,26 @@
         "id": "1DTKpZssRSo3"
       },
       "source": [
-        "Then load the weights from the checkpoint, and re-evaluate:"
+        "Then load the weights from the checkpoint and re-evaluate:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "2IZxbwiRRSD2"
+        "id": "2IZxbwiRRSD2",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
+        "# Loads the weights\n",
         "model.load_weights(checkpoint_path)\n",
+        "\n",
+        "# Re-evaluate the model\n",
         "loss,acc = model.evaluate(test_images, test_labels)\n",
         "print(\"Restored model, accuracy: {:5.2f}%\".format(100*acc))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -399,37 +420,44 @@
       "source": [
         "### Checkpoint callback options\n",
         "\n",
-        "The callback provides several options to give the resulting checkpoints unique names, and adjust the checkpointing frequency.\n",
-        "\n",
-        "Train a new model, and save uniquely named checkpoints once every 5-epochs:\n"
+        "You can give the saved checkpoints unique names and adjust the frequency of weight-saving—for example, every 5 epochs—within the `ModelCheckpoint` callback:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "mQF_dlgIVOvq"
+        "id": "mQF_dlgIVOvq",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
-        "# include the epoch in the file name. (uses `str.format`)\n",
+        "# Include the epoch in the file name (uses `str.format`)\n",
         "checkpoint_path = \"training_2/cp-{epoch:04d}.ckpt\"\n",
-        "checkpoint_dir = os.path.dirname(checkpoint_path)\n",
+        "checkpoint_dir = os.path.dirname(checkpoint_path_2)\n",
         "\n",
+        "# Create a callback that saves the model's weights every 5 epochs\n",
         "cp_callback = tf.keras.callbacks.ModelCheckpoint(\n",
-        "    checkpoint_path, verbose=1, save_weights_only=True,\n",
-        "    # Save weights, every 5-epochs.\n",
-        "    period=5)\n",
+        "    filepath=checkpoint_path, \n",
+        "    verbose=1, \n",
+        "    save_weights_only=True,\n",
+        "    period=5) # Save the weights every 5 epochs\n",
         "\n",
+        "# Create a new model instance\n",
         "model = create_model()\n",
+        "\n",
+        "# Save the weights using the `checkpoint_path` format\n",
         "model.save_weights(checkpoint_path.format(epoch=0))\n",
-        "model.fit(train_images, train_labels,\n",
-        "          epochs = 50, callbacks = [cp_callback],\n",
-        "          validation_data = (test_images,test_labels),\n",
-        "          verbose=0)"
-      ]
+        "\n",
+        "# Train the model with the new callback\n",
+        "model.fit(train_images, \n",
+        "              train_labels,\n",
+        "              epochs=50, \n",
+        "              callbacks=[cp_callback],\n",
+        "              validation_data=(test_images,test_labels),\n",
+        "              verbose=0)"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -443,30 +471,30 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "p64q3-V4sXt0"
+        "id": "p64q3-V4sXt0",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "! ls {checkpoint_dir}"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "1AN_fnuyR41H"
+        "id": "1AN_fnuyR41H",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "latest = tf.train.latest_checkpoint(checkpoint_dir)\n",
         "latest"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -482,19 +510,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "3M04jyK-H3QK"
+        "id": "3M04jyK-H3QK",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
+        "# Create a new model instance\n",
         "model = create_model()\n",
+        "\n",
+        "# Load the previously saved weights\n",
         "model.load_weights(latest)\n",
+        "\n",
+        "# Re-evaluate the model\n",
         "loss, acc = model.evaluate(test_images, test_labels)\n",
         "print(\"Restored model, accuracy: {:5.2f}%\".format(100*acc))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -531,29 +564,68 @@
         "\n",
         "Above you saw how to load the weights into a model.\n",
         "\n",
-        "Manually saving the weights is just as simple, use the `Model.save_weights` method."
+        "Manually saving the weights is just as simple, use the `Model.save_weights` method. By default, `tf.keras`—and `save_weights` in particular—uses the TensorFlow [checkpoints](../../guide/keras/checkpoints) format with a `.ckpt` extension:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "R7W5plyZ-u9X"
+        "id": "R7W5plyZ-u9X",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# Save the weights\n",
         "model.save_weights('./checkpoints/my_checkpoint')\n",
         "\n",
-        "# Restore the weights\n",
+        "# Create a new model instance\n",
         "model = create_model()\n",
+        "\n",
+        "# Restore the weights\n",
         "model.load_weights('./checkpoints/my_checkpoint')\n",
         "\n",
+        "# Evaluate the model\n",
         "loss,acc = model.evaluate(test_images, test_labels)\n",
         "print(\"Restored model, accuracy: {:5.2f}%\".format(100*acc))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5RJstmFODBuo",
+        "colab_type": "text"
+      },
+      "source": [
+        "### As an HDF5 file\n",
+        "\n",
+        "You can also save the weights in [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) by specifying the file type to `'h5'` in in the `save_format` parameter, as demonstrated in the [Save and serialize models](../../guide/keras/saving_and_serializing) tutorial:"
       ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "_vDhOKBjDCrz",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Save the weights as an HDF5 file\n",
+        "model.save_weights('./checkpoints/my_checkpoint', save_format='h5')\n",
+        "\n",
+        "# Create a new model instance, again\n",
+        "model = create_model()\n",
+        "\n",
+        "# Restore the weights, as before\n",
+        "model.load_weights('./checkpoints/my_checkpoint')\n",
+        "\n",
+        "# Evaluate the model\n",
+        "loss,acc = model.evaluate(test_images, test_labels)\n",
+        "print(\"Restored model, accuracy: {:5.2f}%\".format(100*acc))"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -564,7 +636,7 @@
       "source": [
         "## Save the entire model\n",
         "\n",
-        "The model and optimizer can be saved to a file that contains both their state (weights and variables), and the model configuration. This allows you to export a model so it can be used without access to the original python code. Since the optimizer-state is recovered you can even resume training from exactly where you left off.\n",
+        "The model and optimizer can be saved to a file that contains both their state (weights and variables) and the model configuration. This allows you to export a model so it can be used without access to the original python code. Since the optimizer-state is recovered, you can even resume training from exactly where you left off.\n",
         "\n",
         "Saving a fully-functional model is very useful—you can load them in TensorFlow.js ([HDF5](https://js.tensorflow.org/tutorials/import-keras.html), [Saved Model](https://js.tensorflow.org/tutorials/import-saved-model.html)) and then train and run them in web browsers, or convert them to run on mobile devices using TensorFlow Lite ([HDF5](https://www.tensorflow.org/lite/convert/python_api#exporting_a_tfkeras_file_), [Saved Model](https://www.tensorflow.org/lite/convert/python_api#exporting_a_savedmodel_))"
       ]
@@ -578,26 +650,28 @@
       "source": [
         "### As an HDF5 file\n",
         "\n",
-        "Keras provides a basic save format using the [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) standard. For our purposes, the saved model can be treated as a single binary blob."
+        "As demonstrated above, Keras provides a basic save format using the [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) standard. For our purposes, the saved model can be treated as a single binary blob:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "m2dkmJVCGUia"
+        "id": "m2dkmJVCGUia",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
+        "# Create a new model instance\n",
         "model = create_model()\n",
         "\n",
+        "# Train the model\n",
         "model.fit(train_images, train_labels, epochs=5)\n",
         "\n",
-        "# Save entire model to a HDF5 file\n",
+        "# Save the entire model to a HDF5 file\n",
         "model.save('my_model.h5')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -606,23 +680,25 @@
         "id": "GWmttMOqS68S"
       },
       "source": [
-        "Now recreate the model from that file:"
+        "Now, recreate the model from that file:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "5NDMO_7kS6Do"
+        "id": "5NDMO_7kS6Do",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
-        "# Recreate the exact same model, including weights and optimizer.\n",
+        "# Recreate the exact same model, including its weights and the optimizer\n",
         "new_model = keras.models.load_model('my_model.h5')\n",
+        "\n",
+        "# Show the model architecture\n",
         "new_model.summary()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -636,17 +712,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "jwEaj9DnTCVA"
+        "id": "jwEaj9DnTCVA",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "loss, acc = new_model.evaluate(test_images, test_labels)\n",
         "print(\"Restored model, accuracy: {:5.2f}%\".format(100*acc))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -691,23 +767,23 @@
         "id": "DSWiSB0Q8c46"
       },
       "source": [
-        "Build a fresh model:"
+        "Build a fresh model, then traing it:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "sI1YvCDFzpl3"
+        "id": "sI1YvCDFzpl3",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "model = create_model()\n",
         "\n",
         "model.fit(train_images, train_labels, epochs=5)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -716,25 +792,25 @@
         "id": "iUvT_3qE8hV5"
       },
       "source": [
-        "Create a `saved_model`, and place it in a time-stamped directory:"
+        "Create a `saved_model`, and place it in a time-stamped directory with `tf.keras.experimental.export_saved_model`:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "sq8fPglI1RWA"
+        "id": "sq8fPglI1RWA",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "import time\n",
         "saved_model_path = \"./saved_models/{}\".format(int(time.time()))\n",
         "\n",
         "tf.keras.experimental.export_saved_model(model, saved_model_path)\n",
         "saved_model_path"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -748,16 +824,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "ZtOvxA7V0iTv"
+        "id": "ZtOvxA7V0iTv",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "!ls saved_models/"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -766,22 +842,24 @@
         "id": "B7qfpvpY9HCe"
       },
       "source": [
-        "Reload a fresh keras model from the saved model."
+        "Reload a fresh Keras model from the saved model:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "0YofwHdN0pxa"
+        "id": "0YofwHdN0pxa",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "new_model = tf.keras.experimental.load_from_saved_model(saved_model_path)\n",
+        "\n",
+        "# Check its architecture\n",
         "new_model.summary()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -790,43 +868,43 @@
         "id": "uWwgNaz19TH2"
       },
       "source": [
-        "Run the restored model."
+        "Run a prediction with the restored model:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Yh5Mu0yOgE5J"
+        "id": "Yh5Mu0yOgE5J",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "model.predict(test_images).shape"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Pc9e6G6w1AWG"
+        "id": "Pc9e6G6w1AWG",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# The model has to be compiled before evaluating.\n",
         "# This step is not required if the saved model is only being deployed.\n",
         "\n",
-        "new_model.compile(optimizer=model.optimizer,  # keep the optimizer that was loaded\n",
-        "              loss='sparse_categorical_crossentropy',\n",
-        "              metrics=['accuracy'])\n",
+        "new_model.compile(optimizer=model.optimizer,  # Keep the optimizer that was loaded\n",
+        "                  loss='sparse_categorical_crossentropy', \n",
+        "                  metrics=['accuracy'])\n",
         "\n",
-        "# Evaluate the restored model.\n",
+        "# Evaluate the restored model\n",
         "loss, acc = new_model.evaluate(test_images, test_labels)\n",
         "print(\"Restored model, accuracy: {:5.2f}%\".format(100*acc))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -835,33 +913,16 @@
         "id": "eUYTzSz5VxL2"
       },
       "source": [
-        "## What's Next\n",
+        "## What's next\n",
         "\n",
-        "That was a quick guide to saving and loading in with `tf.keras`.\n",
+        "This was a brief guide to saving and loading in with `tf.keras`.\n",
         "\n",
-        "* The [tf.keras guide](https://www.tensorflow.org/guide/keras) shows more about saving and loading models with `tf.keras`.\n",
+        "* Take a look at the [guide to tf.keras](https://www.tensorflow.org/guide/keras), which has more exaplnes of saving and loading models.\n",
         "\n",
         "* See [Saving in eager](https://www.tensorflow.org/guide/eager#object_based_saving) for saving during eager execution.\n",
         "\n",
-        "* The [Save and Restore](https://www.tensorflow.org/guide/saved_model) guide has low-level details about TensorFlow saving."
+        "* Explore the [Save and Restore guide](https://www.tensorflow.org/guide/sa ved_model), which covers low-level details about TensorFlow saving."
       ]
     }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [],
-      "name": "save_and_restore_models.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }

--- a/site/en/r2/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/r2/tutorials/keras/save_and_restore_models.ipynb
@@ -7,7 +7,8 @@
       "version": "0.3.2",
       "provenance": [],
       "private_outputs": true,
-      "collapsed_sections": []
+      "collapsed_sections": [],
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",
@@ -157,7 +158,7 @@
         "id": "7l0MiTOrXtNv"
       },
       "source": [
-        "Install and import TensorFlow and dependencies, including h5py required for saving models in an [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) format:"
+        "Install and import TensorFlow and dependencies:"
       ]
     },
     {
@@ -169,22 +170,11 @@
       },
       "source": [
         "!pip install tensorflow==2.0.0-beta1\n",
-        "!pip install h5py pyyaml"
+        "\n",
+        "!pip install pyyaml h5py  # Required to save models in HDF5 format"
       ],
       "execution_count": 0,
       "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "SbGsznErXWt6"
-      },
-      "source": [
-        "### Get an example dataset\n",
-        "\n",
-        "You'll be using the [MNIST dataset](http://yann.lecun.com/exdb/mnist/) to demonstrate how to save and load weights. To speed up these runs, use the first 1000 examples:"
-      ]
     },
     {
       "cell_type": "code",
@@ -201,10 +191,22 @@
         "import tensorflow as tf\n",
         "from tensorflow import keras\n",
         "\n",
-        "tf.__version__"
+        "print(tf.version.VERSION)"
       ],
       "execution_count": 0,
       "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "SbGsznErXWt6"
+      },
+      "source": [
+        "### Get an example dataset\n",
+        "\n",
+        "To demonstrate how to save and load weights, you'll use the [MNIST dataset](http://yann.lecun.com/exdb/mnist/). To speed up these runs, use the first 1000 examples:"
+      ]
     },
     {
       "cell_type": "code",
@@ -242,7 +244,7 @@
         "id": "wynsOBfby0Pa"
       },
       "source": [
-        "Start with building a simple sequential model:"
+        "Start by building a simple sequential model:"
       ]
     },
     {
@@ -293,11 +295,11 @@
         "id": "mRyd5qQQIXZm"
       },
       "source": [
-        "You can use a trained model without having to retrain it, or pick-up training where you left off—in case the training process was interrupted. And `tf.keras.callbacks.ModelCheckpoint` is a callback that performs this kind of task. It allows to continually save the model both *during* and at *the end* of training.\n",
+        "You can use a trained model without having to retrain it, or pick-up training where you left off—in case the training process was interrupted. The `tf.keras.callbacks.ModelCheckpoint` callback allows to continually save the model both *during* and at *the end* of training.\n",
         "\n",
-        "### `ModelCheckpoint` callback usage\n",
+        "### Checkpoint callback usage\n",
         "\n",
-        "Create a callback that saves weights only during training:"
+        "Create a `tf.keras.callbacks.ModelCheckpoint` callback that saves weights only during training:"
       ]
     },
     {
@@ -360,7 +362,7 @@
         "id": "wlRN_f56Pqa9"
       },
       "source": [
-        "Create a new, untrained model. When restoring a model from weights only, you must have a model with the same architecture as the original model. Since it's the same model architecture, we can share weights despite that it's a different *instance* of the model.\n",
+        "Create a new, untrained model. When restoring a model from weights-only, you must have a model with the same architecture as the original model. Since it's the same model architecture, you can share weights despite that it's a different *instance* of the model.\n",
         "\n",
         "Now rebuild a fresh, untrained model, and evaluate it on the test set. An untrained model will perform at chance levels (~10% accuracy):"
       ]
@@ -420,7 +422,9 @@
       "source": [
         "### Checkpoint callback options\n",
         "\n",
-        "You can give the saved checkpoints unique names and adjust the frequency of weight-saving—for example, every 5 epochs—within the `ModelCheckpoint` callback:"
+        "The callback provides several options to provide unique names for checkpoints and adjust the checkpointing frequency.\n",
+        "\n",
+        "Train a new model, and save uniquely named checkpoints once every five epochs:"
       ]
     },
     {
@@ -440,7 +444,7 @@
         "    filepath=checkpoint_path, \n",
         "    verbose=1, \n",
         "    save_weights_only=True,\n",
-        "    period=5) # Save the weights every 5 epochs\n",
+        "    period=5)\n",
         "\n",
         "# Create a new model instance\n",
         "model = create_model()\n",
@@ -562,7 +566,7 @@
       "source": [
         "## Manually save weights\n",
         "\n",
-        "You have just learned how to load the weights into a model. Manually saving them is just as simple with the `Model.save_weights` method. By default, `tf.keras`—and `save_weights` in particular—uses the TensorFlow [checkpoints](../../guide/keras/checkpoints) format with a `.ckpt` extension (saving in [HDF5](https://js.tensorflow.org/tutorials/import-keras.html) with a `.h5` extension is covered in the [Save and serialize models](../../guide/keras/saving_and_serializing#weights-only_saving_in_savedmodel_format) guide):"
+        "You saw how to load the weights into a model. Manually saving them is just as simple with the `Model.save_weights` method. By default, `tf.keras`—and `save_weights` in particular—uses the TensorFlow [checkpoints](../../guide/keras/checkpoints) format with a `.ckpt` extension (saving in [HDF5](https://js.tensorflow.org/tutorials/import-keras.html) with a `.h5` extension is covered in the [Save and serialize models](../../guide/keras/saving_and_serializing#weights-only_saving_in_savedmodel_format) guide):"
       ]
     },
     {
@@ -598,7 +602,7 @@
       "source": [
         "## Save the entire model\n",
         "\n",
-        "The model and optimizer can be saved to a file that contains both their state (weights and variables) and the model configuration. This allows you to export a model so it can be used without access to the original python code. Since the optimizer-state is recovered, you can even resume training from exactly where you left off.\n",
+        "The model and optimizer can be saved to a file that contains both their state (weights and variables) and the model configuration. This allows you to export a model so it can be used without access to the original Python code. Since the optimizer-state is recovered, you can resume training from exactly where you left off.\n",
         "\n",
         "Saving a fully-functional model is very useful—you can load them in TensorFlow.js ([HDF5](https://js.tensorflow.org/tutorials/import-keras.html), [Saved Model](https://js.tensorflow.org/tutorials/import-saved-model.html)) and then train and run them in web browsers, or convert them to run on mobile devices using TensorFlow Lite ([HDF5](https://www.tensorflow.org/lite/convert/python_api#exporting_a_tfkeras_file_), [Saved Model](https://www.tensorflow.org/lite/convert/python_api#exporting_a_savedmodel_))"
       ]
@@ -610,9 +614,9 @@
         "id": "SkGwf-50zLNn"
       },
       "source": [
-        "### As an HDF5 file\n",
+        "### Save model as an HDF5 file\n",
         "\n",
-        "As demonstrated above, Keras provides a basic save format using the [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) standard. For our purposes, the saved model can be treated as a single binary blob:"
+        "Keras also provides a basic save format using the [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) standard. For our purposes, the saved model can be treated as a single binary blob:"
       ]
     },
     {
@@ -719,17 +723,9 @@
         "id": "LtcN4VIb7JkK"
       },
       "source": [
-        "Caution: This method of saving a `tf.keras` model is experimental and may change in future versions."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "DSWiSB0Q8c46"
-      },
-      "source": [
-        "Build a fresh model, then traing it:"
+        "Caution: This method of saving a `tf.keras` model is experimental and may change in future versions.\n",
+        "\n",
+        "Build a new model, then train it:"
       ]
     },
     {
@@ -867,24 +863,6 @@
       ],
       "execution_count": 0,
       "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "eUYTzSz5VxL2"
-      },
-      "source": [
-        "## What's next\n",
-        "\n",
-        "This was a brief guide to saving and loading weights using `tf.keras`.\n",
-        "\n",
-        "* Take a look at the [guide to tf.keras](https://www.tensorflow.org/guide/keras), which has more exaplnes of saving and loading models.\n",
-        "\n",
-        "* See [Saving in eager](https://www.tensorflow.org/guide/eager#object_based_saving) for saving during eager execution.\n",
-        "\n",
-        "* Explore the [Save and Restore guide](https://www.tensorflow.org/guide/sa ved_model), which covers low-level details about TensorFlow saving."
-      ]
     }
   ]
 }


### PR DESCRIPTION
Suggestions for the Keras Save and Restore Models tutorial (TensorFlow 2.0 Beta1):

- Add a `save_weights` **in HDF5** section: the TensorFlow default `.ckpt` vs Keras `.h5` weights files were discussed during one of the TF2 community testing calls, sometimes it may create confusion, so maybe we should emphasize how to switch between the two more often in various tutorials, just in case
- Add other minor fixes, suggestions, UX improvements in line with the Google Docs style guide

@lamberta @MarkDaoust @yashk2810 this is the first time I used Colab to make changes, hopefully it didn't break anything important, as Jsons are very delicate