### PR TITLE
Fixes link in tf.keras.callbacks

### DIFF
--- a/site/en/api_docs/python/tf/keras/callbacks.md
+++ b/site/en/api_docs/python/tf/keras/callbacks.md
@@ -14,7 +14,7 @@ page_type: reference
 
 
 
-Defined in [`python/keras/api/_v1/keras/callbacks/__init__.py`](https://github.com/tensorflow/tensorflow/tree/r1.14/tensorflow/python/keras/api/_v1/keras/callbacks/__init__.py).
+Defined in [`python/keras/keras/callbacks.py`](https://github.com/tensorflow/tensorflow/blob/r1.14/tensorflow/python/keras/callbacks.py).
 
 <!-- Placeholder for "Used in" -->
 


### PR DESCRIPTION
Solves part of the issue [#29950](https://github.com/tensorflow/tensorflow/issues/29950), that raises some not found links in tf.keras callbacks.