### PR TITLE
 use tf.version.VERSION because tf.VERSION is deprecated

### DIFF
--- a/site/ja/guide/keras.ipynb
+++ b/site/ja/guide/keras.ipynb
@@ -164,7 +164,7 @@
         "import tensorflow as tf\n",
         "from tensorflow.keras import layers\n",
         "\n",
-        "print(tf.VERSION)\n",
+        "print(tf.version.VERSION)\n",
         "print(tf.keras.__version__)"
       ],
       "execution_count": 0,


### PR DESCRIPTION
 use tf.version.VERSION because tf.VERSION is deprecated in keras getting started.

> W0731 15:35:56.917445 4494173632 deprecation_wrapper.py:119] From check_import.py:5: The name tf.VERSION is deprecated. Please use tf.version.VERSION instead.