### PR TITLE
Initial porting of Intro to Estimators to TF2 notebook

### DIFF
--- a/site/en/r2/guide/estimators/_index.ipynb
+++ b/site/en/r2/guide/estimators/_index.ipynb
@@ -1,0 +1,398 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "index.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [
+        "Tce3stUlHN0L"
+      ],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Tce3stUlHN0L"
+      },
+      "source": [
+        "##### Copyright 2019 The TensorFlow Authors."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "cellView": "form",
+        "colab_type": "code",
+        "id": "tuOe1ymfHZPu",
+        "colab": {}
+      },
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "qFdPvlXBOdUN"
+      },
+      "source": [
+        "# Estimators"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "MfBg1C5NB3X0"
+      },
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/beta/guide/estimators\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/guide/estimators/_index.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/guide/estimators/_index.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/r2/guide/estimators/_index.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "oEinLJt2Uowq",
+        "colab_type": "text"
+      },
+      "source": [
+        "This document introduces `tf.estimator`—a high-level TensorFlow\n",
+        "API that greatly simplifies machine learning programming. Estimators encapsulate\n",
+        "the following actions:\n",
+        "\n",
+        "* training\n",
+        "* evaluation\n",
+        "* prediction\n",
+        "* export for serving\n",
+        "\n",
+        "You may either use the pre-made Estimators we provide or write your\n",
+        "own custom Estimators.  All Estimators—whether pre-made or custom—are\n",
+        "classes based on the `tf.estimator.Estimator` class.\n",
+        "\n",
+        "For a quick example try [Estimator tutorials](../../tutorials/estimators/linear.ipynb). For an overview of the API design, see the [white paper](https://arxiv.org/abs/1708.02637).\n",
+        "\n",
+        "Note: TensorFlow also includes a deprecated `Estimator` class at\n",
+        "`tf.contrib.learn.Estimator`, which you should not use."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yQ8fQYt_VD5E",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Estimator advantages\n",
+        "\n",
+        "Estimators provide the following benefits:\n",
+        "\n",
+        "* You can run Estimator-based models on a local host or on a distributed multi-server environment without changing your model. Furthermore, you can run Estimator-based models on CPUs, GPUs, or TPUs without recoding your model.\n",
+        "* Estimators simplify sharing implementations between model developers.\n",
+        "* You can develop a state of the art model with high-level intuitive code. In short, it is generally much easier to create models with Estimators than with the low-level TensorFlow APIs.\n",
+        "* Estimators are themselves built on `tf.keras.layers`, which simplifies customization.\n",
+        "* Estimators build the graph for you.\n",
+        "* Estimators provide a safe distributed training loop that controls how and when to:    \n",
+        "    * build the graph\n",
+        "    * initialize variables\n",
+        "    * load data\n",
+        "    * handle exceptions\n",
+        "    * create checkpoint files and recover from failures\n",
+        "    * save summaries for TensorBoard\n",
+        "\n",
+        "When writing an application with Estimators, you must separate the data input\n",
+        "pipeline from the model.  This separation simplifies experiments with\n",
+        "different data sets."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sXNBeY-oVxGQ",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Pre-made Estimators\n",
+        "\n",
+        "Pre-made Estimators enable you to work at a much higher conceptual level than the base TensorFlow APIs. You no longer have to worry about creating the computational graph or sessions since Estimators handle all the \"plumbing\" for you. Furthermore, pre-made Estimators let you experiment with different model architectures by making only minimal code changes.  `tf.estimator.DNNClassifier`, for example, is a pre-made Estimator class that trains classification models based on dense, feed-forward neural networks.\n",
+        "\n",
+        "### Structure of a pre-made Estimators program\n",
+        "\n",
+        "A TensorFlow program relying on a pre-made Estimator typically consists of the following four steps:\n",
+        "\n",
+        "#### 1. Write one or more dataset importing functions.\n",
+        "\n",
+        "For example, you might create one function to import the training set and another function to import the test set. Each dataset importing function must return two objects:\n",
+        "\n",
+        "* a dictionary in which the keys are feature names and the values are Tensors (or SparseTensors) containing the corresponding feature data\n",
+        "* a Tensor containing one or more labels\n",
+        "\n",
+        "For example, the following code illustrates the basic skeleton for an input function:\n",
+        "\n",
+        "```\n",
+        "def input_fn(dataset):\n",
+        "    ...  # manipulate dataset, extracting the feature dict and the label\n",
+        "    return feature_dict, label\n",
+        "```\n",
+        "\n",
+        "See [data guide](../../guide/data.md) for details.\n",
+        "\n",
+        "#### 2. Define the feature columns.\n",
+        "\n",
+        "Each `tf.feature_column` identifies a feature name, its type, and any input pre-processing. For example, the following snippet creates three feature columns that hold integer or floating-point data. The first two feature columns simply identify the feature's name and type. The third feature column also specifies a lambda the program will invoke to scale the raw data:\n",
+        "\n",
+        "```\n",
+        "# Define three numeric feature columns.\n",
+        "population = tf.feature_column.numeric_column('population')\n",
+        "crime_rate = tf.feature_column.numeric_column('crime_rate')\n",
+        "median_education = tf.feature_column.numeric_column(\n",
+        "  'median_education',\n",
+        "  normalizer_fn=lambda x: x - global_education_mean)\n",
+        "```\n",
+        "\n",
+        "#### 3. Instantiate the relevant pre-made Estimator.\n",
+        "\n",
+        "For example, here's a sample instantiation of a pre-made Estimator named `LinearClassifier`:\n",
+        "\n",
+        "```\n",
+        "# Instantiate an estimator, passing the feature columns.\n",
+        "estimator = tf.estimator.LinearClassifier(\n",
+        "  feature_columns=[population, crime_rate, median_education])\n",
+        "```\n",
+        "\n",
+        "#### 4. Call a training, evaluation, or inference method.\n",
+        "\n",
+        "For example, all Estimators provide a `train` method, which trains a model.\n",
+        "\n",
+        "```\n",
+        "# `input_fn` is the function created in Step 1\n",
+        "estimator.train(input_fn=my_training_set, steps=2000)\n",
+        "```\n",
+        "\n",
+        "\n",
+        "### Benefits of pre-made Estimators\n",
+        "\n",
+        "Pre-made Estimators encode best practices, providing the following benefits:\n",
+        "\n",
+        "* Best practices for determining where different parts of the computational graph should run, implementing strategies on a single machine or on a\n",
+        "    cluster.\n",
+        "*   Best practices for event (summary) writing and universally useful\n",
+        "    summaries.\n",
+        "\n",
+        "If you don't use pre-made Estimators, you must implement the preceding features yourself."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "oIaPjYgnZdn6",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Custom Estimators\n",
+        "\n",
+        "The heart of every Estimator—whether pre-made or custom—is its *model function*, which is a method that builds graphs for training, evaluation, and prediction. When you are using a pre-made Estimator, someone else has already implemented the model function. When relying on a custom Estimator, you must write the model function yourself.\n",
+        "\n",
+        "## Recommended workflow\n",
+        "\n",
+        "1. Assuming a suitable pre-made Estimator exists, use it to build your first model and use its results to establish a baseline.\n",
+        "2. Build and test your overall pipeline, including the integrity and reliability of your data with this pre-made Estimator.\n",
+        "3. If suitable alternative pre-made Estimators are available, run experiments to determine which pre-made Estimator produces the best results.\n",
+        "4. Possibly, further improve your model by building your own custom Estimator."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "IqR2PQG4ZaZ0",
+        "colab": {}
+      },
+      "source": [
+        "from __future__ import absolute_import, division, print_function, unicode_literals\n",
+        "\n",
+        "!pip install tensorflow==2.0.0-beta1\n",
+        "import tensorflow as tf"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "P7aPNnXUbN4j",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Create an Estimator from a Keras model\n",
+        "\n",
+        "You can convert existing Keras models to Estimators with `tf.keras.estimator.model_to_estimator`. Doing so enables your Keras\n",
+        "model to access Estimator's strengths, such as distributed training.\n",
+        "\n",
+        "Instantiate a Keras inception v3 model and compile the model with the optimizer, loss, and metrics to train with:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "XE6NMcuGeDOP",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "keras_inception_v3 = tf.keras.applications.inception_v3.InceptionV3(weights=None)\n",
+        "\n",
+        "# Compile the model\n",
+        "keras_inception_v3.compile(\n",
+        "    optimizer=tf.keras.optimizers.SGD(lr=0.0001, momentum=0.9),\n",
+        "    loss='categorical_crossentropy',\n",
+        "    metric='accuracy')"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "A3hcxzcEfYfX",
+        "colab_type": "text"
+      },
+      "source": [
+        "Create an `Estimator` from the compiled Keras model. The initial model state of the Keras model is preserved in the created `Estimator`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "UCSSifirfyHk",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "est_inception_v3 = tf.keras.estimator.model_to_estimator(keras_model=keras_inception_v3)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8jRNRVb_fzGT",
+        "colab_type": "text"
+      },
+      "source": [
+        "Treat the derived `Estimator` as you would with any other `Estimator`. First, recover the input name(s) of Keras model to use them as the feature column name(s) of the `Estimator` input function:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "_LWiE6UCgIG4",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "keras_inception_v3.input_names"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fNW0xkAcgMhR",
+        "colab_type": "text"
+      },
+      "source": [
+        "WIth the input name(s), create the input function, for example, for input(s) in the format of numpy ndarray:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "y4VL6Ly7gaG5",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "train_input_fn = tf.compat.v1.estimator.inputs.numpy_input_fn(\n",
+        "    x={\"input_1\": train_data},\n",
+        "    y=train_labels,\n",
+        "    num_epochs=1,\n",
+        "    shuffle=False)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JMb0cuy0gbTi",
+        "colab_type": "text"
+      },
+      "source": [
+        "To train, call Estimator's train function:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "4JsvMp8Jge80",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "est_inception_v3.train(input_fn=train_input_fn, steps=2000)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5HeTOvCYbjZb",
+        "colab_type": "text"
+      },
+      "source": [
+        "The names of feature columns and labels of a keras estimator come from the corresponding compiled keras model. For example, the input key names for `train_input_fn` above can be obtained from `keras_inception_v3.input_names`, and similarly, the predicted output names can be obtained from `keras_inception_v3.output_names`.\n",
+        "\n",
+        "For more details, please refer to the documentation for `tf.keras.estimator.model_to_estimator`."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Initial port of the [Intro to Estimators](https://www.tensorflow.org/guide/estimators) guide to a TF2 notebook.

Does not run completely since `train_data` needs to be mocked or use a more interesting dataset.
