### PR TITLE
make inline comment match running text

### DIFF
--- a/site/en/guide/tensors.md
+++ b/site/en/guide/tensors.md
@@ -99,7 +99,7 @@ mymatC = tf.Variable([[7],[11]], tf.int32)
 
 Higher-rank Tensors, similarly, consist of an n-dimensional array. For example,
 during image processing, many tensors of rank 4 are used, with dimensions
-corresponding to example-in-batch, image width, image height, and color channel.
+corresponding to example-in-batch, image height, image width, and color channel.
 
 ``` python
 my_image = tf.zeros([10, 299, 299, 3])  # batch x height x width x color


### PR DESCRIPTION
The ordering of the spatial dimensions is mismatching in the running text and the inline python comment. Which one is correct? I think the most common convention is `batch_size x height x width x channels` if `channels_first=False`. See the [TensorFlow Hub documentation](https://www.tensorflow.org/hub/common_signatures/images).