### PR TITLE
KO: ko/README.md not-to-translate term fix

### DIFF
--- a/site/ko/README.md
+++ b/site/ko/README.md
@@ -127,7 +127,6 @@ translate the following words:
 *   node
 *   nueron
 *   target
-*   import
 *   checkpoint
 *   compile
 *   dropout

--- a/site/ko/README.md
+++ b/site/ko/README.md
@@ -131,3 +131,7 @@ translate the following words:
 *   compile
 *   dropout
 *   penalty
+
+If you have any suggestion about translation guide, feel free to contact
+[Korean TensorFlow Documentation Translation Glossary](http://bit.ly/tf-docs-translation-glossary)
+spreadsheet.


### PR DESCRIPTION
Summary : removed not-to-translate term "import"(가져오기)

in #808, 'import' is able to translate '가져오기', but he is hesitating to change the word.
From this PR, I suggest to remove 'import'.
Thanks. 👍