### PR TITLE
update plot methods in Make predictions section

### DIFF
--- a/site/en/r2/tutorials/keras/basic_classification.ipynb
+++ b/site/en/r2/tutorials/keras/basic_classification.ipynb
@@ -124,7 +124,7 @@
         "id": "FbVhjPpzn6BM"
       },
       "source": [
-        "This guide trains a neural network model to classify images of clothing, like sneakers and shirts. It's okay if you don't understand all the details; this is a fast-paced overview of a complete TensorFlow program with the details explained as we go.\n",
+        "This guide trains a neural network model to classify images of clothing, like sneakers and shirts. It's okay if you don't understand all the details; this is a fast-paced overview of a complete TensorFlow program with the details explained as you go.\n",
         "\n",
         "This guide uses [tf.keras](https://www.tensorflow.org/guide/keras), a high-level API to build and train models in TensorFlow."
       ]
@@ -194,11 +194,11 @@
         "  </td></tr>\n",
         "</table>\n",
         "\n",
-        "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. The MNIST dataset contains images of handwritten digits (0, 1, 2, etc.) in a format identical to that of the articles of clothing we'll use here.\n",
+        "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. The MNIST dataset contains images of handwritten digits (0, 1, 2, etc.) in a format identical to that of the articles of clothing you'll use here.\n",
         "\n",
         "This guide uses Fashion MNIST for variety, and because it's a slightly more challenging problem than regular MNIST. Both datasets are relatively small and are used to verify that an algorithm works as expected. They're good starting points to test and debug code.\n",
         "\n",
-        "We will use 60,000 images to train the network and 10,000 images to evaluate how accurately the network learned to classify images. You can access the Fashion MNIST directly from TensorFlow. Import and load the Fashion MNIST data directly from TensorFlow:"
+        "Here, 60,000 images are used to train the network and 10,000 images to evaluate how accurately the network learned to classify images. You can access the Fashion MNIST directly from TensorFlow. Import and load the Fashion MNIST data directly from TensorFlow:"
       ]
     },
     {
@@ -447,7 +447,7 @@
         "id": "Wz7l27Lz9S1P"
       },
       "source": [
-        "We scale these values to a range of 0 to 1 before feeding them to the neural network model. To do so, we divide the values by 255. It's important that the *training set* and the *testing set* be preprocessed in the same way:"
+        "Scale these values to a range of 0 to 1 before feeding them to the neural network model. To do so, divide the values by 255. It's important that the *training set* and the *testing set* be preprocessed in the same way:"
       ]
     },
     {
@@ -472,7 +472,7 @@
         "id": "Ee638AlnCaWz"
       },
       "source": [
-        "To verify that the data is in the correct format and that we're ready to build and train the network, let's display the first 25 images from the *training set* and display the class name below each image."
+        "To verify that the data is in the correct format and that you're ready to build and train the network, let's display the first 25 images from the *training set* and display the class name below each image."
       ]
     },
     {
@@ -554,7 +554,7 @@
         "\n",
         "Before the model is ready for training, it needs a few more settings. These are added during the model's *compile* step:\n",
         "\n",
-        "* *Loss function* —This measures how accurate the model is during training. We want to minimize this function to \"steer\" the model in the right direction.\n",
+        "* *Loss function* —This measures how accurate the model is during training. You want to minimize this function to \"steer\" the model in the right direction.\n",
         "* *Optimizer* —This is how the model is updated based on the data it sees and its loss function.\n",
         "* *Metrics* —Used to monitor the training and testing steps. The following example uses *accuracy*, the fraction of the images that are correctly classified."
       ]
@@ -587,7 +587,7 @@
         "\n",
         "1. Feed the training data to the model. In this example, the training data is in the `train_images` and `train_labels` arrays.\n",
         "2. The model learns to associate images and labels.\n",
-        "3. We ask the model to make predictions about a test set—in this example, the `test_images` array. We verify that the predictions match the labels from the `test_labels` array.\n",
+        "3. You ask the model to make predictions about a test set—in this example, the `test_images` array. Verify that the predictions match the labels from the `test_labels` array.\n",
         "\n",
         "To start training,  call the `model.fit` method—so called because it \"fits\" the model to the training data:"
       ]
@@ -661,7 +661,7 @@
       "source": [
         "## Make predictions\n",
         "\n",
-        "With the model trained, we can use it to make predictions about some images."
+        "With the model trained, you can use it to make predictions about some images."
       ]
     },
     {
@@ -707,7 +707,7 @@
         "id": "-hw1hgeSCaXN"
       },
       "source": [
-        "A prediction is an array of 10 numbers. They represent the model's \"confidence\" that the image corresponds to each of the 10 different articles of clothing. We can see which label has the highest confidence value:"
+        "A prediction is an array of 10 numbers. They represent the model's \"confidence\" that the image corresponds to each of the 10 different articles of clothing. You can see which label has the highest confidence value:"
       ]
     },
     {
@@ -753,7 +753,7 @@
         "id": "ygh2yYC972ne"
       },
       "source": [
-        "We can graph this to look at the full set of 10 class predictions."
+        "Graph this to look at the full set of 10 class predictions."
       ]
     },
     {
@@ -914,7 +914,7 @@
         "id": "vz3bVp21CaXV"
       },
       "source": [
-        "`tf.keras` models are optimized to make predictions on a *batch*, or collection, of examples at once. Accordingly, even though we're using a single image, we need to add it to a list:"
+        "`tf.keras` models are optimized to make predictions on a *batch*, or collection, of examples at once. Accordingly, even though you're using a single image, you need to add it to a list:"
       ]
     },
     {
@@ -1002,7 +1002,7 @@
         "id": "YFc2HbEVCaXd"
       },
       "source": [
-        "And, as before, the model predicts a label of 2."
+        "And the model predicts a label of 2."
       ]
     }
   ]

--- a/site/en/r2/tutorials/keras/basic_classification.ipynb
+++ b/site/en/r2/tutorials/keras/basic_classification.ipynb
@@ -1,4 +1,20 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "basic_classification.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -12,14 +28,12 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "_ckMIh7O7s6D"
+        "id": "_ckMIh7O7s6D",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -32,18 +46,18 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "vasWnqRgy1H4"
+        "id": "vasWnqRgy1H4",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title MIT License\n",
         "#\n",
@@ -66,7 +80,9 @@
         "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
         "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
         "# DEALINGS IN THE SOFTWARE."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -85,20 +101,20 @@
         "id": "S5Uhzt6vVIB2"
       },
       "source": [
-        "\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/beta/tutorials/keras/basic_classification\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/keras/basic_classification.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/keras/basic_classification.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003eView source on GitHub\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/r2/tutorials/keras/basic_classification.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/download_logo_32px.png\" /\u003eDownload notebook\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "\u003c/table\u003e"
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/beta/tutorials/keras/basic_classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/r2/tutorials/keras/basic_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/r2/tutorials/keras/basic_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/r2/tutorials/keras/basic_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
+        "</table>"
       ]
     },
     {
@@ -115,26 +131,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "jL3OqFKZ9dFg"
+        "id": "jL3OqFKZ9dFg",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "!pip install tensorflow==2.0.0-beta1"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "dzLKpmZICaWN"
+        "id": "dzLKpmZICaWN",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "from __future__ import absolute_import, division, print_function, unicode_literals\n",
         "\n",
@@ -147,7 +161,9 @@
         "import matplotlib.pyplot as plt\n",
         "\n",
         "print(tf.__version__)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -168,15 +184,15 @@
       "source": [
         "This guide uses the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset which contains 70,000 grayscale images in 10 categories. The images show individual articles of clothing at low resolution (28 by 28 pixels), as seen here:\n",
         "\n",
-        "\u003ctable\u003e\n",
-        "  \u003ctr\u003e\u003ctd\u003e\n",
-        "    \u003cimg src=\"https://tensorflow.org/images/fashion-mnist-sprite.png\"\n",
-        "         alt=\"Fashion MNIST sprite\"  width=\"600\"\u003e\n",
-        "  \u003c/td\u003e\u003c/tr\u003e\n",
-        "  \u003ctr\u003e\u003ctd align=\"center\"\u003e\n",
-        "    \u003cb\u003eFigure 1.\u003c/b\u003e \u003ca href=\"https://github.com/zalandoresearch/fashion-mnist\"\u003eFashion-MNIST samples\u003c/a\u003e (by Zalando, MIT License).\u003cbr/\u003e\u0026nbsp;\n",
-        "  \u003c/td\u003e\u003c/tr\u003e\n",
-        "\u003c/table\u003e\n",
+        "<table>\n",
+        "  <tr><td>\n",
+        "    <img src=\"https://tensorflow.org/images/fashion-mnist-sprite.png\"\n",
+        "         alt=\"Fashion MNIST sprite\"  width=\"600\">\n",
+        "  </td></tr>\n",
+        "  <tr><td align=\"center\">\n",
+        "    <b>Figure 1.</b> <a href=\"https://github.com/zalandoresearch/fashion-mnist\">Fashion-MNIST samples</a> (by Zalando, MIT License).<br/>&nbsp;\n",
+        "  </td></tr>\n",
+        "</table>\n",
         "\n",
         "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. The MNIST dataset contains images of handwritten digits (0, 1, 2, etc.) in a format identical to that of the articles of clothing we'll use here.\n",
         "\n",
@@ -187,18 +203,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "7MqDQO0KCaWS"
+        "id": "7MqDQO0KCaWS",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "fashion_mnist = keras.datasets.fashion_mnist\n",
         "\n",
         "(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -214,69 +230,69 @@
         "\n",
         "The images are 28x28 NumPy arrays, with pixel values ranging from 0 to 255. The *labels* are an array of integers, ranging from 0 to 9. These correspond to the *class* of clothing the image represents:\n",
         "\n",
-        "\u003ctable\u003e\n",
-        "  \u003ctr\u003e\n",
-        "    \u003cth\u003eLabel\u003c/th\u003e\n",
-        "    \u003cth\u003eClass\u003c/th\u003e\n",
-        "  \u003c/tr\u003e\n",
-        "  \u003ctr\u003e\n",
-        "    \u003ctd\u003e0\u003c/td\u003e\n",
-        "    \u003ctd\u003eT-shirt/top\u003c/td\u003e\n",
-        "  \u003c/tr\u003e\n",
-        "  \u003ctr\u003e\n",
-        "    \u003ctd\u003e1\u003c/td\u003e\n",
-        "    \u003ctd\u003eTrouser\u003c/td\u003e\n",
-        "  \u003c/tr\u003e\n",
-        "    \u003ctr\u003e\n",
-        "    \u003ctd\u003e2\u003c/td\u003e\n",
-        "    \u003ctd\u003ePullover\u003c/td\u003e\n",
-        "  \u003c/tr\u003e\n",
-        "    \u003ctr\u003e\n",
-        "    \u003ctd\u003e3\u003c/td\u003e\n",
-        "    \u003ctd\u003eDress\u003c/td\u003e\n",
-        "  \u003c/tr\u003e\n",
-        "    \u003ctr\u003e\n",
-        "    \u003ctd\u003e4\u003c/td\u003e\n",
-        "    \u003ctd\u003eCoat\u003c/td\u003e\n",
-        "  \u003c/tr\u003e\n",
-        "    \u003ctr\u003e\n",
-        "    \u003ctd\u003e5\u003c/td\u003e\n",
-        "    \u003ctd\u003eSandal\u003c/td\u003e\n",
-        "  \u003c/tr\u003e\n",
-        "    \u003ctr\u003e\n",
-        "    \u003ctd\u003e6\u003c/td\u003e\n",
-        "    \u003ctd\u003eShirt\u003c/td\u003e\n",
-        "  \u003c/tr\u003e\n",
-        "    \u003ctr\u003e\n",
-        "    \u003ctd\u003e7\u003c/td\u003e\n",
-        "    \u003ctd\u003eSneaker\u003c/td\u003e\n",
-        "  \u003c/tr\u003e\n",
-        "    \u003ctr\u003e\n",
-        "    \u003ctd\u003e8\u003c/td\u003e\n",
-        "    \u003ctd\u003eBag\u003c/td\u003e\n",
-        "  \u003c/tr\u003e\n",
-        "    \u003ctr\u003e\n",
-        "    \u003ctd\u003e9\u003c/td\u003e\n",
-        "    \u003ctd\u003eAnkle boot\u003c/td\u003e\n",
-        "  \u003c/tr\u003e\n",
-        "\u003c/table\u003e\n",
+        "<table>\n",
+        "  <tr>\n",
+        "    <th>Label</th>\n",
+        "    <th>Class</th>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td>0</td>\n",
+        "    <td>T-shirt/top</td>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td>1</td>\n",
+        "    <td>Trouser</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>2</td>\n",
+        "    <td>Pullover</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>3</td>\n",
+        "    <td>Dress</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>4</td>\n",
+        "    <td>Coat</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>5</td>\n",
+        "    <td>Sandal</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>6</td>\n",
+        "    <td>Shirt</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>7</td>\n",
+        "    <td>Sneaker</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>8</td>\n",
+        "    <td>Bag</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>9</td>\n",
+        "    <td>Ankle boot</td>\n",
+        "  </tr>\n",
+        "</table>\n",
         "\n",
         "Each image is mapped to a single label. Since the *class names* are not included with the dataset, store them here to use later when plotting the images:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "IjnLH5S2CaWx"
+        "id": "IjnLH5S2CaWx",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "class_names = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',\n",
         "               'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -292,16 +308,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "zW5k_xz1CaWX"
+        "id": "zW5k_xz1CaWX",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "train_images.shape"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -315,16 +331,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "TRFYHB2mCaWb"
+        "id": "TRFYHB2mCaWb",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "len(train_labels)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -338,16 +354,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "XKnCTHz4CaWg"
+        "id": "XKnCTHz4CaWg",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "train_labels"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -361,16 +377,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "2KFnYlcwCaWl"
+        "id": "2KFnYlcwCaWl",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "test_images.shape"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -384,16 +400,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "iJmPr5-ACaWn"
+        "id": "iJmPr5-ACaWn",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "len(test_labels)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -409,20 +425,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "m4VEw8Ud9Quh"
+        "id": "m4VEw8Ud9Quh",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "plt.figure()\n",
         "plt.imshow(train_images[0])\n",
         "plt.colorbar()\n",
         "plt.grid(False)\n",
         "plt.show()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -436,18 +452,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "bW5WzIPlCaWv"
+        "id": "bW5WzIPlCaWv",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "train_images = train_images / 255.0\n",
         "\n",
         "test_images = test_images / 255.0"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -461,13 +477,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "oZTImqg_CaW1"
+        "id": "oZTImqg_CaW1",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "plt.figure(figsize=(10,10))\n",
         "for i in range(25):\n",
@@ -478,7 +492,9 @@
         "    plt.imshow(train_images[i], cmap=plt.cm.binary)\n",
         "    plt.xlabel(class_names[train_labels[i]])\n",
         "plt.show()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -508,20 +524,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "9ODch-OFCaW4"
+        "id": "9ODch-OFCaW4",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "model = keras.Sequential([\n",
         "    keras.layers.Flatten(input_shape=(28, 28)),\n",
         "    keras.layers.Dense(128, activation='relu'),\n",
         "    keras.layers.Dense(10, activation='softmax')\n",
         "])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -545,18 +561,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Lhan11blCaW7"
+        "id": "Lhan11blCaW7",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "model.compile(optimizer='adam',\n",
         "              loss='sparse_categorical_crossentropy',\n",
         "              metrics=['accuracy'])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -578,16 +594,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "xvwvpA64CaW_"
+        "id": "xvwvpA64CaW_",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "model.fit(train_images, train_labels, epochs=10)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -613,18 +629,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "VflXLEeECaXC"
+        "id": "VflXLEeECaXC",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "test_loss, test_acc = model.evaluate(test_images, test_labels)\n",
         "\n",
         "print('\\nTest accuracy:', test_acc)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -650,16 +666,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Gl91RPhdCaXI"
+        "id": "Gl91RPhdCaXI",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "predictions = model.predict(test_images)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -673,16 +689,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "3DmJEUinCaXK"
+        "id": "3DmJEUinCaXK",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "predictions[0]"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -696,16 +712,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "qsqenuPnCaXO"
+        "id": "qsqenuPnCaXO",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "np.argmax(predictions[0])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -719,16 +735,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Sd7Pgsu6CaXP"
+        "id": "Sd7Pgsu6CaXP",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "test_labels[0]"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -742,16 +758,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "DvYmmrpIy6Y1"
+        "id": "DvYmmrpIy6Y1",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def plot_image(i, predictions_array, true_label, img):\n",
-        "  predictions_array, true_label, img = predictions_array[i], true_label[i], img[i]\n",
+        "  predictions_array, true_label, img = predictions_array, true_label[i], img[i]\n",
         "  plt.grid(False)\n",
         "  plt.xticks([])\n",
         "  plt.yticks([])\n",
@@ -770,7 +784,7 @@
         "                                color=color)\n",
         "\n",
         "def plot_value_array(i, predictions_array, true_label):\n",
-        "  predictions_array, true_label = predictions_array[i], true_label[i]\n",
+        "  predictions_array, true_label = predictions_array, true_label[i]\n",
         "  plt.grid(False)\n",
         "  plt.xticks(range(10))\n",
         "  plt.yticks([])\n",
@@ -780,7 +794,9 @@
         "\n",
         "  thisplot[predicted_label].set_color('red')\n",
         "  thisplot[true_label].set_color('blue')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -794,41 +810,41 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "HV5jw-5HwSmO"
+        "id": "HV5jw-5HwSmO",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "i = 0\n",
         "plt.figure(figsize=(6,3))\n",
         "plt.subplot(1,2,1)\n",
-        "plot_image(i, predictions, test_labels, test_images)\n",
+        "plot_image(i, predictions[i], test_labels, test_images)\n",
         "plt.subplot(1,2,2)\n",
-        "plot_value_array(i, predictions,  test_labels)\n",
+        "plot_value_array(i, predictions[i],  test_labels)\n",
         "plt.show()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Ko-uzOufSCSe"
+        "id": "Ko-uzOufSCSe",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "i = 12\n",
         "plt.figure(figsize=(6,3))\n",
         "plt.subplot(1,2,1)\n",
-        "plot_image(i, predictions, test_labels, test_images)\n",
+        "plot_image(i, predictions[i], test_labels, test_images)\n",
         "plt.subplot(1,2,2)\n",
-        "plot_value_array(i, predictions,  test_labels)\n",
+        "plot_value_array(i, predictions[i],  test_labels)\n",
         "plt.show()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -842,13 +858,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "hQlnbqaw2Qu_"
+        "id": "hQlnbqaw2Qu_",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# Plot the first X test images, their predicted labels, and the true labels.\n",
         "# Color correct predictions in blue and incorrect predictions in red.\n",
@@ -858,12 +872,14 @@
         "plt.figure(figsize=(2*2*num_cols, 2*num_rows))\n",
         "for i in range(num_images):\n",
         "  plt.subplot(num_rows, 2*num_cols, 2*i+1)\n",
-        "  plot_image(i, predictions, test_labels, test_images)\n",
+        "  plot_image(i, predictions[i], test_labels, test_images)\n",
         "  plt.subplot(num_rows, 2*num_cols, 2*i+2)\n",
-        "  plot_value_array(i, predictions, test_labels)\n",
+        "  plot_value_array(i, predictions[i], test_labels)\n",
         "plt.tight_layout()\n",
         "plt.show()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -877,19 +893,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "yRJ7JU7JCaXT"
+        "id": "yRJ7JU7JCaXT",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# Grab an image from the test dataset.\n",
-        "img = test_images[0]\n",
+        "img = test_images[1]\n",
         "\n",
         "print(img.shape)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -903,19 +919,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "lDFh5yF_CaXW"
+        "id": "lDFh5yF_CaXW",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# Add the image to a batch where it's the only member.\n",
         "img = (np.expand_dims(img,0))\n",
         "\n",
         "print(img.shape)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -929,32 +945,32 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "o_rzNSdrCaXY"
+        "id": "o_rzNSdrCaXY",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "predictions_single = model.predict(img)\n",
         "\n",
         "print(predictions_single)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "6Ai-cpLjO-3A"
+        "id": "6Ai-cpLjO-3A",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
-        "plot_value_array(0, predictions_single, test_labels)\n",
+        "plot_value_array(1, predictions_single[0], test_labels)\n",
         "_ = plt.xticks(range(10), class_names, rotation=45)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -968,16 +984,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "2tRmdq_8CaXb"
+        "id": "2tRmdq_8CaXb",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "np.argmax(predictions_single[0])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -986,24 +1002,8 @@
         "id": "YFc2HbEVCaXd"
       },
       "source": [
-        "And, as before, the model predicts a label of 9."
+        "And, as before, the model predicts a label of 2."
       ]
     }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [],
-      "name": "basic_classification.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }

--- a/site/en/tutorials/keras/basic_classification.ipynb
+++ b/site/en/tutorials/keras/basic_classification.ipynb
@@ -1,1244 +1,994 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "MhoQ0WE77laV"
-   },
-   "source": [
-    "##### Copyright 2018 The TensorFlow Authors."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "cellView": "form",
-    "colab": {},
-    "colab_type": "code",
-    "id": "_ckMIh7O7s6D"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "# https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "cellView": "form",
-    "colab": {},
-    "colab_type": "code",
-    "id": "vasWnqRgy1H4"
-   },
-   "outputs": [],
-   "source": [
-    "#@title MIT License\n",
-    "#\n",
-    "# Copyright (c) 2017 François Chollet\n",
-    "#\n",
-    "# Permission is hereby granted, free of charge, to any person obtaining a\n",
-    "# copy of this software and associated documentation files (the \"Software\"),\n",
-    "# to deal in the Software without restriction, including without limitation\n",
-    "# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n",
-    "# and/or sell copies of the Software, and to permit persons to whom the\n",
-    "# Software is furnished to do so, subject to the following conditions:\n",
-    "#\n",
-    "# The above copyright notice and this permission notice shall be included in\n",
-    "# all copies or substantial portions of the Software.\n",
-    "#\n",
-    "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n",
-    "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n",
-    "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n",
-    "# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n",
-    "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
-    "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
-    "# DEALINGS IN THE SOFTWARE."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "jYysdyb-CaWM"
-   },
-   "source": [
-    "# Train your first neural network: basic classification"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "S5Uhzt6vVIB2"
-   },
-   "source": [
-    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/basic_classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/keras/basic_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/keras/basic_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "FbVhjPpzn6BM"
-   },
-   "source": [
-    "This guide trains a neural network model to classify images of clothing, like sneakers and shirts. It's okay if you don't understand all the details, this is a fast-paced overview of a complete TensorFlow program with the details explained as we go.\n",
-    "\n",
-    "This guide uses [tf.keras](https://www.tensorflow.org/guide/keras), a high-level API to build and train models in TensorFlow."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "dzLKpmZICaWN"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1.12.0\n"
-     ]
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Copy of basic_classification.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
     }
-   ],
-   "source": [
-    "from __future__ import absolute_import, division, print_function, unicode_literals\n",
-    "\n",
-    "# TensorFlow and tf.keras\n",
-    "import tensorflow as tf\n",
-    "from tensorflow import keras\n",
-    "\n",
-    "# Helper libraries\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "print(tf.__version__)"
-   ]
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "yR0EdgrLCaWR"
-   },
-   "source": [
-    "## Import the Fashion MNIST dataset"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "DLdCchMdCaWQ"
-   },
-   "source": [
-    "This guide uses the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset which contains 70,000 grayscale images in 10 categories. The images show individual articles of clothing at low resolution (28 by 28 pixels), as seen here:\n",
-    "\n",
-    "<table>\n",
-    "  <tr><td>\n",
-    "    <img src=\"https://tensorflow.org/images/fashion-mnist-sprite.png\"\n",
-    "         alt=\"Fashion MNIST sprite\"  width=\"600\">\n",
-    "  </td></tr>\n",
-    "  <tr><td align=\"center\">\n",
-    "    <b>Figure 1.</b> <a href=\"https://github.com/zalandoresearch/fashion-mnist\">Fashion-MNIST samples</a> (by Zalando, MIT License).<br/>&nbsp;\n",
-    "  </td></tr>\n",
-    "</table>\n",
-    "\n",
-    "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. The MNIST dataset contains images of handwritten digits (0, 1, 2, etc) in an identical format to the articles of clothing we'll use here.\n",
-    "\n",
-    "This guide uses Fashion MNIST for variety, and because it's a slightly more challenging problem than regular MNIST. Both datasets are relatively small and are used to verify that an algorithm works as expected. They're good starting points to test and debug code.\n",
-    "\n",
-    "We will use 60,000 images to train the network and 10,000 images to evaluate how accurately the network learned to classify images. You can access the Fashion MNIST directly from TensorFlow, just import and load the data:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "7MqDQO0KCaWS"
-   },
-   "outputs": [],
-   "source": [
-    "fashion_mnist = keras.datasets.fashion_mnist\n",
-    "\n",
-    "(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "t9FDsUlxCaWW"
-   },
-   "source": [
-    "Loading the dataset returns four NumPy arrays:\n",
-    "\n",
-    "* The `train_images` and `train_labels` arrays are the *training set*—the data the model uses to learn.\n",
-    "* The model is tested against the *test set*, the `test_images`, and `test_labels` arrays.\n",
-    "\n",
-    "The images are 28x28 NumPy arrays, with pixel values ranging between 0 and 255. The *labels* are an array of integers, ranging from 0 to 9. These correspond to the *class* of clothing the image represents:\n",
-    "\n",
-    "<table>\n",
-    "  <tr>\n",
-    "    <th>Label</th>\n",
-    "    <th>Class</th>\n",
-    "  </tr>\n",
-    "  <tr>\n",
-    "    <td>0</td>\n",
-    "    <td>T-shirt/top</td>\n",
-    "  </tr>\n",
-    "  <tr>\n",
-    "    <td>1</td>\n",
-    "    <td>Trouser</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>2</td>\n",
-    "    <td>Pullover</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>3</td>\n",
-    "    <td>Dress</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>4</td>\n",
-    "    <td>Coat</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>5</td>\n",
-    "    <td>Sandal</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>6</td>\n",
-    "    <td>Shirt</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>7</td>\n",
-    "    <td>Sneaker</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>8</td>\n",
-    "    <td>Bag</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>9</td>\n",
-    "    <td>Ankle boot</td>\n",
-    "  </tr>\n",
-    "</table>\n",
-    "\n",
-    "Each image is mapped to a single label. Since the *class names* are not included with the dataset, store them here to use later when plotting the images:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "IjnLH5S2CaWx"
-   },
-   "outputs": [],
-   "source": [
-    "class_names = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',\n",
-    "               'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Brm0b_KACaWX"
-   },
-   "source": [
-    "## Explore the data\n",
-    "\n",
-    "Let's explore the format of the dataset before training the model. The following shows there are 60,000 images in the training set, with each image represented as 28 x 28 pixels:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "zW5k_xz1CaWX"
-   },
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "text/plain": [
-       "(60000, 28, 28)"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MhoQ0WE77laV",
+        "colab_type": "text"
+      },
+      "source": [
+        "##### Copyright 2018 The TensorFlow Authors."
       ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "train_images.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "cIAcvQqMCaWf"
-   },
-   "source": [
-    "Likewise, there are 60,000 labels in the training set:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "TRFYHB2mCaWb"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "60000"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(train_labels)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "YSlYxFuRCaWk"
-   },
-   "source": [
-    "Each label is an integer between 0 and 9:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "XKnCTHz4CaWg"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([9, 0, 0, ..., 3, 0, 5], dtype=uint8)"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "train_labels"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "TMPI88iZpO2T"
-   },
-   "source": [
-    "There are 10,000 images in the test set. Again, each image is represented as 28 x 28 pixels:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "2KFnYlcwCaWl"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(10000, 28, 28)"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "test_images.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "rd0A0Iu0CaWq"
-   },
-   "source": [
-    "And the test set contains 10,000 images labels:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "iJmPr5-ACaWn"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "10000"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(test_labels)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "ES6uQoLKCaWr"
-   },
-   "source": [
-    "## Preprocess the data\n",
-    "\n",
-    "The data must be preprocessed before training the network. If you inspect the first image in the training set, you will see that the pixel values fall in the range of 0 to 255:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "m4VEw8Ud9Quh"
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAATEAAAD4CAYAAACE9dGgAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAdAklEQVR4nO3dfZBc5XXn8e+Z0YxeRqM3JIQQsgVY2Mj2IlgZZEg52CTmpVwRxMYFlcVyQkXsLmxMij8gbLbMVootymtgnThmIwxrUQVmiYGgEJV5kbExdngRQkYSWiwBMhISegVJSBpppvvsH30n9Gjmnntnume6r/h9qK7puaefvo96Zg73Pvfc5zF3R0SkqFoa3QERkVooiYlIoSmJiUihKYmJSKEpiYlIoY0ayZ2122gfQ8dI7lLkI6WLAxzxw1bLe1z4xQ7fvaeU67Uvv3r4CXe/qJb91aqmJGZmFwHfA1qBH7r7bdHrx9DBOXZBLbsUkcALvqLm99i9p8SLT3ws12tbZ2yYWvMOazTk00kzawX+HrgYmAtcaWZz69UxEWkMB8o5/8tiZrPM7BkzW29m68zsW8n2W8zsHTNbnTwuqWrzV2a20cxeN7MLs/ZRy5HY2cBGd38z2fGDwELgtRreU0QazHG6Pd/pZA49wA3uvsrMOoGXzeypJHanu3+3+sXJgdAVwKeBE4Gnzew09/QO1TKwPxPYXPX9lmRbH2a22MxWmtnKbg7XsDsRGSn1OhJz923uvip5vh9YzwB5ospC4EF3P+zubwEbqRwwpaoliQ00eNjvHiZ3X+Lu8919fhuja9idiIwExyl5vgcwtfcgJXksTntfM5sNnAm8kGy6zsxeNbN7zWxysi3XwVG1WpLYFmBW1fcnAVtreD8RaRJlPNcD2NV7kJI8lgz0fmY2HngYuN7d9wF3AacC84BtwO29Lx2geXiDdy1J7CVgjpmdbGbtVM5jl9XwfiLSBBwo4bkeeZhZG5UEdr+7PwLg7tvdveTuZeBuPjxlHPTB0ZCTmLv3ANcBT1A5z33I3dcN9f1EpHkM4kgsZGYG3AOsd/c7qrbPqHrZZcDa5Pky4AozG21mJwNzgBejfdRUJ+buy4HltbyHiDQXB7rrN0XXecBVwBozW51su5lKSda8ZHebgGsA3H2dmT1EpcqhB7g2ujIJI1yxLyLNzwdxqpj5Xu7PMfA4V+rBj7vfCtyadx9KYiLSl0OpQHOlKomJSB+Viv3iUBITkaMYpQHPAJuTkpiI9FEZ2FcSE5GCqtSJKYmJSIGVdSQmIkWlIzERKTTHKBVo5nolMRHpR6eTIlJYjnHEWxvdjdyUxESkj0qxq04nRaTANLAvzcMyfhlrnK2g9bgpYfy9C09LjU144Pma9p31b7NRbakx7z5S275rlfVzidRvhomUtzdKriMxESmwso7ERKSoKgP7xUkNxempiIwIDeyLSOGVVCcmIkWlin0RKbyyrk6KSFFVbgBXEpMmYa3x7SPe0xPGW+bNDePrrxkftz+UHms7EK5Oz6hD8STJbU+uDOM11YJl1aBlfK5YnARq6ZuNCv5s4x9nLo7RrduORKSo3FGxq4gUmanYVUSKy9GRmIgUnAb2RaSwHNOkiCJSXJUl24qTGorTUxEZIVo8V5pIWFNEdp3Y5gsnhfE/+fwvw/ivdp6SGvvd6BPCtj42DDPqDz4fxk/7wTupsZ5Nb8dvnjFnV9bnlqV18uT0YKkUti3t25cerMNUY85HqGLfzDYB+4ES0OPu8+vRKRFprI/akdgX3X1XHd5HRJqAu310jsRE5NhTGdj/6Nx25MCTZubAP7j7kqNfYGaLgcUAYxhX4+5EZPgVa479Wnt6nrufBVwMXGtmXzj6Be6+xN3nu/v8NkbXuDsRGW6VgX3L9chiZrPM7BkzW29m68zsW8n2KWb2lJltSL5OTrabmf2tmW00s1fN7KysfdSUxNx9a/J1B/AoEE9LICKFUKIl1yOHHuAGdz8dWEDlYGcucBOwwt3nACuS76FyQDQneSwG7srawZCTmJl1mFln73Pgy8Daob6fiDSH3or9ehyJufs2d1+VPN8PrAdmAguBpcnLlgKXJs8XAvd5xfPAJDObEe2jljGx6cCjVpl3aRTwgLv/tIb3k2FQ7uqqqf2RMz8I41+bGM/pNaalOzX2i5Z4vrB3fjYrjJf+Xdy3393RmRorv3Ju2Pa4tXGt1oRXtoXxXV+YGcZ3/vv0gq7pGctxTn76jdSY7anPtbpBLBQy1cyqfwmWDDQ2DmBms4EzgReA6e6+DSqJzsyOT142E9hc1WxLsi31Ax/yv9jd3wTOGGp7EWlO7tBdzp3EduWpDzWz8cDDwPXuvs/SJ50cKBCW8KrEQkT6qJxO1u/qpJm1UUlg97v7I8nm7WY2IzkKmwHsSLZvAaoPwU8CtkbvX5zrqCIyYkrJ/ZNZjyxWOeS6B1jv7ndUhZYBi5Lni4DHqrZ/I7lKuQDY23vamUZHYiLSR2+JRZ2cB1wFrDGz1cm2m4HbgIfM7GrgbeDyJLYcuATYCBwE/jRrB0piInKU+p1OuvtzDDzOBXDBAK934NrB7ENJTET60Rz7MrKi5cUyppT54OsLwvg35v48jL/RPS2Mn9S+JzV2+Ykvh235D3H8+6//fhg/8ObE1FhLR/y5vLsgPhJ5Z2H87/bueKqeyavS//RaFm0P2+47kj69UWlF7XfFVK5OfnTunRSRY4ympxaRwtPppIgUVp2vTg47JTER6UeTIopIYbkbPUpiIlJkOp0UkcLSmJgMXlTnNcwW3PhiGP/i+Ndqev+ZwQQEB7w9bPt+qSOMf3vuv4TxnaelT8WTtTjsDzfEU/V8ENSgAbT2xD/TBX/2Smrsq1NeCtt+5+HPpsZa/EDYNi8lMREpLNWJiUjhqU5MRArLHXryT4rYcEpiItKPTidFpLA0JiYihedKYiJSZBrYl8HJmPNrOG344PgwvnvC+DD+bs+kMH5ca/qyap0th8K2s9t2hfGdpfQ6MIDWtvQl4Y54PF/Wf//0P4fxrtPbwnibxUu+nTsmfe2Ly1/7Rti2gzfDeK3cNSYmIoVmlHR1UkSKTGNiIlJYundSRIrNGzpMO2hKYiLSj65OikhhuQb2RaTodDophTFtdHodF8AY6w7j7Ravr7i1e3JqbMOhT4Ztf7svrmG7aPq6MN4d1IK1BvOcQXad14lt74XxLo/ryKJP9bzpcR3Y6jBaH0W6Opl5zGhm95rZDjNbW7Vtipk9ZWYbkq/pv6kiUijulSSW59EM8pz4/gi46KhtNwEr3H0OsCL5XkSOEWW3XI9mkJnE3P1Z4Oi16BcCS5PnS4FL69wvEWkg93yPZjDUMbHp7r4NwN23mVnq4IWZLQYWA4xh3BB3JyIjxTHKBbo6Oew9dfcl7j7f3ee3MXq4dycideA5H81gqElsu5nNAEi+7qhfl0SkoY7Bgf2BLAMWJc8XAY/Vpzsi0hQKdCiWOSZmZj8GzgemmtkW4NvAbcBDZnY18DZw+XB28piXse6ktcZzX3lPeq1W6+S4+uX3J60J4ztLE8L4+6V4nHNS68HU2P6eMWHbPYfi9/7U6G1hfNXB2amxae1xnVfUb4BNR6aG8Tmj3w3j39l+QWps1pijr6P11XPBF1Jj/sK/hm3zapajrDwyk5i7X5kSSv8piEhhOVAu1yeJmdm9wFeAHe7+mWTbLcCfAzuTl93s7suT2F8BVwMl4C/c/YmsfRTnEoSIjAwH3PI9sv2I/nWmAHe6+7zk0ZvA5gJXAJ9O2vzAzOLTEJTERGQA9aoTS6kzTbMQeNDdD7v7W8BG4OysRkpiItJf/oH9qWa2suqxOOcerjOzV5PbGnsHbmcCm6tesyXZFtIN4CJylEGVT+xy9/mD3MFdwN9QSYN/A9wO/BkMOIlZ5vGejsREpL9hLLFw9+3uXnL3MnA3H54ybgFmVb30JCB9WaiEjsSaQcbggo2Kf0xRicXmq08P235pXLw02a+74qP5aaP2h/FoOpwZo/eGbTund4XxrPKOKaPSpxnaXxobth3XcjiMZ/27z2qPl5v7y6fPSo11fmZ32HZCW3DsUY+Lig5ep6uTAzGzGb23LQKXAb0z5CwDHjCzO4ATgTnAi1nvpyQmIgOoW4nFQHWm55vZPCrHcpuAawDcfZ2ZPQS8BvQA17p7PLEbSmIiMpA6VeOn1JneE7z+VuDWwexDSUxE+muSW4ryUBITkb56i10LQklMRPpplgkP81ASE5H+hvHqZL0piYlIP6YjMRkMa2sP4+WuuF4qMnXNkTC+qxQvLTapJZ6Spj1jabMjQZ3YuVPeCtvuzKjlWnXo5DDe2XooNTatJa7zmtUW12qt6ZoVxpcf+EQYv/orT6fGfrzkD8O27T/9dWrMPP555dJEc4XloSQmIkfJPUNFU1ASE5H+dCQmIoVWbnQH8lMSE5G+VCcmIkWnq5MiUmwFSmKaT0xECq1YR2LB0mY2Kq53staMfN0Sx8tdwfxS5czZQkLeHddy1eJ7//D9ML65Z1IYf7c7jmctbVYKpnR5/tDEsO2Ylu4wPm3UvjC+rxzXmUX2l+Pl5KJ50iC77zcetyE19sjePwjbjgSdTopIcTm67UhECk5HYiJSZDqdFJFiUxITkUJTEhORojLX6aSIFJ2uTg5NLesrZtVaeVy201CHFp4dxjdfGteh/cmZ6UvzvdvTGbZ95eDsMD4xmJMLoCNjfcYuT6/f23pkcmoMsmutonUlAY4P6shKHtcFvtMd9y1LVv3clp5gTcw/iuc6m3TfkLo0KEU6Esus2Deze81sh5mtrdp2i5m9Y2ark8clw9tNERlRw7gCeL3lue3oR8BFA2y/093nJY/l9e2WiDSMfzgulvVoBplJzN2fBfaMQF9EpFkcY0diaa4zs1eT083UAQQzW2xmK81sZTfx+ImINAcr53s0g6EmsbuAU4F5wDbg9rQXuvsSd5/v7vPbGD3E3YmIDGxISczdt7t7yd3LwN1AfHlNRIrlWD+dNLMZVd9eBqxNe62IFEzBBvYz68TM7MfA+cBUM9sCfBs438zmUcnFm4Br6tGZqA6sVqNmnBDGu0+eHsb3nD4uNXbwhLgwcN4l68P4N6f/nzC+szQhjLdZ+ue2ufu4sO2Z4zaF8Z/tnRvGd40aH8ajOrNzO9Ln1AJ4v5z+mQOcOOq9MH7jxq+lxqaPi2uxfvjx+IJ7t8cDQq93x0Mne8vp85H9xdxnwraPMi2M10WTJKg8MpOYu185wOZ7hqEvItIsjqUkJiIfLUbzXHnMQ0lMRPpqovGuPLRQiIj0V6erkym3LU4xs6fMbEPydXKy3czsb81sY1KDelaeriqJiUh/9Sux+BH9b1u8CVjh7nOAFcn3ABcDc5LHYir1qJmUxESkn3qVWKTctrgQWJo8XwpcWrX9Pq94Hph0VDnXgJpqTOzwxZ8L48f/1zdTY/MmbAnbzh37XBjvKsdLvkXTwrx2aGbY9mC5PYxvOBKXf+ztiUsNWoNR2B1H4ql4bn8rXh5sxdn/O4z/9daB5gb4UMvY9N/03aW4POOr4+Ml2SD+mV3zsWdTY6e07wjbPn4g/tvZmjFVz/S2vWF8dtvO1Ngfd/42bHsMlFhMd/dtAO6+zcyOT7bPBDZXvW5Lsm1b9GZNlcREpAn4oK5OTjWzlVXfL3H3JUPc80AFl5npVElMRPrLfyS2y93nD/Ldt5vZjOQobAbQe1i8BZhV9bqTgK1Zb6YxMRHpZ5hvO1oGLEqeLwIeq9r+jeQq5QJgb+9pZ0RHYiLSX53GxFJuW7wNeMjMrgbeBi5PXr4cuATYCBwE/jTPPpTERKSvOs5QkXLbIsAFA7zWgWsHuw8lMRHpwyhWxb6SmIj0oySWxuJl2c75Hy+FzS/oXJcaO+jx1CdZdWBZdT+RiaPi5bkOd8cf847ueKqdLKeNfjc1dtmE1WHbZ79/Thj/va7/Esbf+FI8jdCKQ+lTzuzsif/dV7z1pTC+6u1ZYXzB7LdSY5/tfCdsm1Wb19naFcaj6ZEADpTTf1+f74rr50aEkpiIFJqSmIgUVsFmsVASE5H+lMREpMg0KaKIFJpOJ0WkuJpoObY8lMREpD8lsYF1H9/B1qvS19m9ZeLfhe0f2LMgNTZrzNHzrvX18fZdYfyMsb8L45HOlrhm6JMT4pqhxw+cFMZ//v6nwviMtvdTY788eGrY9sFb/mcY/+Zf3hDGP7/8P4bxfbPT5xjo6Yj/UiacsTuM//WZ/xLG262UGnu/FNeBTRl9IIxPao1rA7NEdY2dLenL3AG0fvITqTHbFM+bl4cq9kWk8KxcnCymJCYifWlMTESKTqeTIlJsSmIiUmQ6EhORYlMSE5HCGtxqRw03okmspRvGbU//dB7fNy9sf8rY9LX6dnXH6ys+8cFnw/hJY98L4xNb02t3PhHM5wWwumtSGP/pzk+H8RPHxusvbu+emBrb3d0Rtj0YzGsFcM+dd4Tx27fH61ZeNmVVauyM9rgO7P1yvI7Naxnrde4vj0mNdXk8v9zejDqyzuD3AaDb4z+tVk//O5jUEteg7fvscamx0vba/6SLVieWudqRmc0ys2fMbL2ZrTOzbyXbp5jZU2a2Ifk69FkFRaS5uOd7NIE8S7b1ADe4++nAAuBaM5sL3ASscPc5wIrkexE5Bgzzkm11lZnE3H2bu69Knu8H1lNZWnwhsDR52VLg0uHqpIiMIB/EowkM6gTazGYDZwIvANN7F7ZMVvI9PqXNYmAxQHuHzjhFiqBIA/u5VwA3s/HAw8D17h6PNFdx9yXuPt/d548aHQ8yi0hzsHK+RzPIlcTMrI1KArvf3R9JNm83sxlJfAawY3i6KCIjyinUwH7m6aSZGXAPsN7dq6+3LwMWUVmSfBHwWNZ7tR4p07n5cGq87Ba2/9mu9Clppo/ZH7ad17k5jL9+ML5cv+bQiamxVaM+FrYd29odxie2x1P5dIxK/8wApral/9tPHh3/vyWargbgpa743/afpv08jL/dkz6E8M8HTgvbvnYw/TMHmJyxVN6afentD/a0h20Pl+I/ja6euGRn4uj4Z/q5KelTP73OjLDtzjOC6Y1+FTbNrVkG7fPIMyZ2HnAVsMbMehcxvJlK8nrIzK4G3gYuH54uisiIO5aSmLs/R6X+bSAX1Lc7ItJoRSt21W1HItKXuyZFFJGCK04OUxITkf50OikixeWATidFpNCKk8NGOIl9cIiWX7ySGv7HJ88Lm/+3hf+YGvtFxrJmj78b1/XsOxJPSTNtXPoSXhOCOi2AKW3x8l8TM+qdxli85Nt7Pel3QhxuiaecKaVeeK5493D6ND8AvyrPCePd5dbU2OEgBtn1dXuOTA3jJ47dmxrb35M+TQ/Apv1TwviuvePDeNe4+E/ruVL6UnoXnbAubDt2R/rPrCX+VclNp5MiUmj1vDppZpuA/UAJ6HH3+WY2Bfi/wGxgE/B1d48n9UuR+95JEfmIGJ5ZLL7o7vPcfX7yfd2m8lISE5E+KsWunutRg7pN5aUkJiL9lXM+YKqZrax6LB7g3Rx40sxeror3mcoLGHAqrzw0JiYi/QziKGtX1SlimvPcfWsy5+BTZvb/autdXzoSE5G+6jwm5u5bk687gEeBs6njVF5KYiJylMq9k3keWcysw8w6e58DXwbW8uFUXpBzKq80TXU6ecqN/xrGf/Dq19Lb/ufXw7YXn7A2jK/aF8+b9XZQN/SbYK4xgLaWeArMcW1HwviYjHqp9tb0OcFaMv53Wc6oE+tojfuWNdfZlNHpNXKdrfGcWy01Th3aGvzbX9w7O2w7fVxc+/eJCbvCeI/Hxwefn/hGauzet84N207/u1+nxjZ5XJOYW/0mPJwOPFqZlpBRwAPu/lMze4k6TeXVVElMRJpAHRfPdfc3gTMG2L6bOk3lpSQmIv01ydTTeSiJiUh/xclhSmIi0p+Vm2QpoxyUxESkL6e3kLUQlMREpA+j5luKRpSSmIj0pyQWaAnmkCrHayBOvP/51Nju++Pd/uSrF4bxc25+KYx/ZfZvUmOfat8etm3LODYfk3E9u6MlruXqCn7hsqqZnzs0K4yXMt7hZ++dHsbf7x6bGtt+cELYti2of8sjWsf0UE88z9reQ/F8Y60t8R9518/juc7eei19/ruJy+PfxRGhJCYihaUxMREpOl2dFJECc51OikiBOUpiIlJwxTmbVBITkf5UJyYixXYsJTEzmwXcB5xA5SBzibt/z8xuAf4c2Jm89GZ3X565x4xasOHS8fALYXztw3H7tZycGrPP/VHY9tAJ6bVSAKN3x3Ny7f943H7CG+lzSLUcjhciLP9mfRjP9kENbfeF0XgWtdq0Z8Sn1byH39b8Dg3jDqXinE/mORLrAW5w91XJDI0vm9lTSexOd//u8HVPRBriWDoSS1Yi6V2VZL+ZrQdmDnfHRKSBCpTEBjXHvpnNBs4Ees/NrjOzV83sXjObnNJmce9yTt3Ep00i0gQcKHu+RxPIncTMbDzwMHC9u+8D7gJOBeZROVK7faB27r7E3ee7+/w2RtehyyIyvBy8nO/RBHJdnTSzNioJ7H53fwTA3bdXxe8GHh+WHorIyHIKNbCfeSRmlWVK7gHWu/sdVdtnVL3sMirLMInIscA936MJ5DkSOw+4ClhjZquTbTcDV5rZPCp5exNwzbD0sAD8pTVhPJ7UJduE9BW6MhXn/6fSVJokQeWR5+rkczDg4oTZNWEiUkDNc5SVhyr2RaQvBzQVj4gUmo7ERKS4jr3bjkTko8TBm6QGLA8lMRHpr0mq8fNQEhOR/jQmJiKF5a6rkyJScDoSE5HicrzUmMlLh0JJTET66p2KpyCUxESkvwKVWAxqUkQROfY54GXP9cjDzC4ys9fNbKOZ3VTv/iqJiUhfXr9JEc2sFfh74GJgLpXZb+bWs7s6nRSRfuo4sH82sNHd3wQwsweBhcBr9drBiCax/by362n/ye+qNk0Fdo1kHwahWfvWrP0C9W2o6tm3j9f6Bvt574mn/SdTc758jJmtrPp+ibsvqfp+JrC56vstwDm19rHaiCYxd++znJ+ZrXT3+SPZh7yatW/N2i9Q34aq2frm7hfV8e0Gmouwrpc+NSYmIsNpCzCr6vuTgK313IGSmIgMp5eAOWZ2spm1A1cAy+q5g0YP7C/JfknDNGvfmrVfoL4NVTP3rSbu3mNm1wFPAK3Ave6+rp77MC/QPVIiIkfT6aSIFJqSmIgUWkOS2HDfhlALM9tkZmvMbPVR9S+N6Mu9ZrbDzNZWbZtiZk+Z2Ybk6+Qm6tstZvZO8tmtNrNLGtS3WWb2jJmtN7N1ZvatZHtDP7ugX03xuRXViI+JJbch/Bb4QyqXX18CrnT3ulXw1sLMNgHz3b3hhZFm9gXgA+A+d/9Msu07wB53vy35H8Bkd7+xSfp2C/CBu393pPtzVN9mADPcfZWZdQIvA5cC36SBn13Qr6/TBJ9bUTXiSOzfbkNw9yNA720IchR3fxbYc9TmhcDS5PlSKn8EIy6lb03B3be5+6rk+X5gPZXK8YZ+dkG/pAaNSGID3YbQTD9IB540s5fNbHGjOzOA6e6+DSp/FMDxDe7P0a4zs1eT082GnOpWM7PZwJnACzTRZ3dUv6DJPrciaUQSG/bbEGp0nrufReWu+2uT0ybJ5y7gVGAesA24vZGdMbPxwMPA9e6+r5F9qTZAv5rqcyuaRiSxYb8NoRbuvjX5ugN4lMrpbzPZnoyt9I6x7Ghwf/6Nu29395JXFi28mwZ+dmbWRiVR3O/ujySbG/7ZDdSvZvrciqgRSWzYb0MYKjPrSAZcMbMO4MvA2rjViFsGLEqeLwIea2Bf+uhNEInLaNBnZ2YG3AOsd/c7qkIN/ezS+tUsn1tRNaRiP7mE/L/48DaEW0e8EwMws1OoHH1B5ZasBxrZNzP7MXA+lalatgPfBv4JeAj4GPA2cLm7j/gAe0rfzqdySuTAJuCa3jGoEe7b7wG/BNYAvTP33Uxl/Klhn13Qrytpgs+tqHTbkYgUmir2RaTQlMREpNCUxESk0JTERKTQlMREpNCUxESk0JTERKTQ/j/oNQwZhzrgvQAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 2 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plt.figure()\n",
-    "plt.imshow(train_images[0])\n",
-    "plt.colorbar()\n",
-    "plt.grid(False)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Wz7l27Lz9S1P"
-   },
-   "source": [
-    "We scale these values to a range of 0 to 1 before feeding to the neural network model. For this, we divide the values by 255. It's important that the *training set* and the *testing set* are preprocessed in the same way:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "bW5WzIPlCaWv"
-   },
-   "outputs": [],
-   "source": [
-    "train_images = train_images / 255.0\n",
-    "\n",
-    "test_images = test_images / 255.0"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Ee638AlnCaWz"
-   },
-   "source": [
-    "Display the first 25 images from the *training set* and display the class name below each image. Verify that the data is in the correct format and we're ready to build and train the network."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "oZTImqg_CaW1"
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAj0AAAI8CAYAAAAazRqkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAgAElEQVR4nOydd5xVxdnHf6MxEUFQqlQRrEEJIMWCil2Mxt5rfNUUjZqiMSb6Rt/EGkuMUROM0cRGVIhixQKCIkoRKaJIVUTAFRBR7Of9Y+8Ov3m4Zzi77N29u+f3/Xz48Jw7c+eee2bm3LNPdUmSQAghhBCisbNBfZ+AEEIIIURdoIceIYQQQuQCPfQIIYQQIhfooUcIIYQQuUAPPUIIIYTIBXroEUIIIUQu+FZ1Ordu3Trp2rVriU5FFGP+/PmoqKhwtT1uuczlZ5995uV33nnHy5tvvnnQb5NNNvGyc66obMdbvny5l7/zne8E/bbYYgsvb7jhhtU97RozadKkiiRJ2tT2uPU1n1999VVwXFFR4eVWrVp5eaONNlrvz/r000+9zPMMhOvFrolS0Rj25ueff+7lVatWBW0rVqzwMu8Rnlcg3Jtp+w8APv74Yy9vsMGav7dbtmwZ9GvTpta3RyZKsTfL5T5bSr788ksv18Y+rw1ic1mth56uXbti4sSJtXNWIhN9+/Ytybi1MZec46mmPzQzZ8708rnnnuvlY489NujXu3dvL3/729/28re+FS7hGTNmeHn48OFe7tatW9Dvoosu8vJmm21W3dOuMc65BaUYt7725tKlS4Pju+66y8unnnqql/khs6ZMmTLFy2+++WbQdtRRR3m5rm685bw3szJv3jwvv/DCC0HbI4884mV+MDnllFOCfn369PEyz8vDDz8c9Hv22We93LRpUy+ffPLJQb+zzz4707nXNqXYm3n4zVy0aJGXO3ToUI9nsobYXMq8JYQQQohcUC1Nj8gfMW1OmnbntddeC46HDh3qZfvXH6vNWb1+ySWXBP2WLVuW8YzXsO2223r59ddfD9quuuoqL7MW4sADDwz6/fKXv/TyTjvtVO1zaIzwPD366KNB27/+9S8vP/DAA162JgvW1rFmxppY2Pzy7rvvevnwww8P+vE6OuaYY+JfIGc8+eSTXr7xxhuDtiZNmnj5iy++CNo23nhjL8+fP9/Lxx9/fNBvyZIlXmZTjtXCtm/f3sstWrTw8kMPPRT0u+mmm7y83377efnmm2+GSGefffbxsjUttm7d2stDhgzxclbTG2tzAGDvvff28urVq73cpUuXoN/TTz/tZdbu1SfS9AghhBAiF+ihRwghhBC5QA89QgghhMgF8ukRUWJRWStXrvQyR+pY/xn2C2rWrFnQxj4FHHZsw8g5NPqjjz7yMofL2vfFzr1///5e5jDbcePGBf1Gjx7t5YEDBwZt99xzT+r4jRmeQ/bNAICrr77ay3/84x+9bKOt2A+E/XZsJN2mm27qZfbvOPjgg4N+1hco78yZM8fL9913n5etXxr7Y3zzzTdBG4eVd+7c2cvNmzdP/Vzec3YP8/vYj8v6/uy6665eXrhwoZfZvw4Arr/++tTzyCM8f5w6AgDee+89L/MasPfjo48+2st8f/v666+DfuzvxXuW0xIA5ePHw0jTI4QQQohcoIceIYQQQuSCRmXeYjMKkG7esCq4F1980cuDBw/OND6r+6x6Niv2fJm6yiq7PhxxxBFe5mzK7dq1C/rxd7Fq0rRsyLYfXyvOCGv7pb0nBpvYWG0LhOc+duzYoI0TK+6www6ZPquxwaYpIFR1n3POOV7+y1/+EvTjDNkx89bOO+/s5R/+8Ide5hBqoP6y+JYrbPqJXRs2idgs17w3+R631VZbBf3YxMlj2HuYXSvFxgbCDL8cUj19+vSg32OPPeblQw45pOjYeYITSHLSSSC8Z3L6j8WLFwf9eJ+ym8LUqVODfuyKwPNls3WXI9L0CCGEECIX6KFHCCGEELmgUZm3bPQBq2dnz57t5TvuuCPox+YN9ja3pg6O+ImZtNisYs+J22JjxMw29cWkSZOCYzZpccZPW4SS4WgRIIwqiEWS8LXia8MRJhbOMGvrMXFUUKdOnYp+jsV+Fq+jvEaS8HUEwqiRLbfc0sv2+vC8f/DBB162GWJ5XfHYdo1lNWXmhdNPP93LnIXZmrrYFG3N/mk1zDibNhDOH2OjvGykZRo8Phc95X0KyKRl6d69u5fHjx8ftPFvoS2+nAbvRWva5xpbfN/mosDlijQ9QgghhMgFeugRQgghRC7QQ48QQgghckGj8umJhUM///zzXn7mmWeCfpxtlMMqrX1y5MiRXj7rrLO8HAvRTgvJBsIsstZfJKv9uy4ZNWpUcMzXikNV7Xdh/xxrT7722mu9zFWYeU6AsMov97O+P+yHwD49NmPv5MmTvczVm63PA4dj2u/FFePz6tMTW98ffvhhahv76nCVe7vn2Pcnlm27IaR4qEvY/5AzHD/yyCNBvwEDBnjZ+knxXHA4tPXp4T3DfpB2LnkvcZj70qVLU75F6C/C2b7F2nDaDHtf5P3Bfqt2Lm1oehXWv5V96HheY9m6ywVpeoQQQgiRC/TQI4QQQohc0KjMW1ZVx0yYMMHLNpsrqwJZPuCAA4J+r732mpcvuugiL/ft2zfoxwXdbKbeV199teg57bbbbkG/KpV0OYWuP/TQQ8Exmxv4utmwb1Zz2wKVbCZk86ENjz/jjDO8/Le//c3LPXr0CPqxmY2vXdu2bYN+P//5z7186623eplVtXY8WzyPi2jOmjXLy9tuuy3yQiwLOq8Pu445FLkmn2XNWbE0CXnnvPPO8/JNN90UtHFaAWva5fXO5vaYCYPnwY7HbTGTCBcU5gz5DcF0Up/EUm/w/mOzP7sKAEDv3r29zNfbpguw5rMq7P29HJGmRwghhBC5QA89QgghhMgFDd68FVN5c5TWxIkTvWzVpJ988omX2UzBMgD069fPy1tvvbWXbWTQuHHjvDxs2LCgjdWOHGExZMiQoF+Vqa6cMlxyATogjLBi9WlaYUEgVF1bDjzwQC83a9YsaOPinn/605+8zEVPAWDEiBFeZnU6q22BMHqL58Reb47YstFb/P1ffvllL+fJvGXXPs89R3xY8xZfS26LZVZOM0MDaxfLzDu89nl9v/TSS0G/3/72t6ljsEmLoyJtVnXOaM9zaftx5GaaecS2HXrooan9RAibqmw2bd5XbHa2/dhdgE2Qdr7YjMV7Pjav5YI0PUIIIYTIBXroEUIIIUQu0EOPEEIIIXJBg/DpqWkF5UsvvdTL77//fmo/9uOIVaN98cUXvcw+QtaXqE+fPl7eZpttgjYe/5ZbbvHy3Llzg35V2X5tFeu6Ztq0aV62IahpIcnWf4Nt+5zZ1TJjxgwv22vP88d+CHZtsI2a29jnxsK2cM78DMSzALMvw5gxY7x82mmnpX5WYyNW7Zxla+uvST/2TbH9yim1QzlgQ5arsCHK3bp18/K8efOCNvbJ4vuQ9W3jfjwv1i+Pq7HH5rJLly5Fz13E4fuzTcuy/fbbe5nny94/bcqOKmI+QrweYmljygVpeoQQQgiRC/TQI4QQQohc0CDMWzUtJrj55pt7mc0jbJYAwpA7Vu/ZcFxWC7LJxp4fm8E4fB0I1YJLlizx8kEHHZTyLeqXa665xss2BJUztsbCvvm6WTUpmwm5QOWyZcuCfjwvfN3sePxZnHnUZgAeOnSol5cvX+5luzb4fbaNz8lmkM4L1jTBYc5scoqZrWJFS9P2vjV/iprB82Dvd2y24HukNbnzPuP9FzN1xObcZk8X2eDCvZa0AqGxEHPee9aMzce8z/k3t1yRpkcIIYQQuUAPPUIIIYTIBXroEUIIIUQuaBA+PTWFfUti/gXsq8F20VatWgX9OAyQ7d027C+Wip3fx3bthQsXFv8S9QxXf2dfGgCYPXu2l7m8hPXp4bB9G+46YMAAL/P1sP34mOfPhlimhTjbkGYuRcJlI7gkif0sO88dOnTw8uGHH448EvMJ4Gtu5zO2H9NgPwLr02PXplgDX187Dx07dvTy1KlTU9/H19uOwSVAuM2WBuH7LPv+VFRUBP1sRe8qrF9JWli+CK9vdWA/HpatDxZfe74v2hJP5Yg0PUIIIYTIBXroEUIIIUQuaBD6QWtWYLUrq91syCVn12X1rA2l5JBL7sch2UBowmHTlzXn8Hg2K+nKlSu9vNNOO3nZmlWqQrnru8r6T3/606IyEIZ6v/32216+7bbbgn6jR4/2ss3IzNdgs8028zJfQ6Bm1XtjmX5Z/cvz2rNnz6DffffdV+3PbezwvFuzIV9zVo/XtPoym0vYvGHV97xP2KxSUzV/XujatauX7VzyHuQ533LLLYN+bOrgtBM2fJn78T3Y3t9ltlp/sqZ5sf3S9q/tx/uZ2+xvZjkiTY8QQgghcoEeeoQQQgiRCxqEHtGq1lgNy+YtzrILhFmYuRibjajiMdjM9M477wT9OPsvZyi16liOKLKfxZEK55xzjpenTJkS9KtS5de02GpdwOrr/v37e9lG1jz//PNetnPJ15GvvY3UsBEjVdjrk1YIjz8HCOeSzSEcrSaKw/Nr57qmavUqYqZsxppiWrRo4WWZtLLDGbRjWZLToieB9Ogta97igqPWFYGxpm1RfbL+bth+fN+NRb/yPLO8dOnSap1nfSBNjxBCCCFygR56hBBCCJEL9NAjhBBCiFzQIHx6rH9HWvXeHXfcMThmfwP2s7H2SbZls03S+gZwuDWfk80KzL4p1q7duXNnL3M49IUXXhj022WXXQCUVwigtf/y9+Y5sf4aXJU5du1j/iBpoZQ1Jc1XhMPmLTG7dm2cU0OBv6u9JnX1udZHS6ST5g8HhH4b7PcIhHs6Vj2b9wy/x/oztmvXzsvs31NO97jGQk19etJC0WO+P+wfyVULyhVpeoQQQgiRC/TQI4QQQohcUGvmLVZ/xYoJcj9Wi2VVwcYYPHhwcMzZkLnYXSwkklW81qzGoZlpJjYgPN9YoUUu8Mcht+WKNeHw/DHdu3cPjrkIXVZTZdZMoVmJZeFmYvNg13IsxLcxEzNpxUKba/M9sbmIFdjMI7HrwRniOesyEN4zOdOyhe+ZnBmbM50D6XvdzqVNFVKFMjVnJ2beihVRThsja9oYmbeEEEIIIcoEPfQIIYQQIhfUWF8Yi8KpbTXkmDFjguOHH37Yyy+++KKXObsoEBYF5WgPq6rj8+Ux7HfkMdjUZceLRSOwWYX7DRs2LOh36KGHpo5RLqQVfmW1OBBG0fF1A0ITGUeDWbVrWiRB1gy+sQKVPEZeTVbVIbb20+bJXleep6wRYDF1Ox/zHlN25riJj01TPXr0CNq6dOniZd4v9pouWbLEy2zCsoVJ+X1sVmvfvn3Q77333ks9X5HOrFmzvGzN91mL/8burWn9+PeTKw6UK9L0CCGEECIX6KFHCCGEELlADz1CCCGEyAU1dr7J6vuwbNmy4HjRokVeZhskvw6EPi7cDwh9RNg+aX1pOMyyQ4cOXrY2afYlYfu0rSDNdm2uxv3xxx8H/caOHetla0/nkGj2Zxk/fjwaGmmh4/Y7xzIXx7J+pvWrDZs0nxP7lMT8H/KUdTlG7BpnTS2QNWNsTd6fNexdhPcqm2qCfXL4nskZ1oHw/rdixQovWx9L9vex93uG78GcIb9t27ZBP6UmCJk5c6aXO3XqFLTxteffMQvfC2N7jPvx7+TixYuDfuPGjfMy/2bWJ1opQgghhMgFeugRQgghRC6osXnr5ZdfDo4vu+wyL3MxOVZ3AunZV22hRzafWXUqq9NYBWdDpVmdNnToUC/369cv6Mfhk6zGjWWX5GzKq1atCtpYtWhNbqxa5MKkDSGTZU1hVbad57Rw5ZjZpCbY97NpkdtsxmixNrVRZDSrWTPNXGbnic9Jc5hu+nn33XeDfm+88YaXu3XrFrRxhmZ2Fdh6662Dfnwfmzt3rpdtkVK+z8bgTPpclPmCCy4I+smkFfLcc8952ZqWeT3EzIJZzdNphUnt2rjtttu8LPOWEEIIIUQdooceIYQQQuSCapu3qtTI559/fvA6mzBiBTfTshVztmMgNFVZsxXDRe0WLFgQtF188cVFx2CVGxBmBGXz1j777BP04+iGt99+28u2GB+bTqyqndWCfJ1sZEJDIGs0UyzSjzOH8lqJmbdiKti0NpuhlE2kMbMJo+itSmKZltPMVrGIqth1rUnUHt8TuNhtnkgz/Tz99NPB8Xe/+10v22zpfO343tqxY8eg35tvvullXg82gohdAtq1a+dle/9ksxhnZ+Z7LgBss802EGvgCGBbFYHva1mjsmLwXuR1YyOeOXqrXJCmRwghhBC5QA89QgghhMgFeugRQgghRC6olk9PRUUF7r77bgBr+89wuCOHMNpsxdZ+W4X1pWC7vLUNs0159erVXmY7MQCcdtppXv7vf//rZVvBfN68eUXPfdKkSUG/UaNGeTktIyUQ+idZXxKG7a62X1Voaez9DYW0DNpA6AMQC6VM87th/ynbj+fI+o1Ym3cVNsWCWBvOYG7nM81fwL6+vv5Rdv54POubItbAfjUA0LNnTy/bueR7j/W5ZNL84GJ7mH0nbRg9+xKl+RUB8umxcNoTmy4gayh67J6ZBq8b/j0GwgzNvIbsb2ZdIk2PEEIIIXKBHnqEEEIIkQuqZd7aaKONfGi1NTmxGYtVV126dEntx2pym62zZcuWXubCd3YMVpPaQqJsOjniiCO8vNNOOwX9WC3I5jerguNswmxWsWG7XNzNmqfSwrKt+r+qyGpMrdxQyFqctiYq2DQzlR0jZl7hubTq2bT35JlY+GtN1ONZic11WoZtEZrvOT0HEJoCORMyEM4z7+HYHomlK0m7l9nCpGwSYVcGzvQvwozZQHh9bAoUvvZpVRGAcM9mTSHCYx9wwAFBv//85z9eZneR+szOLE2PEEIIIXKBHnqEEEIIkQuqbd6qMmtZ1WXnzp29zBFQViXJJqI2bdoUlYFQtWrVotzG6llb+JNV7a1atfIyF9kDQrUum+OsBzx/Fp+vVbuzqt22sWqY1bgtWrQI+k2ZMgVAWKC0oZI1y2dWc0hW80Usmy+3seq+MVzvUhOLKExTj8eyKdcEu1Z4z/H9R4TRUfa+zfdSO698v+P7GLslWNjkYu99aUVht9pqq6AfZ17m93BELwAsW7bMy+wOkRdee+211LbY705sX/Kc83qIZV7nvffWW28F/Xj+Zs6c6WWZt4QQQgghSoweeoQQQgiRC/TQI4QQQohcUC2fnk022QS9evUCEIaAA8A///lPL3fo0MHLXJkcCMPK2QfH2pPZBmltyGwP5vFsZlC2O3JYpA3bZBsn2y7teOyPlBaib/uxDITh7GwL5bBSYE12aZtxuJyoSUhyTX070vx4Yv5CsZD1tGr3Wf2P8gzv1Vim69oOHec5sz4GvE/mzJnj5d69e9fqOTRE+D5m9x/fF60/G993+b5lrz3fP/m+aP1K+D7J1dP79u0b9BszZoyX+V5t78fsP5RHn57HHnssOG7durWX7e8GzxnPl/WD5T3L19v240zZPM/sp2o/d9q0aUW+Rd0jTY8QQgghcoEeeoQQQgiRC6pl3mIuueSS4LjK7AUAf/rTn7xszTYc6s2mH5uVk9WwNmQ9LfQxlnU3FprJprTYeAy32XNnFS+HVQKhapFVgVz4DwBOPvlkAMBNN92Ueg71TdYMyqwaj2VzZWxobZppw6rr7fvSzo/PncfLai7LM4sWLUpt4/lIC18HsmduTitCa/cmq9hZzS/CLPP23sf34+nTpwdtvFc5pYYdg699zGWBXRG48On3v//9oB//LvAYNgNxWqHTvMBmXCD83bFmprT0LbbfiBEjvHzIIYd4uUmTJkE/NoXaTN5p/WbMmJHary6RpkcIIYQQuUAPPUIIIYTIBXroEUIIIUQuqLZPT5WN3droDz744KLy888/H/RjXyCubm5TjLPN3vpZcChlLESWK82y34CtEM+2ZrZPZg1fZp8VIPTxsT4n+++/v5d32GEHL9dnWu66xF4P9qfh+bP9+DjNz8OOwVi/kbTQeYWsrxveLzadBF9nvpZ2XrL6UXHoLfez886+JFxKRoSlgOy6Z/+OFStWBG18vTkNifXV4XI9TZs2Tf2sNKxPCI/H64nHBoD333/fy9ttt12mz2pMsM8NAIwePdrLdr/xfomV2knzz4mVWor143vFTjvtlPq5dYk0PUIIIYTIBXroEUIIIUQuqLZ5Ky0kOI199tknOB4/fnzRfm+++WZwzCpZW+184cKFXt5yyy29bM1MNhu0qF2yhnCzapwrKAOhOpTXll1nrFLnNnsOfJy1MjSjkPV1079/fy/PmjUraGMTCau2Lax+53nKeo3ZtAGEayKPpo4YXHXeptewYeAMV9zme6sNFed7NYfA22r33I9lG3qdlprArg0O0c4jZ511VnB89tlne9mat9iMaTNqM2m/7zYNBO9zXhsrV64M+vHx+eefn/q5dYk0PUIIIYTIBXroEUIIIUQuqHFG5tpm++23jx4zO+64Y6lPR9QirAq1hevY7MSZY62ZiSNBspqqYoVEOYKPM89aVXvaOQDVN/U2FthEcuqppwZto0aN8nJFRYWXramDTSSxoro8bzyfXbt2DfqxGd2acPIOm5S32mqroI1NWBZe7xzxY82WHHl63333edmawfbdd9+iY9t9xfcLnstu3boF/fbee+/Uc88jnOXaZvhnbIFsZunSpUVft5mbed3wHrUmx6efftrL7IpSn+Tzri2EEEKI3KGHHiGEEELkAj30CCGEECIXlI1Pj2h4ZK2y3qdPHy/36NEjaOOKyjFfHbb7c9bQWPX0tHB4IPQjYR8CDse25NWHx8LX2Pp3DB48uOh7li1bFhyzjwBnY7fzucUWWxSVs4bDK80AcOutt3rZZszlfXXccccFbezfxv4Y7777btCP/YT69u2b6ZyOOuqo1LZjjjkm0xgihDMe25D1sWPHennmzJlethUTdt9996Jjn3vuucEx+/7wuuFqDOWK7uJCCCGEyAV66BFCCCFELnBpBRqLdnbuAwALSnc6oghbJknSZt3dqofmst7QfDYeNJeNi1qfT81lvZE6l9V66BFCCCGEaKjIvCWEEEKIXKCHHiGEEELkgrJ46HHOHeGcS5xz6bUnwv7znXOti7y+qlj/yDjV6h8Z53TnXId192zcOOdaOeemFP4tds69R8ffXsd7BznnHktpu8M5992Utgucc5uY137jnDvJOXd42vvEutF85hvn3NeFuZ7hnHvdOfcL51xZ/GbkGe3L9aNcFvAJAF4EcHx9n0gNOR1A7h96kiT5MEmSXkmS9AJwO4Abq46TJPliPcY9M0mSN+zrzrkNAVwAwBZbOgDASACHA2gwm7Hc0HzmntWFue4BYH8ABwP4X9vJOad8b3WI9uX6Ue8PPc65ZgB2B/A/oIeewhPpaOfcQ865N51z9zqTacw518Q595Rz7qwi417onJvgnJvqnLs88vnXO+cmO+eec861KbzWyzk3vvDe4c65zdNed84dDaAvgHsLT9pNauXCNGKcc3vRXyavOec2LTQ1KzbfhXXQtyCvcs5d4Zx7BcBvUfmwOco5N6rQ3hzAtwFsA+AHAK4rfE73yLyOds7d5Jwb55yb7pxLz1Ao1kLz2fhJkmQpgLMBnOsqOd0596BzbgQqf/iK3nOdc02dc48XNEXTnXPHFV6/2jn3RqHvn+rtizVitC9TSJKkXv8BOBnAPwryOAB9CvIgAB8B6ITKh7OXAQwstM0H0BXAswBOpbFWFf4/AMDfAbjCex8DsGeRz04AnFSQLwNwS0GeCmCvgnwFgJvW8fpoAH3r+1qW0z8Avwfwq5S2EQB2L8jNUJkZPDbf/voW5uxYGms+gNZ0fCSAKwryXQCOprbY/A0pyHsCmF7f16/c/mk+8/ev6n5qXlsOoB0qtdsLAbQsvF70ngvgqKq5KPRrAaAlgLewJnp4s/r+rg31n/Zl9f/Vu6YHlaatBwryA4XjKl5NkmRhkiTfAJiCygedKh4B8M8kSf5VZMwDCv9eAzAZwPaofCK1fANgaEG+B8BA51wLVG7CFwqv3w1gz7TXM39LwbwE4Abn3HmovKZfFV6PzXcVXwN4ODL2QQCetC9mmL/7ASBJkjEAmjvnNoPIiuYzP7C2/ZkkSarqi6Tdc6cB2M85d41zbo8kST4CsBLAZwDucM4dCeDTOjv7fKF9WYR6fehxzrUCsA8qF/98ABcCOK5K3Qbgc+r+NcJaYS8BGEx9g6EBXJWssXNunSTJPzKckpIWlQDn3DmkZu2QJMnVAM4E0ATAeLfGgT0231V8liTJ15GP6w/g1Rqcpp17rYUUNJ/5xDnXDZXzWFV46RNuRpF7bpIkswDsjMqHn6ucc5cVfnz7o/JH9XAAT9Xdt2i8aF9mo741PUcD+FeSJFsmSdI1SZLOAOYBGJjhvZcB+BDArUXangZwhqv0F4JzrqNzrm2RfhsUzgEATgTwYuEvkeXOuT0Kr58C4IW01wvyxwCq7KXCkCTJX+lmuMg51z1JkmlJklwDYCIq/yqsKf7aO+d6AHiTNqtvW8f8AUCVr8FAAB8V+osiaD7zh6v0d7wdlS4AxX6oit5zXWVU66dJktwD4E8A+hT6tEiS5AlUOsj2qptv0bjRvsxGfXvdnwDgavPaw6h8ABm6dve1uADAnc65a5MkuajqxSRJRjrndgDwckERtAqVvkNLzfs/AdDDOTcJlXbOqnKxpwG43VWG6M0F8MN1vH5X4fXVAHZNkmR1hnPPMxc45/ZG5V8Zb6BSTbprDcf6O4AnnXPvA3gc4V+NDwAYUlDvHo30+QMqN+o4AM0BnFHDc8krms/GSRPn3BQAGwH4CsC/AdxQrGPknrs1Kp1cvwHwJYCfoPIH8hHn3Mao1BD9vNRfJKdoXxZBZShEo8E59wwqHdvfr+b7RqPSGXBiSU5M1AjNpxDlR0Pfl/Wt6RGi1kiSZP/6PgdRe2g+hSg/Gvq+lKZHCCGEELmgvh2ZhRBCCCHqBD30CCGEECIX6HAiZLQAACAASURBVKFHCCGEELlADz1CCCGEyAXVit5q3bp10rVr1xKdSjpfffVVcLxy5UovV1RUeHnDDTcM+m288cZe3mCDNc93drxPPlmTWLRp06Ze7tixY9CPx6gr5s+fj4qKimJZp9eL+prLvDNp0qSKJEna1Pa45TifH3/8sZe/853vBG3f/va3M43x+edrksd++umaagWbb775ep7d+qO92bgoxd7UXNYPsbms1kNP165dMXFi9ULsbXRY8aoRcZYuDXMKPv/8814eMmSIlzfbLCzjscMOO3iZb7rLly8P+r388ste3mWXXbx85ZVXBv2aNMlWQJ2/c02+L9O3b9/1en8aNZlLsf445xaUYtzamM+0SM6aruEXXliTiLV79+5BW6dOnTKNMW/ePC/z9zvmmGNqdE61ifZm46IUe1NzWT/E5rIkeXqy/uizlubPf/5z0Pbss896+bPPPgvaWBvzxRdfeHnChAlBv2HDhhX93I022ig4Zo3OK6+84uXddtst6NeyZUsv77XXXl7+2c9+FvQrh79ChaguvG9jWs2FCxd6+c477wzarr/+ei+zRrY24HM65ZRTgrZrrrnGy+eff36m8b755pvU8YUQjRPtciGEEELkAj30CCGEECIX6KFHCCGEELmgzmtvzZkzx8uHHHKIl7fYYougHzslWx8cjtJiB2XrWLhq1ap1vgcI/YI++OADL9soL44keeaZZ7z80ksvBf1+9KMfefnII4+EEOVIVp+W3r17B8dvv/22l3lPAMAmm2ziZd7T1i+P/d54r7//fljDcPXq1V7mQAI73q9+9SsvcwDCvvvuG/S77777vGy/L18P+fekYx3e065bzJ8zVv6oJo7z48aNC47ZH/Ott97y8rbbbrven9WYqe1ghqycfPLJXv7FL34RtPXp08fLfL+xv+NZ0c4WQgghRC7QQ48QQgghckFJzFsxVdhvfvMbL7dv397LNsybTUt2vG99a81pszqOzVlAqP5imc1ZQJickE1p/DlAmOyQVbp2vL/+9a9ePuCAA4K2Zs2aQYj6ImtY+q677url6dOnB23t2rXzsl37vFe5ze6lxYsXe5lNWjYXFicxZJMW70V7zPeO+++/P+jHCQ7/+9//Bm18PWoz11aeyHqtanJNR48eHRxPmzbNy2xyBYBLLrnEyzyXI0eODPrV1ERSjmRds7F+fMz9subb+/LLL4Nj/j3l+Tr66KODfrNmzfKy/R3nfVobe1GaHiGEEELkAj30CCGEECIXlDx6y0ZjsFq7efPmXrZqMVaHs0oaCM1RX3/9tZdt7S0+ZtW1jfzg8blfLGqMzVRW1c7n9+ijjwZtJ554IoSoL2Lq4eHDh3t5/PjxXu7cuXPQj027dt/y+GkyEO59Vp3biLI0c5zdwzw+79suXboE/Z5++mkvP/nkk0Hb4MGDU883D2Q1YdjX7X03jX/9619e5nI/Y8eODfrdfPPNXu7QoYOXX3/99aAfR2JxhA8A3HTTTV7u1atXpvNr6KSZpmL9+PfTwnvRRjKzGZr72d/MMWPGePmII47wsq29t/3223uZ3UMsdvyaIE2PEEIIIXKBHnqEEEIIkQv00COEEEKIXFByn57ly5cHx+zTw7Zgm9mV/WyszZhDYdPCTIHQ1sh2TGufZGJ2UfYz4szNrVu3Tj0/rhYPyKdH1D0xvzeGs4fzmv7444+DfrFs6ezjE9tz3JY1+3GsX9p9wIbU87kffPDBQRv7H3I2aXvuNvxerGHmzJletteNQ84nTpzo5WXLlgX9TjvtNC/vtddeXrZ+OzwGy0DoMzJ79mwvb7311tHzbyxk9UmL3Q+4LeZLw3vv3XffDdp4j2266aZetr5E119/vZc7duwYtNV2+ghpeoQQQgiRC/TQI4QQQohcUHI97dSpU4NjVnmyqcuGqvKxDQnnMMbu3bt7uWvXrkE/Ln7IIXZNmzYN+rHqjs1snEESAEaMGFF0vBUrVgT9OKMkh68LUR+kqbAPO+yw4JhNP5ySYf78+an9rMkpTQ0eC42tCfZzWe3N39feV/ieYO8rbH45/vjji47XmMlqOrApRLjYJ5sFW7RoEfQ744wzvHzjjTd62ZozuODk0qVLU8+Pw5wnT54ctHFBaJ7nvJi3shYTtixZssTLbHb88MMPg36TJk0q+h5r0mzZsqWXeW189NFHQT9bLLyUSNMjhBBCiFyghx4hhBBC5IKSm7dYTQwAe+yxh5fvvfdeL9uihlwwjtWYMazadfXq1UVla3Li7K5s+rKRVldddZWX+/Xr52U20wGhCn3u3LmZzl2Iuubll19ObbPRlExMVR7LwszEMsZmIWuhRHuuHF1mszpPmDDBy3zfykt2ZmuC5GvH1yBW2Jnv47ZA6N/+9jcvP/XUU14+8MADU8+pbdu2qW1s+mIzCgC89957Xr7zzju9vPvuuwf9dtxxx9TxGzKxuZwzZ46XL7jggqAfu2pwtNWMGTOCfuxi8sYbb3h50KBBQT82XfI9xRZ6jUVUZyWrCV2aHiGEEELkAj30CCGEECIX6KFHCCGEELmg5D49F110UXDMtsW9997by7179w76rVy50svWp4dt9lytuVWrVkG/tMyx1kbP43EonfUz4nBH9kfi8F57HtZ2mXdqWv03zb+gptlyOaQzazinhf1D+HMbig8Ip10AwuzFsevIcxjLyMxjxOztsRDztPUSCyPnNWHD0tmvwKauuO+++7zMGWLzQiwNAGPXDc/R888/7+WTTz456Hf77bev7ykGcBg1/14AwM477+xlzs5sfdVsKHZjIZZBmdO83HXXXUGb/Q2tLm3atAmO2W+O/aeOO+64oB/7CMXu/dwWq5gQQ5oeIYQQQuQCPfQIIYQQIheU3LxlwxGfe+45Lz/88MNeHjlyZNCPi87deuutQRuboLiYnA2lTDODsAoeCNWfrEqz6lkO4bv66qu9bE1Ym2++uZeHDRsWtHH2UhtmmQeymn6s6jLtfVlVmnYN/eEPf/DyokWLMo1hiamQy5XXX3/dy1w0Fwgz6LJamveHbbPmo7TiptZsxW2xMPe0YoOx4sK8Jmw/LoBs923eC4lm3Zt8HwSAPffcs6hs4bQhvG6ypjaw/bhALN9zgdDtYfDgwUXfAwALFixI/ew8YM1ZvI94L2e917HLChD+xvMcvfDCC0G/X//6117OWgTVktVUKU2PEEIIIXKBHnqEEEIIkQv00COEEEKIXFByI/bFF18cfiDZzTlMbYcddgj6Pfroo16+4oorUsdnW6O10af5DVjbfZq/jy1XwSHwAwYM8DJXjwVCu6at6ptHP54YaTb7rP4VHGYMAFOmTPHygw8+6GXre8KhlSeccIKX77///kyfC4Qh3tdee62Xf/e732Ueo67htW79bBj2j7OhzDxnNmUAt/H41reG/QV4/FjIesyen9bPhr/y/cJ+r4ULF6aOL9LJOpcMt9W0ij37pNm0IWnr0Pp95t2PK+Y7GfPj4X3P1/DUU08N+vE9mD+LfXGB0N/LpkRguOTFOeecE7RxyYsY0vQIIYQQIhfooUcIIYQQuaDkur0jjjgiOOaQ9UmTJnmZwwoB4Ac/+IGXuZouAHTp0sXLrFq1oeisMotlhGX1HFdIt+q9jz/+2Msc6njjjTcG/bjNVhrmzNM2C3VjJRZ2mhau+vbbbwfHrCbl6uA21UG3bt283KlTJy/bMNv58+d7+Yknnkg79SgPPPCAl1955ZUajVHXTJ482ctsngPSQ8JtyDqrn60JOE0lbuc5LcO2NTnxvo1l4k7b3/Z1vifY7LFsIuH5ZFO2WJs085R9nddN7H4cu18wvPbuvvvuoO2QQw7x8oknnuhlawaLmVLyQE2zx6dlsefrDoRh6lzBnVMKAOFzQefOnYM2+wxRBaefAEJXB66YYJGmRwghhBC5QA89QgghhMgFJTdvzZw5Mzhm8xFHPe2yyy5Bv5deesnL06ZNC9pYJReLEEjL9BorepkWiWDPl1WmvXr1CvpttdVWXraquu222y71s8uRWGFONo9YEwgTU6GyyvOSSy7x8tChQ4N+XByyffv2Xu7fv3/Qj02cn376qZdt0dr33nvPy5deemnq+bFp1Z7TL37xCy+/+eabXmazLRAWP6xveO3bfcDmiKwZWO0Y/D7O3GxNHWlmq9jeZOya4kKSnFnaRuuwWcx+Rx7jpptu8nJ1IvrKnayZzktNLMIurZ+FswlbV4GJEyd6+Uc/+pGX58yZE/Tbbbfd1n2yjYys5sPYvSLruuHfP3YPWbZsWdDv0EMPTR2jXbt2XuY9a7M/8+9CDGl6hBBCCJEL9NAjhBBCiFyghx4hhBBC5IKS+/RYGyrbb999910v26zGsdBxDjtkW6PNrpnmnxOr5Mx+IPZz2b+Dz8/6DbC/CPusAMDixYu9zOHV5UTMlsvE/HgYDkfkqrtAGGbI2ap79OgR9OO5/eijj7y8cuXKoB+HoLIfENv4gXC9cXjjddddlzreTjvtFLSxDwj7r9jw+HLChuwyaVWV7Tzzmoj5YzAx37usxMLoeZ/x/rZh+ZxV3Z4Tj8nz2ZioLx+eGFkzMnO2dQD43ve+52XOqg4Ajz32mJeffvppL9v1YH0u80BN1kBaiPq6eP31173cs2dPL9tq95z+w97TL7vsMi/zb+3+++9fo3OSpkcIIYQQuUAPPUIIIYTIBSU3b1nzCBd+ZJOFNQmwmcmq1lgtzep1+1lp4da2X1qRPKsK5bbWrVsjDQ7Hs5ljFy1a5OVyNW+x+jOr6vnmm2/28m233Ra0LVmyxMtWnbzjjjt6mdcDvyd2fjFTJc+rzb5rVahV2BDW4cOHp57HH/7wBy//9a9/9fKWW24Z9LvnnntSx6hrrrzySi9b8y0fs+nOhpdyqHDWEPPagPe6NW/xOuVzt1na2bzH9xggNFn/97//9XK5hHk3JnguY/eYa665xst2Hf74xz/28r///e+gjdfowQcf7GXOxA5kN9HnhbRwdvs7llbM2+4VLgLOv/HVuW/88Y9/9DL/Bh9zzDGZx2Ck6RFCCCFELtBDjxBCCCFyQcnNWzZCIs38wIXJgLAwYMy8FVM1Z83InKbWtyo9/lzOEskmOyBU/dkxOCtlucBFKAHgmWee8fJbb73lZRvRwqY6/l4cIQOEhT858goIr7dtY9j0wNc0Zqpk04ZdQxyVxfNnC4dylk9bXLNjx45e3nbbbb1szSZDhgxBuTB37lwvs+oZCOeCTbvWXMffry7NW0xsD/NatOatWDZ3Nrl07dq16HtE7cD3SGty+v3vf+9l3utt27YN+nEk6DbbbBO08bzzfaohmrN4rfOaje09e7+rafRV2vvT9kTfvn2DY86azFF0MaxbCe9LvhfFXExiSNMjhBBCiFyghx4hhBBC5AI99AghhBAiF5Tcp8fCNlq2C9qMzNYvIo00HyH7WWwLtbZ8Ps5a/Zf9IWKh8rEs0fXJ0qVLccsttwAAhg0bFrSxP1UsCy7bzTn7sb0enEXTzhH76rAvkPWF4rXCvkX2s9gvheeBv5Mdg23IXKEbCNeD9TtjPxIev9z8tjhDOJ+ntYmnZSO3c5aW6RxID3m1YcnWbp8Gj89jxEJj2TfMrln237LzxHv1nXfeyXR+5YK9r2RNNVHbn83zYueY9/rMmTO9fOGFFwb92D+Os/Zff/31Qb+YrxVnb2Y/tl133TX1PaUmlvogVvm8JilEapuYT9CRRx7pZc66DAD//Oc/i77H/gbz+Pbez76UvXv3XvfJrgNpeoQQQgiRC/TQI4QQQohcUHLzVtZwT2s6sCouJi27sjUlpYW2x86Jx7AqY/4sNhPYEG02sVjKpZBhq1atcMoppwAA+vXrF7S99NJLXp4+fbqXFyxYEPRj88Dy5cu9bMOE+ZpatSYXca2oqPByzKTCanP7WWlhnLbQJpvj2ARi1ce8VmxqAj4PVt3bUPDvf//7Xr722muLnl8pGTt2bNHXYyYnNm/Z782Zca35KE0VnzW1RE3ha85za9cRm1rtPYa/Z20USK1LYmaPWGhzbVz7NJcA3hNAaGa94YYbvLzPPvsE/ThtxIMPPlijc+LvFTunuiSWPb4m8/Dmm28Gx3feeaeXrcnQZqSvImZm4t8qew/43e9+5+UPPvjAy9ZVIo2YuSyWoqZ79+6p78uaPkOaHiGEEELkAj30CCGEECIX1Hn0VlZYtWZVt2kZKmMq6Zj6MK3gqDVTrFixwsts3rLZQDlywKr/6yuDbTGqzoWLfgLAgAEDiva3Zrt58+Z5efbs2V62GVY5I6o176XNpVVxcgFBLlzHrwOhqZEjsawJktXcMZU3m3xic8eRUGxeAeo/o68tLFqFXd9p2V553QOhuSBmUk7bV/aYzy92jflz7TVNM8fZ785mWGu+tt+lsVDb6y8WhRQzs3Gm5Q4dOnh56tSpQb+hQ4eu5xmGa4/N5nWdkTlJEm+Cj2WP57XHpiMAuOOOO7xso5wZvh8/8sgjQRtn1k87B3uOvI84ig4IzY5PPPFE6jnx7yRnwY+Z1XiPAuH6GjhwYOpnybwlhBBCCEHooUcIIYQQuUAPPUIIIYTIBSU3YrP/BRCGjMZ8cNgWaO3ybDeOhb6lZby0tr+08PiYPw6fe5cuXYJ+EydO9LL1myiXjMwbbrih93Ox1cPff/99L8fspC1btvTyoEGDvGz9dtJ8SoB0Pw27NnjMtPB1IAxh5/fwugPCMMtYVW4+d7tOOIMxr3PrG2KrlNc1e+21V9HXra9Hmo+BnQu+JjG/IB7fXjs+Zlu/vf5p4dB2PD6nWMZoHr++stuWgpifDftkLVmyJOjHe533cIysPkL/+7//GxzzmmI/nuHDh2caL5bGJJb5nn166hrnXPT+V4zJkycHxzxnsXskV6HnVCAAMGLECC8feuih0fMtxgknnBAcH3TQQV6OhZHz3s7K4sWLg2P2kdxtt92qPZ5Fmh4hhBBC5AI99AghhBAiF5TEvMUmh1gWyubNm6eOwWroWCgpjx9TjWcNhY2ZztLU9V27dg368XnE1Ovlgg2xtsdpsAkyZjZg05INe0+7HtYMmFYUNvY+ni9rZu3YsaOXeW1YFXrse6WtG3v9ODy3Pnj88ceLvm7Nt3zM5r927dql9rP7Km3t22vHZrE0kxgQXuNYP563WGbltDkrdtyQiJmc3njjDS/b0GO+B9sizzXJXsxZl8eNGxe0sbk5LUt4jJg5Nta3PovHrlq1CmPGjCl6HkcffbSXec2yydHCaThsFQM2Jdl70Pnnn+/lmHmLOeyww7w8Y8aMoM2GxNcmXDAYyL4OFbIuhBBCCEHooUcIIYQQuaAk5q1YcU9Wf7OJwRLLvpqm1rTqrbSILfv+tMyx9nPZzMYRPzYjc8y8VU4ZmdcXVqfGvPStGlbULU899VTR163ZmE1OvL5vu+22oN9JJ53kZWue5MKuvPatKY3bYns97T02QpCPWT1uI9e4aK7N0p2GjXiy5r5SUHWfyBopFYveqo2Il6ycddZZXp41a1bQ9thjj63X2LHM/BZeK7YwZ13y+eefY+7cuQCAH/3oR0HbpZde6mXeN2witG0cCWZNlfy+WNHOiy66yMtnnnlm0O/Xv/61l0eNGuXl/fbbL+hnM+HXJta8Z10T0si6V6TpEUIIIUQu0EOPEEIIIXKBHnqEEEIIkQtKnpHZ2tnYthgL5c2aVTUtpLXY+6rIWiU4ZjNmv4EePXoEbbHK743Jp0c0DDhNANvHbYhy2n454ogjguPzzjvPy/fdd1/Qxr5Ay5Yt83L79u1Tz4mxfhu8N9mfwWbY5vcNGDDAyxyqCwAvvPBC0bGLfXYVjz76aHDMfiulorqV0WP9+Z5z8MEHB23sB3LxxRcHbSeeeGKmz77iiiu8zP5jF1xwQdBvp512yjRebcC/C7Zqd13SqlUrnH766QCAv//970EbpxLgc7T7kCur87rnTNsA0Lp1ay9bnzdeA9ddd11RGQDatGnjZfbTvPzyy5EG/8bF0ghkxX6vrL53WT9bmh4hhBBC5AI99AghhBAiF9S5eYvVbLFCjBw+yyo3IFTRx7KophVNjBU65fOzKvi0Apax0Ht7frGieUKUAt6DbH7Kqja2XH311UXlGFbdzufBe87eL/iYw95j2dyzEssmzRlyuVgjUHrz1scff4zRo0cDWDvUn+99XPDXZuDl+yd/F5YBYPbs2V6+/vrrgzYOU+ZiliNHjgz6/fnPf/YyFy3NujZqSsykx/d4WxS3vrCZ+8ePH+9lLlptiyhzygT+XhzKDoS/V7FrwylEYteGzWox02R1TbHA2r+tbEqzGZnTUkTYe4pd22lI0yOEEEKIXKCHHiGEEELkAj30CCGEECIXlMSnJ638gyWWXpptftZ2x6GrH374oZdtWv2s4ecM20yt38Ann3ziZU6VbW2JfO7Wh8faa4UoNf/4xz+8PGzYMC/zegZqP/SUsXskq/29tmG/Cq4kD4Q+TnzP2X333Ut+XswXX3yB+fPnA4D/v4qlS5d6mf2i+J4IhH4bfB/s3Llz0O/kk0/2cs+ePYO2Z5991stcMX3atGlBv4EDB3qZ/YKsPxLfF0vtZ8M+IgceeGBJPysrv/nNb4Lj+++/38tcUsL+VvHvJP8m2WvIvjX2d4f91Xh869/Ka8qmo2DW914R+z22v/dpPj0x39wY0vQIIYQQIhfooUcIIYQQuaAk5i3OhmlVnFlNTkcffbSXV65cGbRxCDt/Vix8nfvFqrGzqs6ay1q0aOHlvn37pn4Wq5rtOfF5CFEXsNmGq4zb6tu8z7Jm440RSxPBx7GQ17Q2q1Ln41gI/EEHHeTlO+64I2jjNBTf//73vcyVp+sCzuKbFTbzA8DChQu9zJmx+XUgvFa8NoDQpMVrw2Z15rVizWdMXYaOs3nrhhtu8DJXNq9rbNg3X3vOZH3ZZZcF/SZMmOBl+1tY2+yxxx5e3nvvvUv2OTGTGK87IL1yQ01C5QFpeoQQQgiRE/TQI4QQQohcUBLz1urVq70cU2vbwmKM9XRvSLDazX7/2HcWotTEMr9y5IY1gzAc9WUzATOswq7taLAYbEK2JupevXqltrF569xzzy3R2ZWGVq1aRY/zBkfpNYS5ZLMry5ZZs2Z5edKkSUHb1KlTvcyFZIHQxMm/T7aawO233170c61LyPru55ip86KLLgqOt9tuu6L9rOtMVqTpEUIIIUQu0EOPEEIIIXKBHnqEEEIIkQtK4tPD1X+33XbboI1DGgcMGJA6RiycvaahanUFh3DOmzcvaNt5553r+nSE8PC+uu6664I23rft27dPHaNcqlanEbs/cLoLDmsGwu9Vlz5IorT83//9X32fQq3Bv6f2t/WEE04o2efW9m9ubLz99tsv0xixFDUxtLOFEEIIkQv00COEEEKIXOCyFuIEAOfcBwAWrLOjqE22TJKkzbq7VQ/NZb2h+Ww8aC4bF7U+n5rLeiN1Lqv10COEEEII0VCReUsIIYQQuUAPPUIIIYTIBWX70OOc+9o5N8U5N90596BzbpN19L/LOXd0QR7tnEsvgy7qHOfcb51zM5xzUwvzmp6voPpjD3LOPVZb44k42puNl1Ls0yxzrnVRGjSfa1O2Dz0AVidJ0itJkh0BfAHgx/V9QlU452qWICCnOOd2BXAIgD5JkvQEsB+Ad+v3rCpxzpUkV1UjR3uzEVLO+1RUH81nccr5oYcZC2Br51xX59z0qhedc79yzv0+9kbn3AnOuWmFv0qvKbz2E+fctdTndOfcXwryyc65VwtPxX+ruok651Y5565wzr0CYNcSfMfGTHsAFUmSfA4ASZJUJEmyyDk33zl3uXNucmGOtgcA51xT59ydzrkJzrnXnHOHFV7v6pwbW+g/2Tm3m/0g51y/wnu6RcY5vaChGAFgZN1dhkaJ9mbjIW2fXlbYQ9Odc393hcxyhb/mrynMySzn3B6F15s45x4oaBeGAvBZIJ1ztznnJha0D5fXx5fMEZrPIpT9Q0/hL/HBAKbV4L0dAFwDYB8AvQD0c84dDuAhAEdS1+MADHXO7VCQd0+SpBeArwGcVOjTFMD0JEkGJEnyYk2/T04ZCaBzYSPd6pzbi9oqkiTpA+A2AL8qvPZbAM8nSdIPwN4ArnPONQWwFMD+hf7HAbiZP6TwEHQ7gMOSJJkbGQeo/HE8LUmSfUrxhfOA9majI22f3pIkSb+CZq8JKrUHVXwrSZL+AC4A8L+F134C4NOCduGPADgN/W+TJOkLoCeAvZxzPUv5hXKO5rMI5fzQ08Q5NwXARADvAPhHDcboB2B0kiQfJEnyFYB7AeyZJMkHAOY653ZxzrUCsB2AlwDsi8oJnVD47H0BdCuM9TWAh9frG+WUJElWofK6ng3gA1T+iJ1eaB5W+H8SgK4F+QAAFxfmYDSAjQF0AbARgCHOuWkAHgTwXfqYHQD8HcChSZK8s45xAOCZJEmW1dqXzBfam42QyD7d2zn3SmHf7QOgB72t2P7dE8A9hTGnAphK/Y91zk0G8FphHN7DohbRfBannP0ZVhf+ovM4575C+KC28TrGiBUMGQrgWABvAhieJElSUPPdnSTJb4r0/yxJkq8znLcoQuHajQYwurDZTis0fV74/2usWY8OwFFJkrzFYxTMJUsAfA+V6+Azan4fleuhN4BF6xhnAIBP1vtL5RftzUZKkX36I1T+Fd83SZJ3C3uQ57bY/gWAtRLAOee2QqU2t1+SJMudc3dh3etErAeaz7UpZ01PMZYAaOuca+Wc+w5CtVwxXkGlyq11wf5/AoAXCm3DABxeeG1o4bXnABztnGsLAM65ls65LWv7S+QN59x2zrlt6KVeiGcpfRrAz8jW3LvwegsA7ydJ8g2AUwCw0+oKAN8HcKVzbtA6xhG1j/ZmAydln1b9wVDhnGsG4OgMQ41BwfTonNsRlT+yANAclX9s9IsQxAAAIABJREFUfOSca4dK06goEZrP4pSzpmctkiT50jl3BSpvmPNQ+ZdgrP/7zrnfABiFyr8sn0iS5JFC23Ln3BsAvpskyauF195wzv0OwEjn3AYAvgRwDpRGfH1pBuAvzrnNAHwFYDYqVa5pP4z/B+AmAFMLDyzzC31vBfCwc+4YVM5poK1JkmSJc+5QAE86586IjCNqGe3NRkHaPl2BSr+t+QAmZBjnNgD/dM5NBTAFQNUcvu6cew3ADABzUWm2FKVD81kElaEQQgghRC5oaOYtIYQQQogaoYceIYQQQuQCPfQIIYQQIhfooUcIIYQQuUAPPUIIIYTIBXroEUIIIUQuqFaentatWyddu3YtyYl88803wfF7773n5U8+CZPntmrVystt2rQpyfkAwPLly4PjiooKLzdv3tzL7dq1K9k5zJ8/HxUVFbHstTWilHNZaj77bE0i5pUrVwZtG264Jl/hBhuseaZv1qxZ0G+jjTYq0dnFmTRpUkWSJLW+aBvyfDZUtDcbF6XYm5rL+iE2l9V66OnatSsmTpxYO2dlsA82l156qZfHjRsXtJ166qle/ulPf1qS8wGABx98MDi+4447vDx48JrkkxdccEHJzqFv374lGbeUc1lq3nprTVWJp556Kmhr2bKllzfeeE1G9N12Cwuyd+zYcb3Pg3NcFZI+rxPnXEmS6TXk+WyoaG82LkqxNzWX9UNsLmXeEkIIIUQuqNcyFD/+8Y+9/MILLwRtbO6y5iPWAt18881e7ty5c9Bvm23WlB1p0aKFl5ctC4trsybpiy++8LI1nbRv397Lt912m5dHjBgR9BsyZIiXu3XrBpGNrJqTn/zkJ15+9dVXg7avvvrKy59//jnSOPPMM738+uuve/nTTz8N+u25555evv7664O2Jk2aePnrr9fUu2QTmxBCiPJBmh4hhBBC5AI99AghhBAiF+ihRwghhBC5oM59ep5//nkvz5s3z8u9e/cO+rE/jQ1n/973vuflDz74wMtz5swJ+nFEGEdaTJ06Nej3rW+tuQytW7dOPaelS5d6eauttvLyihUrgn6//OUvvTx8+HCIbGT16Vm8eLGXN99886CNfbK+/e1ve9nO0T333ONlDoG3oewzZszwMq8TIPQn489lXx8hhBDlgzQ9QgghhMgFeugRQgghRC6oc/PWM88842XOVGnDi9nM8OWXXwZtbIJikwObR4AwjJjNFNb8wNl6N910Uy9zVmgA2GSTTYp+VqdOnYJ+bJp78cUXg7aBAwdCFIfNmJxNGQjNR++8846XmzZtGvTjkHU2b9qMzGwWYzMrm8SAcJ5//vOfp567PV8hhBDlh+7UQgghhMgFeugRQgghRC6oc/PWokWLvMxFO2PmLTZT2b5sjrAmDDaJMDZjLpujOCMvm7Ps+GzOsOfHkUcyb8Vh85GN0mM46o/NVmyOjI1h1wKPwevJmlJ79uxZ9D1AGEW2xRZbpJ6DTF9CCFEe6G4shBBCiFyghx4hhBBC5AI99AghhBAiF5Tcp8f6N7D/DFc+ZxkIs+Ra2O+C/WlWrVoV9OPwZfb9sX4bfI78Hnvu/L6NN9449fzYp2fWrFmp/UR4rWy4ODNhwgQvs//MZpttFvR76623io5t/bM4kzfDfmYAcNhhh3l55MiRQdvOO+9c9Jxs6gQhhBDlgTQ9QgghhMgFeugRQgghRC4ouXmLs90Coclo9erVXrZmBc6Ya81RH3/8sZc5I7MNS2YzA5vLrPmBw+PZvGX7sbmEw5Ct6YSxWZ1FSNYio6NGjSr6ujVv7b///l6eO3du6ths3urVq5eXp0yZEvTjNXXUUUcFbVtuuWXRc7IpEUR25s+fHxwvXLjQy0r3IIRYX6TpEUIIIUQu0EOPEEIIIXJByc1b77//fnD8ne98x8tsIrKmJDYd2IzHnIWX32ejt9hsxZ/FrwOh+YyLkVozBUcXtW/f3ss2Uy+fR6tWrYI2Nqu0adMGeYfnlk2VFjZVcdbs8ePHB/1atmzpZV4bNjpw0KBBXmYTygknnBD0u/LKK1PPKatpTsR58MEHvXzppZcGbQcddJCX2ZS54447lvSc7rnnHi9vu+22QVv//v1L+tlCiNIhTY8QQgghcoEeeoQQQgiRC/TQI4QQQohcUHKfng8//DA4Zl+Yjz76yMtjxowJ+p100kle7tChQ9DGfkJcIZv9cYD0DL/Wd4T7cci67de2bVsvsy+JraK9ww47eJkzUAPAm2++6WX59KSHd48dOzY4Xrp0qZfZn8Our+XLl3uZ0x7YDMycQXn27Nle5rkT1YdTUvC+sKkbzjvvvKJt3bp1C/pNnTrVy2effbaXx40bl+l8rJ/fnXfe6eWKioqgjVNoNGvWzMv2/tNYiaXoiHHzzTd7uU+fPl7m+yUQ3jP53tezZ8+gX8eOHTN9blauuuoqL/fo0SNo+8EPflCrnyXKH2l6hBBCCJEL9NAjhBBCiFxQcvOWNStwNmXOsmv7TZo0yct77rln0MYqbw5jteYsVrVzmLrN3MwmLc7cbEPROYyeszC/8sorQT8eo1OnTkHb66+/7uU99tgDeSdNhc4hw0Coeuf5sikB2MSZlmnb9mOOOeaY4PgXv/iFl2+44YbUc1f4eiVpxVaXLVsWHHNh2K5du3o5ZhLhe4RdH3vvvbeXH3vsMS8PHz486McmLLv/TjvtNC+XOiS+HLGpQdJSSDz77LPB8fHHH+9lNlvZa8/Zzvn+eeuttwb92MTZr18/L3OBXyA0RdtM3s8995yXFyxY4GWef0DmrazYfc1rgOere/fuqe8rl/uiND1CCCGEyAV66BFCCCFELtBDjxBCCCFyQcl9es4888zgmKtgr1ixwssc9giEoaUc5g0AG2+8sZfZj8f66nDILJeasPZJHoNtzex/BACvvvqqlzl1vvX14BDc22+/PWjjMhx5xPoNpIWsjxw5Mjhm3x2+vlySAgjnOS1lAbB2qHsVp5xySur5HXbYYUHbI4884uVysVfXFuwPZ79b7LumzedOO+0UHHO5kBkzZniZ0wwAoR8Hz9nPfvazoB/7zn3ve9/z8i9/+cugH/vqcPoMS5oPGbB2GZuGBM8rEN4jrQ/PzJkzvcz3Oy7bAgBPPPGEl3n+7HXq0qVL0c+yJWL4+N133/XyhAkTgn7sP2TP/dhjj/UypziZNWsWGiu14T/D5X6uuOIKL7PfHQC88MILXj700EO9zD6Q63Meadxyyy1e7tWrV9A2cODATGNI0yOEEEKIXKCHHiGEEELkgpKbtywc9j1s2LDUfqyGttl5WZWdFiJrYbWuVfGyyaV58+ZetiYQ7sfq+T/84Q+ZzkHE1Z2cisCGoG611VZe5izcbOoEgM6dO3uZVbU2y6vNol0Fr08AeOmll7zMWcIbAzFTR9r1qS2uu+46L++7775eZpMhEGZGZvNIu3btgn6s9t5rr73W+/x4nTYEc5a9D/Ixy2nmRwB46qmnguMbb7zRy+eee66XbdbsNJPRkiVLgmO+pmyWbtq0adCP1yWnlrDrldeGTTXB65dNZJyxHVjbVFeOpP3GVcfszGZ/Nic/+uijQT82BTLTpk0LjjnUn6+p/a2uSVoWTlcDAD/96U+Lnsfhhx8e9JN5SwghhBCC0EOPEEIIIXJByc1bVjWXZmayKmSO9mA1JhCq8XgMG2XBHv0xdT2/j8fmSC4gVJPGsBFKTEy9nAdi88ARW3Y9cNQbq2rtnHOBSTaD2aKRnN2XP+udd94J+l166aWp53v66ad7+a677krtV1dU7bWYmpv3Y2wuFi9e7OV///vfQduTTz7p5eeff77a5wkAAwYM8DJH2vDYQLiH08weQBhdFDNv8d7kgsdAuHY4c++iRYuCflURSjZysD6x91meW75unAkbALbbbjsvX3755UEbR9Bydno2NQPAySefXO3z5cjdp59+OmjjzM1sorZmMM7+azP6s2mN58neV+rCvFU1N7GCrrE9W5MIKHsfu+SSS7zM64FNxkAYpcUuHJtuumnQj81iXBXBZuHmagUcgWvngSO07bnvvvvuXma3h+nTp6MmSNMjhBBCiFyghx4hhBBC5AI99AghhBAiF5Tcp8faI9mnJeZTYP14GM60yxXNbVZOtt+n+QHZ8+DxrA05luE3bbzGlqm3JvA8WJ8m9rvhrNw22yb7InDmbTsn1vZcRevWrYPjOXPmFD0/TlkAhL46Npx99OjRXubK3occckjRc6gr7PrOugYvuOACL3P2cXtNOESVw0mBtStmZ+Fvf/ubl++///6gja8x2/NttvS7777by+x7xxnggdCHY+XKlUEb+4fxvcT6H2yzzTYAQh+guiIt6669l/L88XxxaD8A7LPPPl5+/PHHgza+3uy3w/5TlrRraGE/kOOOOy5o42P22/jrX/8a9HvmmWe8zH5+QOiHxfcLm/G7Lqiap6z70O5fXmcVFRVetr4vy5Yt8/Lbb78dtHEqD85Yzv5TQHgv5L1sr9t+++1X9Nzt/Zj3G+9LWz2BfTY50zYQ+mQdfPDBXrYpEdjvLIY0PUIIIYTIBXroEUIIIUQuqPOMzAyr0qwqlNWVto3Vzaz6s2GsbKri91j1IY/PoapWVbftttsW+RZrUxuF3xoTsTB9zmbN6k9WfwOhejbN1AWsbZLMck68HqyZgNcUm+KAMBs0F120ZpMTTzwx0zmtL9VVo1t69Ojh5XvvvdfLVeacKrbeemsv2xDViy++2Ms2HDYN3pusegdCFTtffw5jBYDevXt7mdNd2EKJ/fv3Lzqehe8JNjN727ZtAWRfazWhak1mzbp72223BcdsmuJ5HTRoUNCPTUS27cUXX/QymxVi90E+v1iIdtZ7JJu8beoA/v2w5k7eg3wvsW4TNpVFKbG/O2lh2mymAsLUCmzqsaZ8Ni3aa//d737Xy2PGjPEyh5EDYabzqnUOrH1P46oIjDUx8X7mNAV27/DvuE0FwSkSuBgtm3CB0PQXQ5oeIYQQQuQCPfQIIYQQIhfUq3krxnvvvedlGz3BZivGqtbSCgVaE0aaKS0W5cVe6VbVl7UIamMldt0sHB3Famib/ZojiNh8MXv27KAfR6qwacNG2mQtIsnmTqtO5siXmkQt1SZJknhTn1UPs0o4Zko466yzvMxRVNbscdlll3l5l112Cdo4uy6PZ+dz/PjxXuasu3Zv9+zZ08v9+vXzslWPs6mKo+wmTpwY9OPzYHU7EJpQeQ3brL1Vpp5Smq6rW/DV3oPY3MdmD2uq5MLO9nv26dOnaBtH2liyZpyPXTteQ0OGDPHyQQcdFPTjQqc2OpOz6fP6t+dXavPWsmXLcM899wAITb8AcMYZZ3iZI5ZstCSboPh7WlMdZ6W2EVBsMuPIWLse+H7HRWbtb1pa5ntbjcAWeK1i6dKlwTGbpuy9mT9r8uTJXrZFqbMiTY8QQgghcoEeeoQQQgiRC/TQI4QQQohcUK8+PTG77ssvv+xla+PjMGW2vVtbM9snuc3adbkf+wrYCt7cj22S1p7O59SYq6pnzQ7LjBgxIjhmXwH26eFrDYQhkxyeakOceW0sWLDAy9bWzJ/F5xvLItutW7fg+B//+Edq37rm888/91mmbdVqnqdYpXL2EWDfGhuWzv1sWoezzz7by+xHYDPm8vu233774Hsw7McxYcIEL3fs2BFpcIjvHnvsEbRNnTrVy/vuu2/QxmuR9z5XIgfWrJdySkdhw3fTfClsFltOu2AzjnOIOGcwj8HX7f333w/aeF7YZ9P6YvLnPvzww162KRA4S7D18eLfDF5r1t8ttt9rg+bNm2Pw4MFFP4vnLGvFcPYrtPfIefPmedl+Fu8rfp8dg++TPJc8d/Z9fP+0v9W879lXyc4X31Ni+4p/x+1anjRpUur7GGl6hBBCCJEL9NAjhBBCiFxQr+atmBmEQ5Fj5ig2Z1jzVlooeszkxGp9Dnu043FWYA7tBMpL7V1KavI9OdwZCMPKOXzShjjzvHCoImeNBcJssby+Ro0aFfTj9cBmHmuGSTuHGLFMtKVigw028CpiNhcB4TXhLLA2NJbVxRxOa8NaWY1+/vnnB22HH364l3lfxAoMcnFEa2KZNm2al9kkac1gPD7PoS28yGOMHTs2aGNTKZsBbSbgqky1pTKNrFq1yq/rYcOGBW3t27f3Mn8Xe69ikxGvW2vS5HDgmTNnBm28jjmc/6mnngr6pRUZtWarNDOyNXXw+uX32HvCG2+84WW7b/mYTS42VPp//ud/UEqcc/7zjz/++KDNHq8v/J3tbyvvF74e9l6Vdo+zv5k8Bsv1+dtns3KnIU2PEEIIIXKBHnqEEEIIkQvq3LyVVtzRRkpxdklrtooVtWPSTF9WLc1jpBWiBEI1Hpu3LNXNptoYiBXt5KibKVOmBG2cOZT72YKjXHSOC15alSZn7OSIgIEDBwb9OCMwrxMbjcRrjTO7xqgPFe8GG2zgTRccGQOEUVQcBdeyZcugH0f88LxYswJndOVCiUBo0mLTFEfaAGEUCmfFtaYkVrdzpJE1b/Exr0WbmZajU+x8Ll682Mux4o1VpqRS7fMmTZr4TMl2LvmYC6FyoUggNIPxNbSFIzkTrr2mbPria8BFgoHQRM3RUfaezvB49vryuuE5svPF+yxmluZim/Z6nnrqqanvqw023HBDb0a2156PeV1aUxL/XsX6MfYexHPL+8iOYX/zqrBzlPa7a1/n8Vi2a43XSux78RjWZM4FUmPk79dZCCGEELlEDz1CCCGEyAV66BFCCCFELqhzn540W6C1d3JlWRtmyKG27NNhs0HaLLxVWFsznxO/x9pF+X22ujfDtv76CF+uTdJsskD4PWP+Db/+9a+9zPZkILwe3GZt7xymzv1stly233MINmdnBsLq0hzGbe3J7ONj/VLKCfYdsHPB+yWWwZz9bHj/2Qr1HCps1wTvVQ51t3suzQfH+nJx+DL7JrHPChDOIX8v6zvAfiHWp4l9Xzj7L48NrPEVK1W29Q033NBfh+OOOy7Te+y9jr8Lh47bueRrb+/BvPbZZ8bew7haPY9nK5jzvuX1YLMk83jcL1Z9284Fr3kO57fZ8+0aKCU2RYQ9FnWDND1CCCGEyAV66BFCCCFELigb85YNi2VVayz8jsPWbD9WyaaFvtr3cbZnVvcDYehgmuoXCNWwVv1fjgVI7Zzw9+HvmTVE97rrrguOOTx8r732CtrGjRvnZb42NjyV1dx8fraooTWFVnHHHXeknhOH0VuVM3+WDX8uJ5xzfq7steP0CjyftiglFxXkcP9YGKqFrxebozg0Ggj3MJuo7dg8XiwsmeeN16ldH3yfsVmM2SzG9wQO0bfjlwv2vsJZjlnOGtYrRGOl/HavEEIIIUQJ0EOPEEIIIXJBvRYcZWyERNbMsTEzE5tEYuYtHoMjB2y0AL+Px2OzAAC0bt3ay7GM0eWCNQvarMRV2AgRzsb7l7/8xcs33nhj0G/XXXf1Mme9BYDddtvNy5xN2WZaTjM9xEwNjz76qJcPPfTQoO2JJ54o+h47Hs9fLCMz96vvCL0jjzwyOGaTERfgtHPBpsG5c+d62RaE5LVvs5vzNeL9xxm1gTASjs3I1kzDUVr8nqwmJrtm+Tva/c0mt5ipVQjRcJGmRwghhBC5QA89QgghhMgFeugRQgghRC4oG58eDm8FQvu69RtgHxrOHGvt9+xbwX4NNjssh+eyT48NWecx+LOsbwT79DREHnroIS//8Ic/9LK9buzbwVgfiBkzZnh55513DtqmTp3q5e7du3t5+vTpQb+0zKz22g8fPtzL1o+HScvWbeE1ZDPMMrw2yi0tAfu/cAZrm826MRLzERJC5A9peoQQQgiRC/TQI4QQQohcUDYZmefNmxcc23BShgvNdevWzcu2uCDDJjFbOJJDtHlszs4MhGHTbM6w4dVMQwhZt1lrL7zwQi+zaZHNgDGs6Yjn5eWXXw7adtllFy9zmLT9LA415gKKRxxxRNDv8MMPz3SOaWH51hzCpiFbDJNpCPMshBB5R5oeIYQQQuQCPfQIIYQQIhfooUcIIYQQuaBsQtatLwWXfIj51rDvD1dcB0LfDw6Jtynx7fuqsL4pfI5c8iJWdiBWkbpc4HINQHittthiCy/z9QTC68Ph6/Y7s1+M9X2ZMGGClzt16uTlvn37Bv24RMX8+fO9PGzYMKTBvkS8ZoC1SytUkbYWAKBdu3apbUIIIcofaXqEEEIIkQv00COEEEKIXFA25i0bQsymJGtyaNu2rZfZdGJNGPw+Hs9Wbf/000+9zGYPa4pJM2PZqu1M1mrQ9cmpp54aHP/nP//x8syZM73M4fxAesbrWNh3kyZNgjZ+35w5c7zMIepAmCl71KhRRb7F2thM3kxaSgT7Hs4EHQvZZ1Nf7HOFEELUH+X/iyyEEEIIUQvooUcIIYQQuaBs9PCzZs0KjtmcYU0Ry5cvLypbM9iHH37o5ZUrV3p59uzZQb8lS5Z4ecqUKV7eddddg35s3mHTV1p234aCNTk999xzXl64cKGX77rrrqDf448/7mWOropFQGXFFjN94oknvDxo0KD1Hn+bbbYp+jqvOyDM+N2jR4/U8cqtyKgQQoi1kaZHCCGEELlADz1CCCGEyAV66BFCCCFELqhzn560EG6bgbeiosLLHKIOhKHpbdq08bL1q1i0aFFReeeddw76cebeBQsWeNmGqG+yySZeZt8fzlpsaQgh6zE4S/Lvfve7oM0eV2H9s7h6OvtgAWH6APafSfO5qS24kny/fv28bNcan1+rVq1Sx1OYuhBClD8N+xdZCCGEECIjeugRQgghRC5wNutwtLNzHwBYsM6OojbZMkmSNuvuVj00l/WG5rPxoLlsXNT6fGou643UuazWQ48QQgghRENF5i0hhBBC5AI99AghhBAiF9T7Q49zrpVzbkrh32Ln3Ht0HK3v4Jwb5Jx7LKXtDufcd1PaLnDObWJe+41z7iTn3OFp7xPrxjl3hHMucc5tn7H/fOdc6yKvryrWPzJOtfpHxjndOdehNsbKC8653zrnZjjnphb27YBaGHO0c67v+vYR1UNz2fApxRzS2Km/uQ2Fek8ukiTJhwB6AYBz7vcAViVJ8qdaGPfMYq875zYEcAGAewB8Sk0HADgWwHUAHgPwxvqeQ045AcCLAI4H8Pv6PZUacTqA6QAWraOfAOCc2xXAIQD6JEnyeeEBtmEXo8spmsuGTznPoXPuW0mSfFXf51Hvmp6sOOf2Ig3Qa865TQtNzZxzDznn3nTO3esKGQX5Lwfn3Crn3BXOuVcA/BZABwCjnHOjCu3NUbkwtgHwAwDXFT6nu3Oul3NufOGpebhzbnMa/ybn3Djn3HTnXP+6vSLlh3OuGYDdAfwPKh96ql4fVLhea80T9WninHvKOXdWkXEvdM5NKMzB5ZHPv945N9k595xzrk3htbT5W+t159zRAPoCuLcw/03SPkt42gOoSJLkcwBIkqQiSZJFzrnLCnM23Tn3d7Mvr3HOveqcm+Wc26PwehPn3AOF+RgKwF9759xtzrmJhb9eU+dfrDeay4ZP2hzOd85dXrg/TnMFTbxzrqlz7s7C/L7mnDus8HpX59zYQv/Jzrnd7Ac55/oV3tMtMs7pzrkHnXMjAIysu8sQIUmSsvmHSs3Ar1LaRgDYvSA3Q6WWahCAjwB0QuUD3MsABhb6jAbQtyAnAI6lseYDaE3HRwK4oiDfBeBoapsKYK+CfAWAm2j8IQV5TwDT6/v61fc/ACcD+EdBHofKvzawjnmaD6ArgGcBnEpjrSr8fwCAvwNwhfc+BmDPIp+dADipIF8G4JZ1zF9sXvvW97VsKP8Ke3EKgFkAbqVr2pL6/BvAoXR9ry/IBwN4tiD/AsCdBbkngK9o/7Ys/L9h4f09NVeaS/2r1hzOB/CzgvxTAHcU5CsBnFyQNyu8rymATQBsXHh9GwATC/Kgwj14NwCTAHRZxzinA1jIa6i+/zUYTQ+AlwDc4Jw7D8BmyRo12atJkixMkuQbVE521yLv/RrAw5GxDwLwpH3ROdei8FkvFF66G5UPOFXcDwBJkowB0Nw5t1k1vk9j5AQADxTkBwrHVcTm6REA/0yS5F9Fxjyg8O81AJMBbI/KTWj5BsDQgnwPgIFp85dhXkVGkiRZBWBnAGcD+ADAUOfc6QD2ds694pybBmAfAD3obcMK/0/CmnWwJyrnDUmSTEXlQ2kVxzrnJqNyDfQAIJ+7EqC5bPhE5hAoPlcHALjYOTcFlQ+eGwPoAmAjAEMKc/4gwnnaAZV/iB6aJMk76xgHAJ5JkmRZrX3J9aTefXrScM6dA6DK1HFwkiRXO+ceR+VfFOOdc/sV2j6nt32N4t/psyRJvo58XH8AP6nBadokR7lNeuSca4XKG+KOzrkElX/JJc65iwpdYvP0EoDBzrn7/r+9Mw+XqrrS/rsc4hAVRVARZHRgEjCgBjXOIcZE/Ry6jUkbjd0ZzBejpttEkzbdrSZqmy/RpGObxHRsTIgxse2AIw7ggKCiMomioqCIiiASMZKg7O+Pqrt59+KeTd3LHarueX/Pw8OqOrtOnTr77H3OXe9aa4fqnwq8awCXhxB+1sJDKm1fdDTVsTUVwNTqJPllVP7CHxNCeMUqsXpb00eargV/HWzQZ2Y2AMA/Adg/hLDSzG5w+xJtiPqy8WmmD8+obmqurwzAySGEBbyPaj+/AWAkKh72NbT5NVT6bT+sj30s2s+BAN7d5B/VhtStpyeE8NMQwqjqv6VmNiiEMDeEcCWAmaj8xd9a3gGwPQCY2TAAz9JDUdwWQlgFYGWTVg3gdAAP0H5Ore7jEACrqu3LyikAxocQ+oUQ+ocQ9gDwEoBDavjsdwGsQMUd67kbwFlWiReCmfU2s12aabdZ9RgA4LMAHi7qv430a+x/sXHMbB8zY8/bKABNE9/yar+dsuEnN+BBAJ/R1VpAAAAgAElEQVSr7nM4KjdaANgBlUlzlZntCuCTbXLgYgPUl41PQR/mKkLfDeAcitPar/p+NwCvVT3zp6PyR2wTbwP4FIDvm9nhG9lP3VG3np5mOM/MjkDlKXU+KnLU2Fbu6+cA7jSz1wDcDuAu2nYTKm69r6MywM8AcJ1VUtxfBPAFarvSzB5BZTCf1cpj6SqcBuAK994tqDyA/G7D5htwHoD/MrN/DyE0eYcQQphsZkMATK+Op9WoxA4tc59/F8AwM3sClfihU6vvF/Vf0fs3VN9/D8DYEMJ7NRx7mdkOwE+q0u77AF5AxbX+NoC5qMQSPF7Dfv4TwK/MbA4q8udjABBCmG1mTwF4GpV+mtbWP0BE1JeNT1Effrqg/aUArgYwp/rAsqja9loAt5jZ3wCYAuetCSG8YWbHoXIfPSuzn7qj9MtQmNk9qATQvtbCz01FJeh6ZrscmBBCCCHalEby9LQLIYSPd/YxCCGEEKL9Kb2nRwghhBDloG4DmYUQQggh2hI99AghhBCiFOihRwghhBClQA89QgghhCgFLcre6tGjR+jfv387HYpojkWLFmH58uW28ZYto7P68t130+KcK1asiPYWW6y/HDfffPOkndH6pO+/X7xQ74c+tH5B4T//+c+Fn1m7dm2099lnn40ddpvxxBNPLA8h9Gzr/dbj2ORznuvPRqUrjE1OZPnrX/+abHvvvfUlqj784Q9He8stt9zk7+Xv4u8BgG7dum3y/ltDe4zNehmX69atizafb3/ut91222jzGOX5EkivgW22qb91mXN92aKHnv79+2PmTJWl6UjGjBnTLvvtrL58/PG0ttn48euX29p5552jvf32aVFkfiBavnx5tP3Ns2/fvtGeNWtWtJctS2sZvvnmm9GeMmVKTcfeFphZrjpqq6nHsckPtP5Gxv3ZnvjsVH692Wab5uju7LHJNzL/W3LbGH74ePnll5NtTz/9dLQPPPDAaO+2224bPbaNsXjx+mEwf/78ZNsxxxwT7Vofjvn3Aq3r2/YYm+05Llvym1evXh1t7le2AWDEiBHR3mqrraL92mtpGbtdd9012iNHjiz8Xh5vHfmHTq4vS1+nR3QsU6dOTV7Pmzcv2jwoXnrppaQdD1p+6Nlpp52Sdnxz3XHH9eu/9ujRI2m3aNGi2g9aJPBEdvfddyfbbr755mjzw+Qbb7yRtFuzZv1SPl/5ylei/dRTTyXteGJ/5plnoj14cLoKzfXXXx9tnrj9RMuv/QNRo3mf+HhrvQF++ctfTl7/5S/rl8TjmxyQ9tk111zT7PcCqRdgv/3Wrz7gvQj8oMsPOv4PnLvuWl8g/+2334728ccfn7Q7+eSTo93ah75GJve7FixIlsDCO++8E+3nnnsu2nPmzEna8fzJcyv3A5COXx5Ho0aNStrV45jqmleDEEIIIYRDDz1CCCGEKAV66BFCCCFEKVBMj+hQfPbWgAEDov3WW29Fe4899kjasUbP2VYck+DbcUxP9+7dk3b8OY7vqYdMi3qAA03/9m//NtnGfbhq1apkG8cZ8Dnn7B+/f47z8rFcDAcOc4wCAHzmM5+JNscbfOlLX0raXXjhhdH28QadFXTZWmoNyr7ooouivXLlymTb7rvvHm2fvcVjkPvZB7XyuT/77LOjPXbs2KQdB7/y9/p4O44R4mwijhcD0sDr888/P9lWxuWVFi5cGO0lS5Yk2/r16xdt7j8/f3If8Vzosy856YTjfXzQdnsF+28K8vQIIYQQohTooUcIIYQQpUDyluhQOF0SSOvlcFq6l8H49S677BLtXNFBlkC8u5s/9+CDD0Zb8laFM888M9peEuFUVi9bsczCEpEvLcCyJpcgOOqoo5J2O+ywQ7T/9Kc/RXu77bZL2hVJU3fccUfSbuLEidF+5JFHkm2NIGkxubTsF198MdpcFsLLxixv+N/P++zdu3eznwFSmen3v/99tFmaAlIZi/v1gw8+KPxetlkSA4C5c+cW7oPlGN7mZZquBMtMLFMBaTmCPn36RPvGG29M2t16663RPvbYY6N99NFHJ+2GDBnS7Hf5UiBctqBeihjK0yOEEEKIUqCHHiGEEEKUAslbokNhKQNIJahcVhBnArG72stWvA9213uXPMtbXr4pK7/4xS+izdV4fXYNn/9c1hD3jV+7h9dFY7e3lzW533IyBb/eeuuto92zZ7r8Dktkt9xyS7KNK/w2ArmlPO67775ocx/xeQfSc5Vb047Haa9evZJtLFFPmjQp2r46L8vXLHv4a4jXdWIJz491vqYeeuihZNvhhx9e+LlGhs8HS5hAen55CR4glTVZqnzhhReSdrx2IWfzLV26NGnH0jDLm5xBBqRS2mmnndbs+x2NPD1CCCGEKAV66BFCCCFEKdBDjxBCCCFKQWliejiV8rrrrku2DRs2LNqcMnvCCSe0/4GVDB+rw/EBrO3zKsxAGnfDcQieIv3ep89yO/9dZeXaa6+NNp8fnw7McPyF/xyTq37M+DgV/m6ON/DtOCWXY1P86uMc++PTdRstpicHX9N8rn3MFJ9Tf64YPm++cjOfey4lkGvH8Tg+pofHN88XXGkbSK8pTssH0pieXOxTo8FxPBxLA6Rz3J577pls49XUDzjggGjvtttuSTtOOec4Kf4MADz22GPR5nihI488MmnH1820adOivffeeyft9ttvP3QU8vQIIYQQohTooUcIIYQQpaDr+P02wowZM6LtFyt8/PHHo/2Tn/wk2ueee27S7uqrr27x93p38mWXXRZtTgv+2c9+lrTzskEjw2nHnDIMpNIiu9q9HMLVRl999dVoc5omkFZ6ZXevT7vmKqJ+AUWRSh1epuD+zMmGuXR27t+iKs5AKk3wNp9ezcfL8oivAsvtfPVYTsv11X8bDU4d5nPoSwdw6riXjXk8ch/lqpvzd/l2LHVwOy8/8fXF38vH6vfPafNdGZ4HuTK93+bH0bhx46LNcySXGPDtWFr2shX3Gfc/LxoNpBXb+drzc+5ee+0VbV9tva2Rp0cIIYQQpUAPPUIIIYQoBQ0vb9W6mBxHjnfr1i3ZxnIXR/1fc801SbvTTz892qNHjy78LnYz8v4AYMWKFdHm6qhnnHFG0u6www4r3H+jwS7P7bffPtnGFXPZRe0lFT5X7Lr1Lu+DDz442uwa99cGu/K7UsXWlnDWWWclr/lc8vl+5ZVXknbsHvfZH5yhw32YW8yy1kUgixaR9LAs8/rrryfbuCK4vxYfeOCBaHP12EbAy1YsEbCkzOcGSKVivxgpjxGWBXOVm/24ZVi2qrXPOWPLSyd8vL46cVeCxyWfXy8LspTk50WeW/mc9uvXL2nHfcsZW1zFGQCefvrpaBdV0Pavc1mVS5YsifbgwYPRnsjTI4QQQohSoIceIYQQQpQCPfQIIYQQohQ0fEyPjxVgWAN+6aWXou01Q9aaOV7BV7UcM2ZMtE855ZRo9+3bN2n3wx/+MNoDBgxItnEMBGvtO++8c8GvaHy4mrKPKeDYDo5L8O04hoOrzfrUYq5S2r9//2j71GXu565UHqAlnHPOOcnryZMnR5vPv48P4H7yJRk4zoDjNnLjlLflKjdzP3H8ApDGn3Aava/Uy7/Ff9eDDz4Y7UaL6fEpwByTxWPMl3jgOXKfffZJtvGYy1Xo5v1zrEatVbj9+OOx+uSTT0bb9zlfhxxH2dXgOLSi0gxAGqvTvXv3ZBvf43gM+PN2/fXXN7sPHxvH8FzhY8t4PuBr1M/vXL5FMT1CCCGEEG2AHnqEEEIIUQoaXt7KVX2dMGFCtHfcccdo+3Q5dsFxSrmvNsvu3zvvvDPa3sU/ZMiQaHMKL5AuoMcuaE7ZA4Dhw4ejq8BuV++iZtg16t3wXFGZ3ebcr0Dq8uWKu14+5D7Ppdl2Zfwif3wN8uKbPlV44MCB0faLHvIY4bHpXfFFac/shgfSMcif8dcRS8Xslu/Tp0/Sjredf/75ybb999+/2WNqBFgGAoqvaZ5zgOJqykDxoqB+zs1Jl0XtcinrRZWbvRTDoQJ+fPPYZ5m7EeH5k22/sgDPhb6fuc/4nuTvcX/84x+jzeVW/Dnk+1guFZ2lNJa3Ro0albTLyWdtjTw9QgghhCgFeugRQgghRCnQQ48QQgghSkHDx/Tk+N73vhdtXnrCr/RdtDIw66d+G5dA95o2l7f36b6sV7NmzqvAA8AxxxyDrgKfH586zrAe7JcK4TR1Zqeddkpec/l9XrnXx55w3/rlCARwyy23FG777Gc/G22/ujXH5HAcj48DKVo+xrfjMZeLP+HrimOT7rrrroJf0bXglF8Px3D4+EMu3ZBLN+ax6VPPi9LUc3E7nKbu98fHwcful5rg+DG/j1mzZkW70WN6OH6G5zcf08PbfEq4j5Vrwt+fjj766GjzPc6347HNc2nuezl+yLfjffi+rDVmrFbk6RFCCCFEKdBDjxBCCCFKQUPKW+z+YtcXV10G0jQ4Tm/0shW7cXNuNm7H7nmfHuqrYRbtg13506dPL/xMo8PnMVdigLd5d6xPYW/CV82ePXt2tFne8qmZ7DKudcVnUaFoHACpzJQrVVBUndf3BUsnOYmFjyO3CnjRvoF8Zeh6Z+HChclrlohYivDlB/bee+9o+7FZdB5z540/U9TH/vj8NcQyDW/z7fh7/TEtWLCg8LvrHZ9uzuEYLAv5+x2PMV/Ko+ja9vculvqLxh5QPN78NcSyGFeW9u1YduWyMUBarqQtkKdHCCGEEKVADz1CCCGEKAUNIW/5yHGO6GdX3SWXXJK069mzZ7Q5S8G76nJuc4Zdeuye9dk/vM1nRPBvYTfu1KlTC7+30eE+8lk3LDuxNOKzgoqyvtg9DwDTpk2LNrv1Wd4E0uqg3m0u8vjsxyKKMrSA4sVl/XjJZfkwvP9c1W8mJ7U2GkuXLk1es7SYq9TLc6mXs4okvlrHS63n11etZ8mFszP9tcHztpe//QKsjYQ/73xtswzkx6E/j0XUKkflMm35fPO49PP7c889F23OqvR9yWPWV2eWvCWEEEII0Qr00COEEEKIUqCHHiGEEEKUgrqN6WGdMKctTpo0Kdo33HBDso3TmVn/9LpjUQp8rh3Hi3gtlXXz3ArerFe/8MILyba77757g+PuCni9mvVlPqc+vsCnYDYxdOjQwu/i1EcfD8LxXo2WntzZcNqzH5tF8QI+jq7WdGh+zbENPq6EY39qjW3oSvhUdB8z0UQups7D557Pdy62irf5uY/7j8e6L0/B4zEXn8W/0Vcn9jFOjYTvO+6jomrVQLrSvE/7Lior4Mcbn28e274vebzlSkRwDBLPub7iftFK8u2BPD1CCCGEKAV66BFCCCFEKWgzeYvdmkW2h93fXmLISQ6XX355tC+99NJoDx48OGnHbjd2z+ZSJHPHW7TgoXcRshvXp+oWSWns7gXWVxb2KaaNSM7lXbRYnU+lLFoUdP/9909ec19wf/l+KFoIT2wcrqzKpSCANOWVXeVejipapNJTJH/6ccHHwaUgyoIv68FjrqgqLpD2Ua2VrH1/8XdxP/s5jeF2fqzzHFHrIpV+XmnkMhT+2ubfwufeS5o8p+X6KHfv4te8fy8z8j2Uj9efd/4uTkX3C+SyNCd5SwghhBCiDdBDjxBCCCFKQZvJW229WN/EiROj/c1vfjPZxovJjRw5Mtq56pLs8vZuXG7H7ric5JbLJMlJJ0ULlfosmCbXYiO7aZvIZX5wNsLKlSsL2xVlaRVldQHp9ZBz3St7q0KR9OphF7iXMHghV+4b70YvkpFz7vGcTMqvc7JKrb+xEfBZTwxLBCxpjRo1KmnHfeQlh6LK9zlJhLN6ijLIgHS+82OTf9euu+4abS+x8O/KLQ7Nx8HHV694CZKvbR4fOVk+VwGd50UvGTK5cc5Zxbw/Py5ZtuL7rL+GeP+vvPJK4TG1BfL0CCGEEKIU6KFHCCGEEKVADz1CCCGEKAXtXpHZV4a89957oz1r1qxo33bbbUm7efPmRduvpM1pyqxV+rRN1itzqehMUVq6h/Vlr62znur3wcfE3+X176Z2jR53AOT7iFfQ5ZWR/TndY489mt23T2UvqhSaKyuQ07XFhhTFGABpLAn3RS6lmvfhxwGPH+4z3598vXSl1dNzcAych89pUfwFkI+74ba5c1rr3FqUKu3jQHg8ckVfH8PCK3j7WCXe57Jly6Ldu3fvmo61M/F9wr+Ff7MfA7vttlu0+f4JpDGtuZTwon72cyRXwOaVBWbOnJm048rLHJ/l48f4GvIxTW1NOWYHIYQQQpQePfQIIYQQohS0Wt6aOnVq8vqSSy6JNqecsWsRAHbfffdor169Oto+HfFjH/tYtL3Ew+4+3pZzwfFnfDuu5squRe8+5DTLXEVZTgP17v+iSqR8LgBg7NixAIDf/va36Eq8+eabyesimdC7vHnx2BzsxuX9+ZIA7OItYwXf5qg1nTu3OCCPLZa3/PXN+8+VZSiSm/338jZfqbboexudt99+O9r+fPD8xBVz+/Xrl7TjMeKleN5HTsIqqhjs8WnURZ/hsc9p88OHD0/a8X3Gz+l8TCyRNQI+rb6ozAmng/ttvqpz0Rznzw2fbx6zfuFrPt98v3vppZeSdlxq5IADDoj2XXfdlbTbd999o+2vtWeffTbaftWF1iBPjxBCCCFKgR56hBBCCFEKWiRvrV27NkZdn3322ck2dndxRg7bQOpC5chu757MLXbGsAs2l6GTg2Um/i7vdmUXIctgnHXkj8Mvbspux5z8cuihhwIoXmizkeB+8Fk8S5YsiXYum81n8BXBLl92//vz2NYVxMsESyQsIQNpZVU+r74/eVtRJheQzhe5CsR87dS6cGajk5Psi+aZT3ziE0m7OXPmRNvLKjyP5aqb8/75M74v+XO8Py/N8XHwb9xrr72SdjfffHO0vXxalAHWCPg5kudPPteHHHJI0q7oPgYUS8he0uRxmRtHvH+eZ30fMfws4KU57i8/H7d1Npc8PUIIIYQoBXroEUIIIUQp0EOPEEIIIUpBi2J63nzzTVx77bUANkwp5vicWis+cqq4111Zx/TbWPNjTdJXk+Q4Gd5fLr2Tq37638gpkq+//nq0uRImAPTq1SvaXrvk2BI+JtZFgfWaaVevLlukt/u0xe7du9e0vz59+kT7mWeeibZfJZj16kZYebkjKIrh8H3B8SI+JoDPZS4VvSgF2o85HiPcZz5eLxdzUusxNFpsV65iPP82budjDDnWyo+xWmN6OL6D2/kYLN+3Tfg5kvfBc66PYeFUaR8zxvGXPt263vHxWfxbeB7LxWDl4Psf37f9d3NsEd+rAeDVV19t9nsHDhxY2K5nz57R9jFYfG346vu5mN7W0LXvqEIIIYQQVfTQI4QQQohS0CJ5y8yiq9TLEiwLsdvNS0nsumSJKOdq9tIEu2h5f969V5QW6SUjdsOyO867RQ8//PBoX3rppdG+++67k3b8W3LVNdnF196LrNULvo9YKuFryp83XtQuxy677BJtruTp5UN+3QiLEHYmXqbi69uPpVplptxisEzRNi/t8LXTFco81EJOZuQ5k+e3nLzF8zGQjjmWOnzFax5zvM3LNNwvvBD1yy+/nLRj2YrnSC8/8vFyRV8g/f0+Bbze8fdCHissM/kqyzwGvPzL46hoUWb/OrfAL7fj/vKSJlfgZwmLqzMD6bXsy7e09XiWp0cIIYQQpUAPPUIIIYQoBS2St3r16oWLL74YwIYLR95///3RZrejjw5nNxm757x7luWo3EJ4bPt2RdIXu1Z9u2984xvRPu+881ALN954Y/Kas7e8W5Ddy+xaLsps6Grk3K7s4vTZAt5VXgRngvBn/LXB5zuXBSPy2Y5eLinKtvIUVe71Ega34/35721NBd5Gz97ia9hLTqtWrYp2bmFj/s25yshFi14C6b2AJeWPfvSjSbsiGczLp1zlm4/dZ8nya78Q5fPPP194vPWOnyP5/LB85Fc7mDlzZk3757Hjzz2PIx4fPtSD5UN/TTF8j2cZc5999knaPfjgg80eH7BhaMKmIk+PEEIIIUqBHnqEEEIIUQr00COEEEKIUtDqYIYf//jHyWuOT7n66qujPX78+KQdp4SvXLky2r7qIqep+XgOTmnj7/Xpcvxd/Jl//ud/Ttp9+9vfxqbAKxUDqXbp9VmOW+EKlU2r1zfRpEMXVa5tJDhWwKdZ8u/j1NLdd9+9Vd/Vv3//aLOW78seMIrpqVB0rbVkleqiFdN9vExRantulXUmF4vAY6wrw7EUubgKPr+PPvposo3jQpYsWZJs43PK+/d9wn3B+/NjnffBn/EVmefNmxdtTpu/5557knY83/uYJo4L8XNrI+PTuRme43Kp6Nx//v5UFJPnS4jwXM3jzcfwcmwm36s5zR3IV2/3MT6bijw9QgghhCgFeugRQgghRClotV/fp2Kz++uCCy5o1vZwmvuTTz6ZbGMX5+LFi5NtnMLG7j7vBvva174W7QsvvLDwOIrIVXhmrrjiiuQ1V6fOLR7HLr7Ro0c3u+9GS6NtDnZrencqS1Dsrvbuz1rhtFg+d/488vf6YxIpnP4M1J5izraXzooWefVueXbF8/fm3OF+8cmuyrJly6K95557Jtt4juQUcJ/2zdKznz9ZwuD+8n1ZJF/nxjpv8+UpWE5lycannvN3LViwINnG102jz6E8L/bt2zfaPo18/vz50fYVqotkZz/eeBv3uQ8PYMmwaIUEvw/+HbmQgtwqBm2BPD1CCCGEKAV66BFCCCFEKdBDjxBCCCFKQatjeoriW1rCkUce2axdL9T6G88444x2PpLGhmMsimI5gFR35rioXDuv17P2nNOaOY4gl85eJmpNWc+d/6Ixk1tJPafZcxxH7joqiiXqyhTFwwHptb98+fJo+/7imEifYs7jIlc6g+OHBgwYUNiuaHz7/uJSHnw9+ePLxQ/x72+0khQcgwUAr7zySrRHjRoVbR/rumjRomiPHDky2cZjjM+HP/d8HrlsiF+6idtxX/o4I97GMWj+OuRj8ktctXXMpTw9QgghhCgFeugRQgghRCloLL+faHi4wqqHXaG5yqPskvWuT67uyi5TL7uwe1XyVh4vb9WaEs7lGnISFqfN+r7gvs71E/cvu+UbfSX1HFzF3ksiXJmcSw546YCrJHtJmdvy+fXV81lmYpmNU949fLy+HX8X9xdXugdSidPLnTzP5CS3emT48OHJaz5+rnjsJacTTjgh2r4qOY8Dnhf9+GBZkMevL1vBKybw/ODnY57HWWb15QdOOumkaPtrORcS0Rrk6RFCCCFEKdBDjxBCCCFKgeQt0e6wm5wj+IF0gUKu7JqTMnLyVlEFUC9rsESTW6yxTBRJP/78sEucXdYAsHTp0mizK95nifA+WN7yMiTLYnzt+P2xBMDV3DmzCMjLq43GsGHDou2lKV4E+Xvf+160fSYTSyQ8FoFUdnr++eejPXHixKQdS2ncf88991zSjs899/m4ceOSdty33H/++FhymTlzZrKNK7offPDBaCR8hWr/ugm/igGTW6Qzt4Aw9x/LTH6e5X3wvO0pWmTWS5VcUZyls/ZAnh4hhBBClAI99AghhBCiFOihRwghhBClQDE9ot3hFX+PO+64ZBtr+927d4/2EUccUbi/XKVsXkWadWIf28FVXzk2oswUVa495phjktd33313tLkKLJDG+LDW7+OCOF6A01d933LsFccI+dXCOW164MCB0c7F8DR6+jqnNn/rW99Ktj388MPRPv7446PNacit5eKLL97kfbQFHNNz7rnnJtsOOeSQaDdaReYcPF/6uB2Og/RxNkUlQHw6OI833p8/hxynyXOpjxfieCQ+hqI4JWDDeL22WP0h2V+b7k0IIYQQok7RQ48QQgghSoHlFpLboLHZmwAWb7ShaEv6hRB6brxZy1Bfdhrqz66D+rJr0eb9qb7sNAr7skUPPUIIIYQQjYrkLSGEEEKUAj30CCGEEKIU1MVDj5mdaGbBzAbX2H6RmfVo5v0WrSfQ0vaZ/ZxpZrtvvGV5MbOdzWxW9d/rZvYqvd70PFrR5mxKn5nZ4WZ2W8G2681saMG288xsW/feRWb2OTP7P0WfE+2LmX3HzJ42sznV/j8wMw8fb2YXFuzncDM7qP2PWBRhZruZ2U1mttDM5pvZHWa2dwv3saOZfbW9jrE9qYuHHgCnAXgYwGc6+0BayZkA9NCTIYSwIoQwKoQwCsB1AH7U9DqE8FcAsAoddk2aWdcp4NEO1NJnrdzvP4QQ5vv3zWxzAOcB2NZtGgdgMoD/A0APPR2MmY0F8GkAHwkhjABwNIBXitqHECaGEK5oZj9bADgcgB56OgmrFKe6FcDUEMKgEMJQAN8GsGsLd7UjAD30tAYz2w7AwQD+HvTQU/2LYKqZ/cHMnjWz35irJmZm25jZXWb2xWb2e4GZPV79y+TfMt///8zsSTO7z8x6Vt8bZWYzqp+91cx2KnrfzE4BMAbAb6p/ATVfBUo0i5ntaWbzzOw6AE8C6GVmf2dmc6vvf7/abgsze5s+9xkzu57seWY228ymUPsfmtlj1f76h+r7R5vZvWZ2E4CnOvwHd0HM7DDyAD1lZk0rBm7X3PitjusxVXu1mV1iZo8C+A4qfzxMoX7cAcCHAOwF4HgAV1W/Z1BmnE41s6vN7JHqdXFAx56RLkcvAMtDCH8BgBDC8hBC08qy51Tnz7lW9dRbxfP9H1X7huo4nALgdwC+AuD8ah9+rBN+S9k5AsDaEMJ1TW+EEGYBeNjMrqqOl7lmdipQuT9X741NfXxC9WNXABhU7cerOv5nbAIhhE79B+DvAPyyaj+Cyl8TQOUvglUA+qDycDYdwCHVbYsA9AdwL4DP075WV/8fB+DnAKz62dsAHNrMdwcAn6va3wXwH1V7DoDDqvYlAK7eyPtTAYzp7HPZKP8A/CuAf+9OaXsAACAASURBVKraewJYB2D/6us+1f7tAWBLAA+g8lfmFgDepn18BsD1VfsZALtW7R2r/38VwIVVeytUHnD6ovJX6moAfTv7PDTSP+6zZrZNAnBw1d6u2le58RvHS3UM/i3taxGAHvT6JACXVO0bAJxC23Lj8RdV+1AA8zr7/DXyv2qfzgLwHIBr6ZwvAnBO1f4qjcczaS69oTr/br6x60j/OqQvv46Kx9a/fzKAewBsjorX52VUHna3ALBDtU0PAC+gcl/t36jjqtM9PahIWzdV7Zuqr5t4LISwJISwDpVB15+2/RHAr0II45vZ57jqv6dQ8R4MRuUvRc86VP76AIBfAzjEzLqhcuN8oPr+fwM4tOj9mn+lyLEwhPB41T4QwP2h8tfkWgATsPHzPA3A+Ko3p+maHgfgC2Y2C8CjqLhjm66B6SGEl9v0F5SbaQB+aGZfR2WMNNXKz43fJj4AcEtm38cAuNO/WcN4/C0AhBAeBLCDme3Ygt8jiBDCagCjAXwJwJsAfmdmZ1Y3/0/1/yfQfP8CwO9DCB+05zGKTeYQAL8NIXwQQngDlT8290flAef7ZjYHFSdDb7RcCqsrOjWmwcx2BnAkgOFmFlB5ygxm9s1qk79Q8w+QHu80AJ80swmh+hjKuwZweQjhZy08JBUt6hx4wZaiBZHWuW1bk/1FVB6WPg1gtpmNqLb9agjhPt6JmR3tvk+0EDP7v6iccwA4NoRwhZndDuBYADOq5xjIj98m1mzkhngAgLNbcZh+LGtsbwLVPpoKYKqZzQVwRnVTUx8X9S+g8VZPPA3glGbeL5p3PwegJ4DRIYS1ZrYI6dzbcHS2p+cUAONDCP1CCP1DCHsAeAmVp86N8V0AK1Bxt3ruBnBWNV4IZtbbzHZppt1mWH8BfBbAwyGEVQBWkt58OoAHit6v2u8AaIpjEJvGDABHWCVzaAtUZKwHqt6ClWa2l1WCnU+kzwwMIcwAcDGAlaj8NXI3gK9W9wEz20fxVm1DCOGnYX1A81IzGxRCmBtCuBLATFQ8q60ljiUzGwbgWXooits2Mh4BoCkm4RAAq6rtRSuojh32lI9C66sMa67sXO4HsJVRHKyZ7Y/KvHmqmW1uldjWQwE8BqAbgGXVB54jAPSrfqxh+7Gzs1dOQyUgirkFlQeQ323YfAPOA/BfZvbvIYQm7xBCCJPNbAiA6dXYydWoxA4tc59/F8AwM3sClfiDU6vvnwHgOqukzr4I4Asbef+G6vvvARgbQnivhmMXzRBCWGJm30Xlr0oDMCmEcHt187cA3IWK3jwflVgdAPiRmQ2otp8cQphnZs+gEsMzq3oNLANwAkR7cF51QvwAlX65E8DYVu7r5wDuNLPXANyOSn83cROAX1RltFNQPB6BygPRIwB2AHBWK49FVNgOwE+qEuH7qMR1fAkVz2pLmQTgD9WA2HNCCA+13WGKjRFCCGZ2IoCrrVJWYA0qsVnnodLPs1Hxin4zhPC6mf0GwCQzm4mKRP1sdT8rzGyamc0DcGcI4YJO+DmtQstQCCHqEjO7B5VEhdda+LmpqATLzmyXAxNCNCyd7ekRQohmCSF8vLOPQQjRtZCnRwghhBCloLMDmYUQQgghOgQ99AghhBCiFOihRwghhBClQA89QgghhCgFLcre6tGjR+jfv387HUox77zzTvL6L39ZX+i1R48e7fa9b775ZvJ6m23W17bbbrvt2u17mUWLFmH58uVF1TJbTUf25bp166K92Wb18ZzNAfxmbX56C3niiSeWhxB6tvV+O2ts1sratWuT12+/HdeOxQcfrC/I7BMrtt9+ff2zjhpztdIVxqZYT3uMzXrpy7feeivaf/rTn6L9/vvvJ+14/PG43GKL9FGBx+Juu+3WZsfZVuT6skUPPf3798fMmZtW+qI1N5spU6Ykr1988cVo//3f//0mHU+Oa69Niz2PGDEi2occUkvR6E1nzJgx7bLftujLWnnvvfW1GvnBsTPhwe4HdHtiZq2tZJulPfuzJRmeRWP61VdfTV7fdttt0V65cmW0/cPREUccEe3cmCuaV/yxt+UDblcYm2I97TE266UvJ0yYEO377lu/Ms/y5cuTdjz++OHIOxcOPvjgaF9wQf3VJcz1ZX382S2EEEII0c7UTXFC/msPAE4++eTCbVtuuWW058yZE212xwGplMISC7v6PK+//nq0ly1LV63g/W299fo11x577LHC/YnUu/PXv/412cbnu3fv3tHOeRfYc7RmzZrCbStWrIh29+7dk3b9+vWD2HRynhP25vz85z9PtnF/9Oy53gvN4xRIva3PPfdctM86K11ZolYPTmfJmkK0BbWGCuy0007J61Wr1i89161bt2h7aerdd9evDfvhD3842gsXLkzaTZ48OdoXX3xxtP18zNTL2JOnRwghhBClQA89QgghhCgFeugRQgghRCno8JieIi3v/PPPT14/++yz0d5rr72SbZtvvnm0H3/88WjvscceSTtOdf/kJz8Z7enTpyftOOZk9erV0eZ0Wf+9zz//fLRvuOGGpN2ZZ54J0Txf/vKXk9d33XVXtHfcccdo+5ierbbaKtqcYeBjQPj64v737ZYuXdqSwy41fszyufTbbr311miPHz8+2j4ri+MROI5g5513TtoNGjQo2vfff3+0R48enbQbOXJks8dXLyUShGgLctfzCy+8EG0/3/F44XIRu+66a+H+OUaWY1iBNCZy0aJF0b7ooouSdpdffnm0ea7wx9eR41QzghBCCCFKgR56hBBCCFEKOjVlnV1cCxYsSLax+8xXRuYUV3bBcUorkKbcTZ06tbBdUXE673LjdOtevXpFm114gOStHPPmzUteF1Xz5KrbAPDaa69FmyVIn3q+ww47RJtdsvVSFLER8VJjzhXNaepcMoD7DwAGDBgQbU5zfeCBB5J2XMaAJckf//jHSbv//M//jPaHPvShaHemG31TaDrnHZnamyvkmEs35jmYz69v15oCkvWS5tyR1FpQ86WXXkpec+o4z4NAWhyUC7NyiQ8gvcf9+c9/jrYPHeF9cHr8nXfembTj9PgLL7ww2n4cdqQk3RgzgBBCCCHEJqKHHiGEEEKUgk6Vt771rW9F28sZ7KLmzB0gzaJi2cK76njtEJZEvPuQX2+77bbR9hWe2Q3Px8AyGgDccsst0ebK0iKtwAyklXn5PHrZi92zAwcOjLaXrfi6YXvatGmtPGLREllh8ODB0ebK6X4cFFU357W2gNTdzpXZvUzKFWdzFZ4bRd4qOudz586NNp9fnt+A1q0Lluvn3DaeC1uz/9Z+b1cl95u5Evk999yTbOP1sfxaWW+88Ua0OZzDLzjKcjKvcemvL74X8rztFwXmSuwzZsyI9v/+7/8m7YpWT/Db2oLGmAGEEEIIITYRPfQIIYQQohTooUcIIYQQpaDDY3pYr+PKyKzJA6ku72N6GI7H8bE1Pn6kuWMAgN13373Z/fkYIf4ca5q+3U9/+tNoK6Ynxa+yzvEAHNfF8ThAWjmUP+M16aJYEa+TL168ONpacb3teOaZZ6L91ltvRXvPPfdM2j399NPR5jggH9vHabM85ny1dI7fy8X0NEIK9Lp16+Lvvvnmm5NtEydOjPaIESOi7eMeHnzwwWj37ds32lyNF0jPm698z6VC+Jx6eJ88V/tj4hhJ3jdXYgfSPsvN/dx/fl7heYGvKV/+hGNk6pUpU6ZE++GHH4627y8+bxzvBaT3Rp5b/RjgKvYHH3xws+8DwJIlS6LNMUJ+XPK8zXPDpZdemrTjdHulrAshhBBCtAF66BFCCCFEKehweYtdV+yq+/znP5+044VEc+5Pdpn6ysqcDs3prlxN2X+OFz/0bjZ2r/P+fJqtd0mXHT5vy5YtS7ax651lK79AJbtnOU3du799amUTfiFLru4reasCSz9s59zNv/zlL5PXffr0ifawYcOi7WUmHoPsOvdyJbv2hw4dWnhMnAL7j//4j9H2MmlusdR6YdWqVZg0aRIAYNasWcm2yy67LNoPPfRQtHnhXiCVdkeNGhVtX8WXZRC/EDOnPXPK8/Lly5N2XOaDZTBeNBpIxyC34zR8IB3fPPf7sc4SHlf/BtLfzPIpz+9AunB0vXLjjTdGm+9VXtJj/LXN547nWX9O+X7K14YvS/CFL3wh2q+88kq0/WoHLE9z5WaWujoaeXqEEEIIUQr00COEEEKIUtCpFZmZ8ePHJ6856+m+++5LtrHrkjOncouYsWvVu/5YEmEpxstlnOlw0UUXRfsb3/gGRDGcxePPKbs8fYYAU5TFwW58IO0j/i5f4dlnC4p0XBQtIgkA999/f7SfeOKJZBtLE3z+/T54QUTuC5akAeC4445rdhtnj/jX5557brSvueaapB0fR60LO3Y0W265Zcwo9bLCzJkzo/3YY49Fmxd29K9ZBjrssMOSdlzp3M/BxxxzTLQXLVoUbX9Mp556arRZvmZpA0jnAd7mpY6DDjoo2jxve+mEQwz8vMLXF2dssSQIpDJNvcJSP49LP4cNGjQo2rm5lPFyMr/m7/Jjg6VL/gzLoEAalsByGUtiHY08PUIIIYQoBXroEUIIIUQp0EOPEEIIIUpBp8b0cMyN1/x5pXLWkwFg//33jzbrmL6aK2v2rE/mqrQy8+fPT16zTsppmiIPa/l+VXSfmt6EX+GeyVXV5W38Xb5at0+7FSm5lbMfeeSRaPtyEhx7xfEiw4cPT9otWLCg2W2+5ADHAXAKtU+95hR4juviaw9I44L8PFDrauHtzZo1a+L54XMIpLEQfN4WLlyYtOM5c86cOdH25TW4ar2vms1p4Lx6NpeZ8HCJgD322CPZxvMp/y5f0Z7hir5NafzNbfPX1wsvvBBtLn/iY11y310v8FzF90kfP8MrC/gYSI674evc3/uK7pO+9ANfh7zNV2Tmyuv77LNPtP1559IBvtJ0WyNPjxBCCCFKgR56hBBCCFEKOlzeKqr06uUMdsGxWxtIXeBFVWSB4uqr3q3N38378O0kabU9XCLAL5LHsHTJrlrfJ9x/uYVJc9VMy0qti3GyfMS2hyURliIA4OWXX442py/772XXPqcoezmcj4P71lc0PvLII6Ndr/LWFltsEWU4X8GcSy+wpOV/C3+u6DNAWsl6zJgxyTaWMEaOHBltLlkApFLjvvvuG22WlYA0FX3q1KnR9hLpk08+GW3uE3+PYAnPLyTK8gnv398jiuT1eqIo/dzPYSxV+nsmS1C50AEOCShKX/f7Y9vLVjy/89jm94FU7pS8JYQQQgjRBuihRwghhBClQA89QgghhCgFHR7TUxQrkIshKFqCAEg1WZ+yzksUFKWv5/bnS5sXUa/l7OsF1p59LAafY44B8Zov6/Kc+sil+IG0/Dz3g//eeonfqCc4LoTPj4+X4Bic/v37J9tYmx8wYEC0fXwH981rr70WbY4JAdK4El6SwMdocWosx7D4Fbw5pqdex+kHH3wQVwPncwgAH/vYx6LNK6v7WIohQ4ZEm8eET3M+77zzou1jdTieipcCOvjggwuPifv/2GOPTdrNnj072rz0xGmnnZa0K1r+guOKAGDGjBnR9qUJmKFDh0abV1wHNow1q0e4vAOvTu/vd4y/J3Fbvsf5McDzZC7ukcdfURyl339RaRggHaeHH354Ybu2QJ4eIYQQQpQCPfQIIYQQohTUzSrrOVezT2XmFDl2s+VSntlV591sLLGwi18p6m0DlxjwlT2ZXIo5S5zcR34lZ5bB+Hrw8lZO4iwrRe7niRMnJq/Zxc5SI5COJXaps8QApCnVfH14mYLHIMvVPo23SQ4CUjmH03g9tcrXHc37778fZSiW9IA0BZ/T9P3cxytw8zlgiQkAjjrqqMJ9sKzygx/8INp+XrzxxhujzfKWX8GcZYspU6ZE219DLNX94Q9/iPbbb7+dtOMK0l4OX7p0abP789dhrauRdyR+DPD44KrLXt7iOY3HA5CeHx4f/rzxPnjO9PMxw3KZl8R4H3yP9/f7J554onD/bY08PUIIIYQoBXroEUIIIUQp6FT/bq0VYD3sDmU3rne7skuOJZFc9Wfe1q1bt5qPSRTDLlQvKbD7MydvcYVRdvF6iiqs+u/1spgoHoM+e4vHLVfWBdL+7NevX7S9NMGSCy9S6LOtWK7k4/MSAI9VXlzWL2DKkkAuK7Qz2XbbbTF69GgAacVkIJV0eJHVBx54IGnH8iFnaPnsrSuvvDLa/nxcddVV0eaMuGuuuSZpx1leLF9Pnz49aXfcccdF++tf/3q0/TXE1wZnbHkZjBcg5Sw/IF2AlCUXL+999KMfRb3B1cqB4pUFPDz3eamS59acrMvjN7c6QdFnPPxduewt/5vbE3l6hBBCCFEK9NAjhBBCiFKghx4hhBBClIJOXWW9tRVROc2QtUqvGbK+zNo+xxAAxat2e62SV3neaaedCr+3Xiu9dha1rmjOOnSuL/nc86rA7XFMZaKoSvW8efOS1x/5yEei7eNAnnvuuWhzn/Xp0ydpx2OE4za4Krdnjz32iPaSJUuSbRw3xr/Dj+Hnn38+2hz3UU9sttlmMS7pzjvvTLYNGzYs2lzJeMWKFUk7fs3nbcKECUk7TntfvHhxso3jXQYNGhTt008/PWn3P//zP9Hm2A++ToB0NXaOreJ5FUivDf4d++23X9KOt/l9fPKTn4z2r371q2j7FO1cnEln4eOueF7MVTjOpYTzOOC4VR/fWnQ+/P74PPLx8dwMpPFZXDrA7y9XyqStkadHCCGEEKVADz1CCCGEKAV1s+CoT4ljd9wvf/nLZBu75Dil1S+6x/tg26fscaofy1u+mutFF10U7euuu67ZfYsN4f7KLZLH14aXn9iFypKKT23n72KZw6ey545DpHKBl5zY/e5TzFmq4jTnF198MWnHbnQuH+AXgOR0eZZHfCo69/uzzz4bbT82eeHTepW31qxZE6she4mIf8/8+fOjzYt+Aun1Pm3atGiPGDEiacfVeXkRUADo27dvtH/9619Hmys1A2kqOvfLww8/nLTjMTxq1Khoe4maK37zfHz77bcn7fbee+9on3/++ck2lln52vD3Hy+T1gO+RESuGjJTJIMBxfOiHx+1hmbwPZT37cvGsAyWC23h0jPtje7WQgghhCgFeugRQgghRCmomxX3cm61++67L3ldVEHZw641jg73UgdLa2xzZVegYxdF60pwH3kZk12e7Gr18hNnBbBskpPBcpkZRZWbRQU+r5zhAwDjxo2LNlf+BdJ+44wtlqGBVCJ74YUXou2za7jaL1d49lI2zx+8qKTPasotQFovbL311thrr70AbPg7+drnCsW86CeQnoMhQ4ZE+7LLLkvajR07Ntr+3Nxxxx3RZsnFVz9mSYsXhf3Nb36TtDvhhBOa/S5fjZclt9deey3axx9/fNKOr7Vbb7012XbggQdGu6m6NbBhhWuWyOoFn4nGfc74TCluV2uWmp+P+d6auyfzNt6Hn7cPOOCAaHMVdT9v+4rt7Yk8PUIIIYQoBXroEUIIIUQp0EOPEEIIIUpBQ8T0+AqV3JbjRXwqOuuYrCH6KrK8v5ym6VeuLYI1TqWzp/hzyOeYz5VPSe7du3e0eaVprw3zPt59993C46g1DbSs3HLLLdH2Ket8zv05fvTRR6PN1YR9O44L4VIQv/vd75J2nM7MMXU+xfXoo4+ONldsf/XVV5N2HBdUr4QQYsyZT0XnWI0pU6ZEe+bMmUm73XffPdocZzNw4MCknU8/Z3hsHnnkkdH2MV4c78Nz67777pu04/gOjlXycSAcx8XzO1eWBtLq2j6mh4/pxBNPjLaPC/Lp4fWAj+Pi88N90q1bt6Qdp/r7fuVUcr4/+VifohjLXIVnvmf6Y2+KTQPS68bHHHXkfKw7shBCCCFKgR56hBBCCFEKOlXeqnXxUU5bBFIZi91kPsW8qBKnl5z4OIoqVwKpe04SVu0UuWeBtC+5rIB3d7K7fpdddom2l01YPuP+87KaUtbzcJVkL2/xAqS9evVKtj311FPR5r72lVpZcuHUW99P7C7nsend8pz2zlWdvcTCkki9snbt2jjncfo2kM41XAbA/07+3Pjx46PtQwW6d+8ebV8ZmSs581jidHAgTfvm/jrnnHOSdixP5hYSZclp0aJF0b7//vuTdryoqK9czSnQPFd7iaweFxzlsQGk1z3Pi4MHD07a7bzzztH24QEsheUqVBfd1/w9rkj68vMqzw9cDd2Xmsnto9awklrR3VoIIYQQpUAPPUIIIYQoBQ0hb3kJo8hV57O3ir7Lw9+dOw52+XP2iK+MKVJY3splC3Bf+uyc7bffPtosb3lXaNE15eUy7kuxIXx+fIYcS8q8uCeQyiC5McdjldvlKnbnxiZn/LCE4TONvNu/Htl8882jPOUXxORKxmPGjIk2y78AsHDhwma39e/fP2nH8pHPaj3iiCOizdeAl1W40i7LZV5K432wFLN48eKkHe+DpUpftZflN65ODQDHHntstHnxUb5OAOBTn/oU6g1/nfMcx9t8lfOiKslAOt5yoRm5FQ6YogW8/b2a+5mvL86wBFJJb+nSpcm2ts64lKdHCCGEEKVADz1CCCGEKAV66BFCCCFEKaibisw5uBovkOqBrCd6LZTjAdj28R38uVwMAWurrGMrpicPn1Mfg1NUidPHXvhYhCZ8Si/HmxRVIQVq167LCuvqBx10ULKNU0jnzp2bbOP+zY1NpmicAmm/se3LSfD3cjo0p0kDacyBjz/wJS86k6aYCV+tePr06dHm9Ht/fXP8C1ck9uPokUceibZPe+fXfBy/+MUvknZ8PfTo0SPafgwfc8wx0eZ4pCuvvDJp9/TTT0f7i1/8YrRHjhyZtLv88suj7cua8D2C46K4QjCwYcxXPeBjU7lved7y5SJ4Ls2VBuGx4sdR0ffmUtbZ9hWZ+d44ZMiQaHO1diAtl+BXmVdMjxBCCCFEK9BDjxBCCCFKQd2krHvYjeddZkWpyN6ll0tZruV7veuPj5fdqYMGDapp32JDWYn7hV3o3sXrF0psgtNbgdSl7lM6RR4uE8Dn0Y9TTof2KcCtISdvMexu91VaWabg+YIXIgWAyZMnR9vLL/Uib2255ZYxVdtXSWaJgMeLT+fmlO3DDjss2lwxGwDGjh0bbT/GuGwBf5eXyDg1nc+pl+a40jJX9R42bFjSjtOced8vvfRS0o7nXS/v8fXA9wFfXZy/q17gyvRAevx8Tn3YB8udfh9FFZS9bFX0XbnFt3kfuUrLfN34MAfehy9X0tbI0yOEEEKIUqCHHiGEEEKUgk6Vt3IZHZyFk6viy27NWhePy7Xjbd71x9/lJTdRDLtCvcxYVKXTy1tF0oOXsNi9zq7WnDtVVGD5gV3nCxYsSNpxH/oMEq7QzJXTPUVV0GvNEvGZV1ypmI+hZ8+eSTt22c+fPz/ZxtV/O5M1a9bEc37TTTcl27i6Mlcp56wpAJgwYUK0WY70GVosGfnqz+PGjYs2y2KcHQdsKBk14bNweFFYlpU4WwtIxzq3mzVrVtJuzpw50fZZnHx98FziF5ydMWNGs8femfi5j8cHV7X2i6fy+fGyKN+7cvfd3HEwPLfy/O6/11debu54PG0hmefQzC+EEEKIUqCHHiGEEEKUAj30CCGEEKIU1G1F5lw116K08lzsD5OryJzTPjmmgFeFFXm4MrLvE06L5fPN8QpAceXQXEwJ6/r+e3N6dVnhWI1XXnkl2j6Vmava3nrrrck2jtHicZqLI+B2Xuvnz3Fati8TwcfE146PMeD4g1pjADuazTbbLP4GjqsB0lhHTvv2K6QfeOCBzW7j8Qakqd2+DABXs+bYudxK9XzufSo6z7u+gjLDaeq8CrxPh+7bt2+0fZwRp2xzqrRPt/ers9cDPtWf4XPg+5y35eY3nkv9vZDHBLfLrXbA+PFWtL9cbGfu+moL5OkRQgghRCnQQ48QQgghSkHd+vjZ3eVddezirTX9jqn1Mzn3t0+RrPVzZWfAgAHJa04l5zIARRWYPb4qKae/cj/7a0jy5IZwyjrLGSw3AGk/eXd2rpIzk0tZZdglzp8588wzk3af/vSno/3xj3882iyBeGqt0t7RrFu3LspOPuWex8u9994b7f322y9pd8ABB0Sb09kfeuihpB2XFfDSF6ec86KlfhHXl19+OdocAsDp9UAqfbF86mUa/o18Hfr0Z5amfHkEXtDyqKOOijanfAOpfFYv+HIMLDvyNi7TANReUbzWCuhFZSVy+/ASKV9DPJZ9n7Mcyff39kCeHiGEEEKUAj30CCGEEKIU6KFHCCGEEKWgbmN6GK//8SqsrVlOwOuYrDVy2p9PkeTv8mXfmdbEGXVluNS9Ty3lVdI5Jfmggw6qad8+ZoP7jLVhHw9Qj1p+Z8NxEXxevcbO/eTPa63LS+yyyy7RXrp0abRzy4rwmPvRj36UtPvOd74T7ZEjR0Z7zz33TNpxHEx7r+bcWrbeemsMHToUwIbxHRyb9jd/8zfR9nMVL7HBZR18iQc+V7fddluyjeOJOK7LxzMOHz482rxshF/6ha8jjsXzx8TfxXOzvzY4LoivJyBdjZ6X1/ArtZ966qmoN/z9iWOhOH7K9znH9PilQXj8FZX/ANK4uaKV2Zt73YTvBy6JwH1S60ry7YE8PUIIIYQoBXroEUIIIUQpaAh5i93fnly13yJqTdPzLnl2LfP3tmT/ZYRTS33K+m677RbtF198MdqjRo2qad8jRoxIXu+0007RZrnGu4I/8YlP1LT/MsGp6OyW9qtlsyzk5UV2v7MM5s8/pw6/9dZb0fbyJ383jz/vHi9KX/YrxHNqe60pvh3NNttsE1dD96uityef//znO+y7RO2wvMXyk69KPnny5Gh76ZZDRLhUgx+XTK1hGrlKyzynH3bYYdH2JUT4c76sQFsjT48QQgghSoEeeoQQE/bk1wAABy5JREFUQghRCjpV3qrVfcYZAcCGlSib8AuV8WuOCPfR4UWLs/lqszlXIKPsrRSWFNhuC9hlCgBTp06Ndi5LQWwIu8C56i5n2AFAnz59oj1hwoTC/c2ePTvaXqJmGYsXpjzuuOOSdjzmcotZcpYWf+akk05K2vFxjB49uvDYhegsfFXjxYsXR5vlLR8qwJK9r7zN9zLeh6+MXrRAaC5Lmrd5WY2zcHlRYJ8RyhL38uXLC7+rLZCnRwghhBClQA89QgghhCgFeugRQgghRCloiJgev5I2V4Hl1HEfe8BprVzZ1GumrGOyPskpt0CqQ+ZWWRcpnILoU41rhc89x2D5eKyiOB4fj8Upkr7id1nh+Kirr7462n68XHXVVTXtj6v9sp3DrxbeGvga8HMHzxG8GrsQ9YKPe+Qq4hyD46sfn3322c3a9cjxxx+fvOb5+eSTT27X75anRwghhBClQA89QgghhCgF1pLqwWb2JoDFG20o2pJ+IYSeG2/WMtSXnYb6s+ugvuxatHl/qi87jcK+bNFDjxBCCCFEoyJ5SwghhBClQA89QgghhCgFDffQY2YfmNksM3vazGab2TfMrOF+R9kws52r/TbLzF43s1fpdevy2EVdY2a7mdlNZrbQzOab2R1mtncL97GjmX21vY5R1A7NvbPN7EkzO2jjnxL1RtnHZcPF9JjZ6hDCdlV7FwATAEwLIfyLa7dFCOH95vYhOhcz+1cAq0MIP3DvGyrX5LpmP9j2x6FrpJ2o9uUjAP47hHBd9b1RALYPITyU/XC6n/4AbgshDG+P4xS14+beTwD4dgjhsI18TNQRGpcN6OlhQgjLAHwJwNeswplm9nszmwRgMgCY2QVm9riZzTGzf6u+92Ezu736F8s8Mzu1+v4V1SffOWb2g8IvFm2Gme1Z7YPrADwJoJeZ/Z2Zza2+//1quy3M7G363GfM7Hqy51X7cwq1/6GZPVbtz3+ovn+0md1rZjcBeKrDf3B5OALA2qaJFQBCCLMAPGxmV1X7ay6Nve3M7L6qB2GumZ1Q/dgVAAZVPQy1VUUUHcEOAFYC2b6DmV1sZs+a2T1m9lsz+6dOO2IBaFx2bkXmtiCE8GJV3moqTzkWwIgQwltmNg7AXgAOAGAAJprZoQB6AlgaQvgUAJhZNzPrDuBEAINDCMHMduzwH1NehgL4QgjhK2bWB8BlAMYAWAXgXjP7NIC7Mp//FwCHhxDeoH77EoBlIYQDzGwrADPMbHJ120cBDA0hvNwuv0YAwHAATzTz/kkARgEYCaAHgMfN7EEAbwI4MYTwJzPrgUp/TQRwIYDhIYRRHXTcophtzGwWgK0B9AJwZPX9NWi+70YDOBnAfqjca55E89eE6DhKPy4b2tND8HoW94QQmtapH1f99xQqA24wKg9BcwEcbWZXmtnHQgirAPwJlcF7vZmdBODPHXb0YmEI4fGqfSCA+0MIy0MIa1GRLw/dyOenARhf9eY0XdPjAHyhOkk/CmBHVPoeAKbrgafTOATAb0MIH4QQ3gDwAID9URnD3zezOQDuBdAbwK6dd5iiGd4LIYwKIQwGcAwqY85Q3HeHAPhjCOG9EMI7ACZ11oGLjVKacdnwnh4zGwjgAwDLqm+9y5sBXB5C+FkznxsN4FgAl5vZ5BDCJWZ2AICjAHwGwNew/i8Z0b74PmuOdW7b1mR/EZWHpU8DmG1mI6ptvxpCuI93YmZHu+8T7cPTAE5p5v2i/v0cKh7Y0SGEtWa2CGkfizoihDC9+pd/T1Tm0eb6rrbFFUVHUvpx2dCeHjPrCeA6AP8Rmo/IvhvAWWbWFHzX28x2MbPdAfw5hPBrAD8A8JFqm24hhDsAnIeKq090PDMAHGGVbK8tUHkAfaAa3LzSzPaqypkn0mcGhhBmALgYlTiD3qj0/Ver+4CZ7WNm23ToLyk39wPYysy+2PSGme2PSv+camabV8fvoQAeA9ANFTlyrZkdAaBf9WPvANi+Yw9dbAwzGwxgcwArUNx3DwM4zsy2rs6vn+qcoxVE6cdlI3p6mnTlLQG8D+BGAD9srmEIYbKZDQEwveKFxWoAfwdgTwBXmdk6AGsBnI1KB/7RzJr+Qjm/vX+I2JAQwhIz+y6Aqaj0w6QQwu3Vzd9CJbbnZQDzATQtj/4jMxtQbT85hDDPzJ4B0BfArGrfLwMQAyxF+1KNizsRwNVmdiEq0vEiVP6g2A7AbAABwDdDCK+b2W8ATDKzmQBmAXi2up8VZjbNzOYBuDOEcEEn/BxRoWnuBSpj7YwQwgeZvnu8Gv8xG5WlGGaiEqcnOgmNywZMWRdCCNEYmNl2IYTVZrYtgAcBfCmE8GRnH5coL43o6RFCCNEY/NzMhqISB/LfeuARnY08PUIIIYQoBQ0dyCyEEEIIUSt66BFCCCFEKdBDjxBCCCFKgR56hBBCCFEK9NAjhBBCiFKghx4hhBBClIL/D3r/yQ21AObSAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 720x720 with 25 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plt.figure(figsize=(10,10))\n",
-    "for i in range(25):\n",
-    "    plt.subplot(5,5,i+1)\n",
-    "    plt.xticks([])\n",
-    "    plt.yticks([])\n",
-    "    plt.grid(False)\n",
-    "    plt.imshow(train_images[i], cmap=plt.cm.binary)\n",
-    "    plt.xlabel(class_names[train_labels[i]])\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "59veuiEZCaW4"
-   },
-   "source": [
-    "## Build the model\n",
-    "\n",
-    "Building the neural network requires configuring the layers of the model, then compiling the model."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Gxg1XGm0eOBy"
-   },
-   "source": [
-    "### Setup the layers\n",
-    "\n",
-    "The basic building block of a neural network is the *layer*. Layers extract representations from the data fed into them. And, hopefully, these representations are more meaningful for the problem at hand.\n",
-    "\n",
-    "Most of deep learning consists of chaining together simple layers. Most layers, like `tf.keras.layers.Dense`, have parameters that are learned during training."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "9ODch-OFCaW4"
-   },
-   "outputs": [],
-   "source": [
-    "model = keras.Sequential([\n",
-    "    keras.layers.Flatten(input_shape=(28, 28)),\n",
-    "    keras.layers.Dense(128, activation=tf.nn.relu),\n",
-    "    keras.layers.Dense(10, activation=tf.nn.softmax)\n",
-    "])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "gut8A_7rCaW6"
-   },
-   "source": [
-    "The first layer in this network, `tf.keras.layers.Flatten`, transforms the format of the images from a 2d-array (of 28 by 28 pixels), to a 1d-array of 28 * 28 = 784 pixels. Think of this layer as unstacking rows of pixels in the image and lining them up. This layer has no parameters to learn; it only reformats the data.\n",
-    "\n",
-    "After the pixels are flattened, the network consists of a sequence of two `tf.keras.layers.Dense` layers. These are densely-connected, or fully-connected, neural layers. The first `Dense` layer has 128 nodes (or neurons). The second (and last) layer is a 10-node *softmax* layer—this returns an array of 10 probability scores that sum to 1. Each node contains a score that indicates the probability that the current image belongs to one of the 10 classes.\n",
-    "\n",
-    "### Compile the model\n",
-    "\n",
-    "Before the model is ready for training, it needs a few more settings. These are added during the model's *compile* step:\n",
-    "\n",
-    "* *Loss function* —This measures how accurate the model is during training. We want to minimize this function to \"steer\" the model in the right direction.\n",
-    "* *Optimizer* —This is how the model is updated based on the data it sees and its loss function.\n",
-    "* *Metrics* —Used to monitor the training and testing steps. The following example uses *accuracy*, the fraction of the images that are correctly classified."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Lhan11blCaW7"
-   },
-   "outputs": [],
-   "source": [
-    "model.compile(optimizer='adam',\n",
-    "              loss='sparse_categorical_crossentropy',\n",
-    "              metrics=['accuracy'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "qKF6uW-BCaW-"
-   },
-   "source": [
-    "## Train the model\n",
-    "\n",
-    "Training the neural network model requires the following steps:\n",
-    "\n",
-    "1. Feed the training data to the model—in this example, the `train_images` and `train_labels` arrays.\n",
-    "2. The model learns to associate images and labels.\n",
-    "3. We ask the model to make predictions about a test set—in this example, the `test_images` array. We verify that the predictions match the labels from the `test_labels` array.\n",
-    "\n",
-    "To start training,  call the `model.fit` method—the model is \"fit\" to the training data:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "xvwvpA64CaW_"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 1/5\n",
-      "60000/60000 [==============================] - 10s 160us/step - loss: 0.4965 - acc: 0.8247\n",
-      "Epoch 2/5\n",
-      "60000/60000 [==============================] - 8s 138us/step - loss: 0.3745 - acc: 0.8648\n",
-      "Epoch 3/5\n",
-      "60000/60000 [==============================] - 8s 142us/step - loss: 0.3358 - acc: 0.8757\n",
-      "Epoch 4/5\n",
-      "60000/60000 [==============================] - 8s 141us/step - loss: 0.3140 - acc: 0.8853\n",
-      "Epoch 5/5\n",
-      "60000/60000 [==============================] - 8s 135us/step - loss: 0.2963 - acc: 0.8906\n"
-     ]
     },
     {
-     "data": {
-      "text/plain": [
-       "<tensorflow.python.keras.callbacks.History at 0x178c8d44a58>"
+      "cell_type": "code",
+      "metadata": {
+        "id": "_ckMIh7O7s6D",
+        "colab_type": "code",
+        "cellView": "form",
+        "colab": {}
+      },
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vasWnqRgy1H4",
+        "colab_type": "code",
+        "cellView": "form",
+        "colab": {}
+      },
+      "source": [
+        "#@title MIT License\n",
+        "#\n",
+        "# Copyright (c) 2017 François Chollet\n",
+        "#\n",
+        "# Permission is hereby granted, free of charge, to any person obtaining a\n",
+        "# copy of this software and associated documentation files (the \"Software\"),\n",
+        "# to deal in the Software without restriction, including without limitation\n",
+        "# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n",
+        "# and/or sell copies of the Software, and to permit persons to whom the\n",
+        "# Software is furnished to do so, subject to the following conditions:\n",
+        "#\n",
+        "# The above copyright notice and this permission notice shall be included in\n",
+        "# all copies or substantial portions of the Software.\n",
+        "#\n",
+        "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n",
+        "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n",
+        "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n",
+        "# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n",
+        "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
+        "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
+        "# DEALINGS IN THE SOFTWARE."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "jYysdyb-CaWM",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Train your first neural network: basic classification"
       ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model.fit(train_images, train_labels, epochs=5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "W3ZVOhugCaXA"
-   },
-   "source": [
-    "As the model trains, the loss and accuracy metrics are displayed. This model reaches an accuracy of about 0.88 (or 88%) on the training data."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "oEw4bZgGCaXB"
-   },
-   "source": [
-    "## Evaluate accuracy\n",
-    "\n",
-    "Next, compare how the model performs on the test dataset:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "VflXLEeECaXC"
-   },
-   "outputs": [
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "10000/10000 [==============================] - 1s 71us/step\n",
-      "Test accuracy: 0.8727\n"
-     ]
-    }
-   ],
-   "source": [
-    "test_loss, test_acc = model.evaluate(test_images, test_labels)\n",
-    "\n",
-    "print('Test accuracy:', test_acc)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "yWfgsmVXCaXG"
-   },
-   "source": [
-    "It turns out, the accuracy on the test dataset is a little less than the accuracy on the training dataset. This gap between training accuracy and test accuracy is an example of *overfitting*. Overfitting is when a machine learning model performs worse on new data than on their training data."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "xsoS7CPDCaXH"
-   },
-   "source": [
-    "## Make predictions\n",
-    "\n",
-    "With the model trained, we can use it to make predictions about some images."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Gl91RPhdCaXI"
-   },
-   "outputs": [],
-   "source": [
-    "predictions = model.predict(test_images)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "x9Kk1voUCaXJ"
-   },
-   "source": [
-    "Here, the model has predicted the label for each image in the testing set. Let's take a look at the first prediction:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "3DmJEUinCaXK"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([9.4569641e-09, 9.1678389e-09, 8.5358849e-09, 2.8125953e-11,\n",
-       "       4.8381317e-08, 1.5418796e-03, 7.6329192e-09, 2.6696799e-03,\n",
-       "       5.2743690e-08, 9.9578828e-01], dtype=float32)"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "S5Uhzt6vVIB2",
+        "colab_type": "text"
+      },
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/basic_classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/keras/basic_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/keras/basic_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
       ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "predictions[0]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "-hw1hgeSCaXN"
-   },
-   "source": [
-    "A prediction is an array of 10 numbers. These describe the \"confidence\" of the model that the image corresponds to each of the 10 different articles of clothing. We can see which label has the highest confidence value:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "qsqenuPnCaXO"
-   },
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "9"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FbVhjPpzn6BM",
+        "colab_type": "text"
+      },
+      "source": [
+        "This guide trains a neural network model to classify images of clothing, like sneakers and shirts. It's okay if you don't understand all the details, this is a fast-paced overview of a complete TensorFlow program with the details explained as we go.\n",
+        "\n",
+        "This guide uses [tf.keras](https://www.tensorflow.org/guide/keras), a high-level API to build and train models in TensorFlow."
       ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "np.argmax(predictions[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "E51yS7iCCaXO"
-   },
-   "source": [
-    "So the model is most confident that this image is an ankle boot, or `class_names[9]`. And we can check the test label to see this is correct:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Sd7Pgsu6CaXP"
-   },
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "9"
+      "cell_type": "code",
+      "metadata": {
+        "id": "dzLKpmZICaWN",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from __future__ import absolute_import, division, print_function, unicode_literals\n",
+        "\n",
+        "# TensorFlow and tf.keras\n",
+        "import tensorflow as tf\n",
+        "from tensorflow import keras\n",
+        "\n",
+        "# Helper libraries\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "print(tf.__version__)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yR0EdgrLCaWR",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Import the Fashion MNIST dataset"
       ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "test_labels[0]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "ygh2yYC972ne"
-   },
-   "source": [
-    "We can graph this to look at the full set of 10 class predictions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "DvYmmrpIy6Y1"
-   },
-   "outputs": [],
-   "source": [
-    "def plot_image(i, predictions_array, true_label, img):\n",
-    "  predictions_array, true_label, img = predictions_array, true_label[i], img[i]\n",
-    "  plt.grid(False)\n",
-    "  plt.xticks([])\n",
-    "  plt.yticks([])\n",
-    "  \n",
-    "  plt.imshow(img, cmap=plt.cm.binary)\n",
-    "  \n",
-    "  predicted_label = np.argmax(predictions_array)\n",
-    "  if predicted_label == true_label:\n",
-    "    color = 'blue'\n",
-    "  else:\n",
-    "    color = 'red'\n",
-    "  \n",
-    "  plt.xlabel(\"{} {:2.0f}% ({})\".format(class_names[predicted_label],\n",
-    "                                100*np.max(predictions_array),\n",
-    "                                class_names[true_label]),\n",
-    "                                color=color)\n",
-    "\n",
-    "def plot_value_array(i, predictions_array, true_label):\n",
-    "  predictions_array, true_label = predictions_array, true_label[i]\n",
-    "  plt.grid(False)\n",
-    "  plt.xticks([])\n",
-    "  plt.yticks([])\n",
-    "  thisplot = plt.bar(range(10), predictions_array, color=\"#777777\")\n",
-    "  plt.ylim([0, 1])\n",
-    "  predicted_label = np.argmax(predictions_array)\n",
-    "  \n",
-    "  thisplot[predicted_label].set_color('red')\n",
-    "  thisplot[true_label].set_color('blue')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "d4Ov9OFDMmOD"
-   },
-   "source": [
-    "Let's look at the 0th image, predictions, and prediction array."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "HV5jw-5HwSmO"
-   },
-   "outputs": [
+    },
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAC6CAYAAACQs5exAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAOvUlEQVR4nO3de9BV1XnH8e8jqMhFuYh4o762xTFGKSghbdN0kmpMtK1Km6TSpNM0M512TMbazhjTm71O0kmnt2nT2kYdk9ZLUkMS0jRB/UcBkQAmKmi9JIBVFAWVFxBRYfWPvaGHs9d+OQeBpe/7/cw4857nrLP32kf9nXX22mufSCkhSTr8jijdAUkaqQxgSSrEAJakQgxgSSrEAJakQgxgSSpkdOkOSKUdf/zxaWBgoHQ3NEytWrVqU0ppau45A1gj3sDAACtXrizdDb3JnHgibNzYe/tp0+DZZ5v1iFjf9hpPQUhSRj/heyDtwQCWpGIMYEkqxACWpEL6moRztliH0rp169i0aVOU7od0uPQVwM4W61CaM2dO6S5Ih5WnICSpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpkNGlO6CDZ9euXY3aEUfkP2Mjouft7ty5s1E7+uijs20ff/zxRm3GjBk970saSRwBS1IhBrAkFWIAS1IhBrAkFWIAS1IhXgVxkKSUeqpB/sqEp59+Ott22bJljdpFF12UbTtu3LihunjA2q54yFmwYEGjds011xzM7kjDhiNgSSrEAJakQgxgSSrEAJakQpyEO4TalgHnLF68OFtfvnx5o7Zhw4Zs2yuvvLLn/fXjueeea9QWLVqUbTthwoRD0gdpOHIELEmFGMCSVIgBLEmFGMCSVIgBLEmFeBXEQZK7Gfro0fm3d8WKFY3aI488km07bdq0Ri1303OAefPmNWqTJk3Ktn3llVcatdNOOy3bdvPmzY3a4OBgtu0pp5ySrUtqcgQsSYUYwJJUiAEsSYUYwJJUiJNwB2D37t2NWm7Cbfv27dnX33777Y1a2z13c5NlW7duzbbt557EufqaNWuybU899dRGrW1yLzcZKSnPEbAkFWIAS1IhBrAkFWIAS1IhBrAkFfKWuwoiN3sfEdm2uasV2trm6m0z+qNGjRqqi3tdd9112XpuefGYMWOybdevX9+o5a6MaNvu66+/nm2bO962X1XOXaGxZcuWbNudO3c2am1XgxyqX3GW3iocAUtSIQawJBViAEtSIQawJBXyppiE62dira2e08+vEucm3HqdbAO49dZbG7Vnn30223b27NmNWttk2UsvvdSoTZ48Odt2ypQpjdqmTZuybbdt29ZzH3Lalji//PLLjVrb/YtnzZrV8/6k4cgRsCQVYgBLUiEGsCQVYgBLUiFvikm4fibWcqvbcjXIT6K17aufCbcbb7yxUXvssccatenTp2dfn/uRy7ZJrR07djRqbT98mbtPcNvxjh07tlFrW2HXzyRpzqJFi7J1J+E00jkClqRCDGBJKsQAlqRCDGBJKsQAlqRCDtlVEG1XJuTkZtTbrgrILS/uZ8lxmw0bNjRqCxYsyLbNXZkwY8aMRi233Bfy98zNXRkBcOSRRzZqbVcg5JYBt8m9Z22/zJxr23Yv31zfli5d2nO/pJHEEbAkFWIAS1IhBrAkFWIAS1IhfU/Cdd83t20J7xudGOtnqevzzz+fra9bt65Re/TRR7Ntn3nmmUbtqKOOyrY99thjG7XcfXsHBwezr3/ttdcatdzEHOTf39xxQf5+vhMnTsy2zR1b24+Q5iZEjznmmGzb3DbGjx+fbbt69ep9HucmN6XhzBGwJBViAEtSIQawJBViAEtSIQawJBXS91UQvd64fOPGjY3a+vXrs223b9/eUw3yM+Vr167Nts0tzR09On/IEyZMaNTallNv2bKlp3617SvXr7arCnLLg1999dVs25NOOqlRa7sSI9eHSZMmZdvmllS/8MIL2ba5Kx7afh26exttV2FIw5UjYEkqxACWpEIMYEkqxACWpELe8P2A77rrrmw9d3/dtkmp3FLitgmZ3CRgPxNrbffozU0Utd2TOLdsODeB1TaJl+tD2/Hm7rvbtrQ3t+y4bZl2P3LH1rbUPDcZ2TZp2PbvTRopHAFLUiEGsCQVYgBLUiEGsCQVYgBLUiF9TUMPDg5yxx137FO74YYbsm3PPPPMRi23VBb6Wwb8Rm8kntsX5Gfq22b6t27d2tO+2m4wnrvZfNsx5K7OyC3zBnj44YcbtbYrEPpZ9pu76qJtqfiYMWN6ej3ACSecsM/j3C9AS8OZI2BJKsQAlqRCDGBJKsQAlqRC+pqEGzduHHPnzt2ndt9992XbPvTQQ43akiVLet5X24RMbhJt8uTJ2ba5+nHHHZdtm5usaluKvHnz5kYt92vLuXvuQv4evW2/Av3AAw80ajNnzsy2HRgYaNTuvPPObNvccup+fsm6bRnxySef3KjlfkUampOZ3g9YI40jYEkqxACWpEIMYEkqxACWpEIMYEkqpK+rIEaNGtW46fe1117b8+vbboa+fPnyRi13VQHAvffe26itW7cu2/bBBx9s1NqW0OaueGi7MiF3tUDuiotzzjkn+/oLLrigUbv44ouzbXNLe/txySWXZOtPPvlkozZlypRs29xVDG1LunNXR+R+2RngjDPO2OfxGz1W6a3GEbAkFWIAS1IhBrAkFWIAS1Ihh/VnadvuC3v++ef3VAO44oorDmqfhruFCxeW7kLP+lkKLQ0H/hcvSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUyOh+Gq9atWpTRKw/VJ3RiHda6Q5Ih1NfAZxSmnqoOiJJI42nICSpEANYkgo54ACOYF4EKYIze2y/LoLjM/Vtfe63r/ZDbOdjEZzc8tyHIlgTwe4I5nQ99/sRPBHBoxG8v6P+gbr2RASf7qjfHMGDEXymo/bHEVw6RN9mR3B9V+0bESzr8djeE8F/tRzzP/WyjQNpP8R2JkZwRcfjqRF8541uV3qr6+sccJf5wBLgcuBPD0pvDq+PAauBDZnnVgO/BPxrZzGCs6iO9+3AycBdEZxRP/154H3AU8CKCBZSv78pMTOCxREcB4wF5qbEXwzRtz8A/rJjvxOBc4FtEZyeEmv7PNbSJgJXAP8MkBLPR/BMBO9KiaVlu+bksg6eiGy5dXL5gAI4gvHAu4D3AgupAziC99R/bwLOBlYBH02J1PHaY4CvAV9NiS90bfdq4MPA0cDXUuJPWvb/N/W+XwQur/+HngVcRxVwPwA+nhIv5urA+cAc4OYIdgA/lRI79mw/JR6p99PtUuC2lNgJrI3gCWBu/dwTKfHD+nW31W2/DhwTwRHAUcAu4M+Ba/PvLEQwAZiZEg90lH8Z+CawkeoD4LN125uAwfpYTgQ+lRK3d23vHcC/1dvorE+t35cfqUtXtYTh9Hq0ejpwS0r8Wf3636N6LwGuT4m/H6L+V8CPRfB94M6UuLp+bz4C5QPYyWWVcqCnIC4DvpMSjwEvRHBux3OzgauAs4AfpQrqPcZTBcktmfC9EJhBFWizgPMi+NnMvscB96fEucDdsDekvwRckxIzgYeGqtchtRL4SErM6gzf/TgF+N+Ox0/VtWy9DvIngfuBrwA/DkRKfG+IfcyhGoF3mg/cWv8zv+u5k4CfAX6BKuj2iuCnqUL20j0fDh3+Afi7lHgHVThfT95cqqCcBXwogjkRnAf8BvBO4CeB36xPm2TrwKeBH9Tv9dX1dlcC7x7ifZCGvQM9BTEfqhEPcFv9+P768XdT4imAesQzQHWqAuAbwOdS4ubMNi+s/9kTTuOpAvmerna7gS/Xf/8HsKD+aj8xJe6u618E/rOt3t+h7iP3BSOR/yBLAClx1d4XB98EfiuCPwR+gmo0+IWu150EPN/xmmlUwb0kJVIEr0dwdkp7Q/rrKbEbeLhuu8fbqEa+F6aUPc1yAXBWxyj/2AgmpMTWrnZ3psTmui8LqMI+UX1D2d5RfzfV+5OrL8zs/znIn4OXRoq+AziCKcDPAWdHkIBRQIrgU3WTnR3Nd3XtYylwUQS3dJ6W2LNp4LMp7XvetQfd2zmUngKmdzw+lf8/h9xWB6CedFtJNYI/OyU+HME9EdycEi93NN0BjOl4/CvAJKpTHgDHUp2G+KP6+c73u/MD4pl6O7O7+1I7gq5TLy26399E/oOoe//7MwZ6/uYhDUsHcgrig8CXUuK0lBhIienAWqqR0f5cC2ymnozpsgj4eH1+mQhOieCElj5/sP77V6lGhluAFyP2fqX9NeDutnr991ZgQg997rQQuDyCoyM4nWqE/l1gBTAjgtMjOIoqIPeO+iI4Evgd4K+pzkXvCbU954Y7PUI14t1jPvCB+r0eAM6rt78/LwE/D3ymPjff7Q7gkx19nNWynfdFMLk+d38Z1YfoPcBlEYyNYBwwD1g8RD33Xp9B81SLNKIcyCmI+XSdawS+ShWGX242b7gKuDGCz6W0d9RMStwRwduAZfVIbxvwUaqvqp22A2+PYBWwhWqECPDrwHURjAV+SHUucqj6TXW9MQkXwTzgH4GpwLci+H5KvD8l1kTwFeBh4HXgEymxq37NJ6k+REYBN6bEmo4+fwL4Ykq8HMGDQETwEPDfKfFS58GlxP9EcFw9GTeFapLsvo7n10YwGME7h3yXq7YbI/hF4NsReyfG9rgS+Hzdn9FU4fnbmc0sAf6d6kPhlpRYWR/vTVQfPlBNtn1vP/WlEawGvl2fB34v8K39HYM0nEVKh/MbvHoRwe8CW1NqnRh7y4vgHqrJwRdL90UqxZVwb07/wr7ndoeV+hK4vzV8NdI5ApakQhwBS1IhBrAkFWIAS1IhBrAkFWIAS1IhBrAkFfJ/mETmJvftLlgAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x216 with 2 Axes>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DLdCchMdCaWQ",
+        "colab_type": "text"
+      },
+      "source": [
+        "This guide uses the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset which contains 70,000 grayscale images in 10 categories. The images show individual articles of clothing at low resolution (28 by 28 pixels), as seen here:\n",
+        "\n",
+        "<table>\n",
+        "  <tr><td>\n",
+        "    <img src=\"https://tensorflow.org/images/fashion-mnist-sprite.png\"\n",
+        "         alt=\"Fashion MNIST sprite\"  width=\"600\">\n",
+        "  </td></tr>\n",
+        "  <tr><td align=\"center\">\n",
+        "    <b>Figure 1.</b> <a href=\"https://github.com/zalandoresearch/fashion-mnist\">Fashion-MNIST samples</a> (by Zalando, MIT License).<br/>&nbsp;\n",
+        "  </td></tr>\n",
+        "</table>\n",
+        "\n",
+        "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. The MNIST dataset contains images of handwritten digits (0, 1, 2, etc) in an identical format to the articles of clothing we'll use here.\n",
+        "\n",
+        "This guide uses Fashion MNIST for variety, and because it's a slightly more challenging problem than regular MNIST. Both datasets are relatively small and are used to verify that an algorithm works as expected. They're good starting points to test and debug code.\n",
+        "\n",
+        "We will use 60,000 images to train the network and 10,000 images to evaluate how accurately the network learned to classify images. You can access the Fashion MNIST directly from TensorFlow, just import and load the data:"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "i = 0\n",
-    "plt.figure(figsize=(6,3))\n",
-    "plt.subplot(1,2,1)\n",
-    "plot_image(i, predictions[i], test_labels, test_images)\n",
-    "plt.subplot(1,2,2)\n",
-    "plot_value_array(i, predictions[i],  test_labels)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Ko-uzOufSCSe"
-   },
-   "outputs": [
+    },
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAC6CAYAAACQs5exAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAMA0lEQVR4nO3df2xV9RnH8c+X8rNQBNZq2RQaiCDBOV06HDMEdHY4N8OMcdkmU1kylywYl2xZSJZFyYDokpEJC39MN90Ws5nFsAnTuT82N7LJIiUOWILAEmRYqDSKIJQK7bM/7uksPc9peyntQ9v3K2m897nPPffbg348nO/53pPMTACAwTcqegAAMFIRwAAQhAAGgCAEMAAEIYABIAgBDABBRkcPAIhWXV1tdXV10cPAMNXY2NhiZjXeawQwRry6ujrt2LEjehgYplJKbxS9xikIAAhCAANAEAIYAIIQwAAQpKxJOGaLMZAOHjyolpaWFD0OYLCUFcDMFmMg1dfXRw8BGFScggCAIAQwAAQhgAEgCAEMAEEIYAAIQgADQBACGACCEMAAEIQABoAgBDAABCGAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEEIYABDQm2tlFLffmpro0fbNwQwgCGhuXlgeiMRwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEEIYAAIQgADQBACGACCjI4ewKVs06ZNbn3Pnj197u0rM3PrKaV+bRfApYsjYAAIQgADQBACGACCEMAAEIQABoAg/b4KorW11a1PmDChX9sYO3bsBY+pU0VFRZ97t27dmqs1NTW5vZdffnmudu+99+Zqa9eudd9/1VVX5WrlXO3Q3t7e595y9gGAwcURMAAEIYABIAgBDABBCGAACNLvSThv8kmSVq5cmastXrzY7S1nwm6geEuJFyxY4PZ6E4RXXnllrvbss8+67/cm8e688063t6qqKlcrmljzJueKljj3F0ukgf7jCBgAghDAABCEAAaAIAQwAAQhgAEgSFlXQXR0dOjUqVPn1Q4fPuz2Pv/887na6dOn3d5rr702V5s2bZrbW1lZ6Y7Lc+jQoVztqaeecntra2tzterqard3y5YtudqyZctytePHj7vvf+GFF3K1vXv3ur2zZs3K1RoaGtzemTNnuvX+8q6uKNrno0bl/5/OcmjAxxEwAAQhgAEgCAEMAEEIYAAIUtYkXGtrq3tHYE/3yTpJeuaZZ9ze6667Llcr+j5gr37gwAG3d/fu3bna+++/7/YuWrQoV9u5c6fbu3Tp0lzNmxws+h1uu+22XO2tt95ye/ft25ervfLKK27vvHnzcrX58+e7vfX19blaTU2N2+tNojGxBvQfR8AAEIQABoAgBDAABCGAASBIWZNw7e3tudVdb7/9tr/h0flNv/vuu27v5s2bc7WpU6e6vWfPns3VvO/MlaSFCxfmanPmzHF7vRVc3go9SWppacnVvFV+Rav5vH3mTeJJ0owZM/pUk6QTJ07katu2bXN7X3311T6PYcqUKbla0ao777uOr7nmGrd33Lhxbh0YKTgCBoAgBDAABCGAASAIAQwAQQhgAAhS1lUQo0aN0sSJE8+reUtlJWnFihW5Wl1dndvrXRVw5swZt9ebkR8/frzb621j165dbq9n0qRJbt27WsBb4nz06FH3/d4S5cmTJ7u93na9qx0k//uLi67E8BTtc2+ZdFNTk9vr7Zs1a9a4vcuXLz/vedH3JwPDFUfAABCEAAaAIAQwAAQhgAEgSFmTcMePH8/dbHP69OlurzdJUzR55N14smi57blz5/r0WZLU1taWq3k3mCxSNCnkLakeM2ZMruYty5XKm4TzFC0ZvuKKK3K1ot/Xm9wrmsz06kV/lt6fRUrJ7V2/fv15z5ubm90+YLjiCBgAghDAABCEAAaAIAQwAAQhgAEgSFlXQbS1teXuQDx79my31/sy86I7Kh8+fDhXK2epa0dHh9vrKer1rgoouoOyN6vvfbn4sWPH3Pd7vRMmTHB7vasrinhfFF/0+548eTJXK7rqw+stWqbtLWfev3+/29v984r2NzBccQQMAEEIYAAIQgADQBACGACClP19wN0nwbZv3+72lrPU1ev17jIs+Ut2ve/BlaT33nsvVytnKXJFRYVb9+747NW8Oy1L/lLkIt4kXNEEmPe9vUX70VtKXPR9wN6dqL3fV/KXihdtd/Xq1ec9f/jhh90+YLjiCBgAghDAABCEAAaAIAQwAAQhgAEgSFlXQcyYMUMbN27M1Tze3Xi9pbKSfxVE0ZUC3qy+d1dlSaqqqsrVvFl6yb9ioWim31ve29ramqsVfRG597sVLcMtZ1zl9Hp/Pt4dpyX/6pWiuy3PnTs3V2toaHB7u9uwYUOf+oDhgiNgAAhCAANAEAIYAIIQwAAQpKxJuIqKCk2dOvW82rp16y7qgABgpOAIGACCEMAAEIQABoAgBDAABCGAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIEhZ34YGAJ1WrVrV595HH310AEcydHEEDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEEIYAAIQgADQBACGACCEMAAEIQABoAgBDAABCGAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABBkdDnNjY2NLSmlNwZqMBjxZkYPABhMZQWwmdUM1EAAYKThFAQABCGAASBISACnpO+lpH+npF0p6bWUdONF3v6SlLT1Im1rbjbGzp8TKelb2WvXp6TtWX1HSlqQ1e/Kfr9tKelDWW12SvpND5+TUtKfU9Lk7PklvY9SUk1K+uPFHBMw0pR1DvhiSEkLJX1e0sfN1JaSqiWNHexxFElJo810rvO5mV6XdH32WoWkNyVtzl7+oaTVZnoxJd2ePV8i6duSPinpS5K+ImmjpDWSvt/DR98u6V9mOjFE9tGxlHQkJd1kpr9Hj6k/mFweeI899tigf2ZKg/6RRQonlwc9gCVNl9RipjZJMlNL5wsp6aCkX0i6Q9IYSXebaW9KmqhSiH1UpTE/Yqbfp6Q6Sb+SNDHbxEoz/aPrh6WkT0j6qaS7JDUXbOd+SZ+TND7b1i0FY/+0pP+YqfM/VpNKR6ySLpPUlD3ukDROUqWktpS0SNIRM+3vYb/ck41zKO2j32XjHtIBzOQywpjZoP5INkmy1yTbJ9kmyRZ3ee2gZA9mj78p2ZPZ43WSLc8eT8neO1GySsnGZ/WrJduRPV4i2VbJPiVZo2QzetnO/ZIdlmxaL2P/uWQruzyfJ9khyf4r2ZuSzczqDdnnbpHsMslekmxqL9t+Q7KqobSPJPuIZLsH+98hfvgZLj/JzAYl6LvK/iq/SNLNkr4haZWZns6O7m4y05vZOc+1Zro1Je1Q6cir89TANElLVTri/IlKpwjaJc0xU2VKWiLpZ5JaJX3GrHRk2sN2bpS02Ewrehjz2Ozz5pupOattkPRXMz2Xkr4o6QEz3drtffdJmiLpn5K+I+kdSQ+Z6XS3vpNmqhpK+ygljZF01Kx0nhtAeSJOQchM7ZJelvRyStot6T5JT2cvt2X/bNcH40uS7rLS+dj/S0mPqPRX5o+pNKF4psvLR1QKkhv0wamBou3cKOlUL8P+rKSdneGbuU/SQ9nj30p6stt2K7OepZL+JGmZSueE75H0RLftn0tJo8zUIQ2ZfTRepQAHcAEG/SqI7KqCq7uUrpfU2wTIS5IeTEkp28YNWf0ylc6tdkj6qqSKLu85rtI5y3XZ0V5P2+mLL0v6dbdak6TF2eNbpNw53u9KetxMZyVNUOmccYdK54a7e13SrGxcQ2UfzZG0p5dxASgQcQQ8SdLGlDRFpb/mHpD0QC/v+YGkH0valQXDQZWuEtgk6bmUdLekv6jbEZqZmlPSHZJeTElf62E7PcqOZBtUOhXQ1dclPZ6SRqt0ZPlAl/d8WFK9mR7JSj+StF2l0PuC8zF/UOkKigMaOvvo5mzcAC5AyDlg5KWk6ZJ+aaaG6LH0VUr6m6RlZnoneizAUMRKuEuEmY5IeqJzIcalLiXVSFpP+AIXjiNgAAjCETAABCGAASAIAQwAQQhgAAhCAANAEAIYAIL8DzJzprb/MWsRAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x216 with 2 Axes>"
+      "cell_type": "code",
+      "metadata": {
+        "id": "7MqDQO0KCaWS",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "fashion_mnist = keras.datasets.fashion_mnist\n",
+        "\n",
+        "(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "t9FDsUlxCaWW",
+        "colab_type": "text"
+      },
+      "source": [
+        "Loading the dataset returns four NumPy arrays:\n",
+        "\n",
+        "* The `train_images` and `train_labels` arrays are the *training set*—the data the model uses to learn.\n",
+        "* The model is tested against the *test set*, the `test_images`, and `test_labels` arrays.\n",
+        "\n",
+        "The images are 28x28 NumPy arrays, with pixel values ranging between 0 and 255. The *labels* are an array of integers, ranging from 0 to 9. These correspond to the *class* of clothing the image represents:\n",
+        "\n",
+        "<table>\n",
+        "  <tr>\n",
+        "    <th>Label</th>\n",
+        "    <th>Class</th>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td>0</td>\n",
+        "    <td>T-shirt/top</td>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td>1</td>\n",
+        "    <td>Trouser</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>2</td>\n",
+        "    <td>Pullover</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>3</td>\n",
+        "    <td>Dress</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>4</td>\n",
+        "    <td>Coat</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>5</td>\n",
+        "    <td>Sandal</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>6</td>\n",
+        "    <td>Shirt</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>7</td>\n",
+        "    <td>Sneaker</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>8</td>\n",
+        "    <td>Bag</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>9</td>\n",
+        "    <td>Ankle boot</td>\n",
+        "  </tr>\n",
+        "</table>\n",
+        "\n",
+        "Each image is mapped to a single label. Since the *class names* are not included with the dataset, store them here to use later when plotting the images:"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "i = 12\n",
-    "plt.figure(figsize=(6,3))\n",
-    "plt.subplot(1,2,1)\n",
-    "plot_image(i, predictions[i], test_labels, test_images)\n",
-    "plt.subplot(1,2,2)\n",
-    "plot_value_array(i, predictions[i],  test_labels)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "kgdvGD52CaXR"
-   },
-   "source": [
-    "Let's plot several images with their predictions. Correct prediction labels are blue and incorrect prediction labels are red. The number gives the percent (out of 100) for the predicted label. Note that it can be wrong even when very confident."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "hQlnbqaw2Qu_"
-   },
-   "outputs": [
+    },
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsYAAAI8CAYAAADyYW3KAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAgAElEQVR4nOzdebwcVZn/8c8h+77vQEI2QiAkIWFX9jUiiOMQ8CeCjsi4zaCjg+MCjoPK4Iwrg8ggoo6AssiiILtAIAGSkBsCJBCyQMi+7yvn90fVPXnOSVen781N7pLv+/XixVNdp6ur03266tZ56jnOe4+IiIiIyP7ugPreARERERGRhkAnxiIiIiIi6MRYRERERATQibGIiIiICKATYxERERERQCfGIiIiIiIANK/vHbC6d+/uBwwYUN+7sV+ZN28ey5cvd3W5TX2O9WfKlCnLvfc96mp7DeWzfP/990O8YcOGEHfo0KFW29u4cWOIDzhg5/WB1q1b12p7da2xfI5VVbB9e+l1zZvDyJF1/pKNUmP5PGtq3bp1IV6yZEmI27ZtG7Xbtm1biFu1ahVi268BduzYUfJ1tm7dGi0PGjSo5jtbBxrC56g+VzfKfZYN6sR4wIABTJ48ub53Y78yduzYOt+mPse61bs3mGNOpFcvWLx457Jzbn5dvnZD+SztAfill14K8emnn16r7U2dOjXE7du3D/HQoUNrtb261lg+R1fmT+rt26EBfHUahMbyeZZi5zpwyQf+5JNPhvhnP/tZiEeNGhW1W2x+pAYPHhzi9evXR+1WrVoV4ubNd56ezJ07N2r3pz/9qaJ9r2sN4XNUn6sb5T5LpVKINHBFJ8W7WyciIiI106CuGIvI/mPz5s3R8k9+8pMQ33nnndE6eyVp2bJlIW7Tpk1hu3JsyoSN7VUqgJNOOinEV1xxRYjPOeecil5HpLErd8X42muvDfHzzz8f4gcffLBwex07dgyxTWkC2G5yBGzf3rRpU9Tuz3/+c4jPO++8wtcSqQ1dMRYRERERQSfGIiIiIiKAToxFRERERADlGIvIPnT11VeH+JZbbonWrV27NsRpuSebb9ilS5cQp7mH7dq1C7Et/WRLRKXbszmUW7Zsidr95S9/CbHNmzz++OOjds8++ywiTZEtZ5iqqqoKse2XPXrEVbBsiUXbL7t27Rq1a9GiRYhtv5w9e3bUbubMmSFWjrHUNV0xFhERERFBJ8YiIiIiIoBSKURkL7MpEzfccEOIe/fuHbWzaRBpWSg7rGpn0UpnqrPLdhvpcPD2gqmj0u3ZyT+aNWsWYluaCuDDH/5wiB966KGS2xZpauwEHd27dw+xTYuCeIa7cjPf2e2l6U/Wu+++W/OdFamQrhiLiIiIiKATYxERERERQKkUIrKXffvb3w6xnfUqTZewd6svXry4cHudO3cOcZr6YGeus8Oy6Sx73bp1K/m66cx3tkqFTefo1atX1M5WpVi+fHm0zg4xizRmS8rMQW/7Ttq3LZvGZKtQQJyuZLdhfzcAli5duvudFaklXTEWEREREUEnxiIiIiIigE6MRUREREQA5RiLyF62Zs2aENsSTDZnF+K84s997nPRuiuvvDLERx11VIhtiTeABQsWhLhDhw4h7t+/f9TO5krafbLPB+jXr1/JduvWrYva2Rn45syZE61TjrE0FTNmzChc17JlyxCnM1La3GGbi5yWa7O/CUUl3mDXPH6RuqQrxiIiIiIi6MRYRERERARQKoWI7GW25Jktr5amUlg/+MEPouVOnTqF2A6xbty4MWp3yimnhPjpp58u3P5hhx0W4pkzZ4Y4nbHrpz/9aYht2bkePXpE7WzJtwkTJkTrjjnmmML9EGlMqqqqomWbPmH7dtovbblEm1plyyZCXKLN/j7Y3xDYNYVKpC7pirGIiIiICDoxFhEREREBlErRoNjh2AMO2Pk3S7lZhNIhJnv37ltvvRXiIUOG1MUuiuzW1q1bC9fZ73L63bU++clPRssPPPBAyXarVq2Klm36xDXXXBPidOasu+66K8QrV64M8fz586N248ePD7FNpbB9FeI77adNm1ZyX0Uau5dffjlatscpmz6RziBp0ydsVZm0r3Tp0iXE9liWpmYcdNBBNdltkRrRFWMREREREXRiLCIiIiIC6MRYRERERARQjvEeseVkbGzzrgDee++9EE+cODHE5557btSuNiVo0hmBrPvuuy/EV199dY23LVIbCxcuLFxn+0Y6O5aVzkBX5O677y5cd+mll4a4TZs20TqbIzxy5MgQL1q0KGrXvn37ivbDsrn9Ik3JG2+8ES23aNEixLZvr1+/PmrXp0+fEE+aNCnE6f0zthSjjbdv3x6169q1a012W6RGdMVYRERERASdGIuIiIiIAEqlqDNp+oT13HPPhfjFF18McTrk/E//9E81ft2lS5dGy48++miIO3ToUOPtieypZcuWVdQuHR61w7Jp37DDqtbJJ59cuP2zzz47xHPnzo3W2aHYRx55JMR25jyI0yxsWkW6P82aNQvx4sWLC/dJpDGzZdcg/t6XS6X46Ec/WtH27W9C27ZtC9uVKwkpsqd0xVhEREREBJ0Yi4iIiIgAOjEWEREREQGUY7xHbMknOwVmOm2mLXHTq1evEKdlnS688MIQ26kxN2/eHLXr379/iFesWBGtW7t2bYj79etX/g2I7AW2PGHKljVM2ZzCNE/X5i/abcyaNStqZ8sSzpkzp/C1DjvssBDPnDkzxO+8807U7qabbgqxLTNl+yfEZRPLvX+RxmzJkiXRcqUlRi+55JKSj6flRu307N27dy/cXjpFtEhd0hVjERERERF0YiwiIiIiAiiVokbSEk02fWLDhg0hvueee6J2drjIpkWsW7cualc0k146/Pzaa6+F+MADD4zW2SFem+ohsq+UK9dmyzul5drscjrj3De+8Y2S7R577LGoXVVVVYhtP7EpRhCnT9j0i/Hjx0ftpk2bVuJd7PpbYGfw2rZtW8nniDR26WyVtiRouePNqaeeWvLx448/Plq2M8Omvw9Wt27dyu6nyJ7QFWMREREREXRiLCIiIiICNPFUCpuCYIc6IR4KTdfZZTs8ZIeBUzfffHOIbeUJgNatW4d4/vz5IU6rTdjn2WGkdP/sncDpXb12ZqItW7aE2KZ6pNsQqUuLFi0qXFdUXQLi73ynTp2idT/4wQ9Kbi9tZ/vQ66+/XrgfvXv3DvHy5ctDbPtqOemwsU2rKte23G+ISGNmU4jS/pAep6oNGDAgWp4wYUKIy1WwSfu9SF3SFWMREREREXRiLCIiIiIC6MRYRERERARoAjnGaR6SzcdNc3Mtm+uYqjQn8M477wyxnalr9OjRUTubO7l69eoQd+3aNWpnS9DYvMf169cXbi9l/z3s7EDpLHujRo0q3IbInihXrs1q2bJltHzaaaeF+LnnnovW2bKEtk/aPHqI+25a8s2yfcjmJafbs9vo3LlziNMybmlftubNmxfiQYMGFbYTaWzsMXbr1q0hrvR7npYbtf233PFbZG/SFWMREREREXRiLCIiIiICNIFUinLDLbYkWzpTlR2OTbdRlD5x2223RctvvvlmiA866KAQr1ixImpn0xvszEH9+vWL2tmZ8Ow+tW3bNmpny7yVSyWxHn300WhZqRSyt9h0oZT9jqff/8svvzzEjzzySLQu7QPV0n6dLhex/cSmVaSpFLbs1Ec/+tEQF82IV4pNi1IqhTQlRbO/Hn744RU9f9y4cdHyDTfcEOJK+7JIXdMVYxERERERdGIsIiIiIgI0olSKomGVNHXAphbYyhPlqlCkFi5cGOL77rsvxDYNAmDIkCEhtpUj0uFYm1rRokWLwn23VSSsdN/tLELpOjujnd3+888/X3LbInUtTSWybB/q2bNntK5Lly6Fz7P9ptyskJX286LZLdPt2b587LHHFm7Pvm46e56GhKWpsn3HHnsHDhxY0fNHjhwZLdvKFuWqL2nmVtmbdMVYRERERASdGIuIiIiIADoxFhEREREBGmCOcXXOUloyrTa5g1Y6G5edjWrWrFnRukWLFoXYzs7VsWPHqJ0tS7V27doQb9u2LWpn8xTt+7L7AHFOlZ1lK50hrCivC6BNmzYl26WzgM2YMQPYNW9aZE+l5dpszq0tNZjmCb7xxhuF27RlodL+ZVU6W5btN+Vmy7TvpdLSkGmftOXaRBqzdKY6W6LNHqP79u1b0fZsv04px1jqi64Yi4iIiIigE2MREREREaABplIUzTq3ZMmSEM+fPz/EdignXbZpAnPnzo3a2dJo6XBOhw4dQmyHSNesWRO1s9u320jLrtn0BltqzZamAejTp0+IbWpGuj1b1sqWiQNYuXJliG36xOLFi0u2s+kWInWh0vJkhx56aLT89ttvF7a1aQx2++XKNZZTNPOd7Z/p9tLycla5VIo0jUuksUr7wJw5c0Js+5GdFbacNE3QKpdmUVTaVKQu6IqxiIiIiAg6MRYRERERARpgKkW1J554Ilq2s9HZIZZ0mNKmBti0jHLpEmk6gk07sMOi6Yx2NqXBDqWm27P7ZO+mTStF2EoUlQ6/prOF2TuDbapHmrZRbphKZE+kVSOKvmtpKsUzzzxTuM2iO9TTtAXbD8tVsrHPs3FRKhfEd+Snd+eXqzyR/h6INFbHHHNMtGwrydg0pGnTpu3xa6XHWytNeRKpS7piLCIiIiKCToxFRERERACdGIuIiIiIAA0sx3jt2rU89thjAPzqV7+K1g0bNizEtqyZzRWGOMfQloJJy5LZvMJ0GzYf1+Yprlu3rnAbNp83LSFlX9vmL9sSdACvv/56yX0oV1ItzVO25ersjGNpu+qyOy1atCjctkht2PKEUJy3m+YAz5w5M8Tp93JPywqmzy+a7a5c7v3s2bND3Lt372id7dfpvqu0lDQVJ510UrT861//OsT2ePvKK6/Uavv2N6HczHeVzoQrUhv6domIiIiIoBNjERERERGggaVStGvXLpSDmTRpUrTu1VdfDfGECRMKt2GHMW2KRNeuXaN2drlTp07ROpvGYNMlVqxYEbWbNWtWiO1wqZ21DuKh2qqqqhAfeeSRUbsBAwaE+PHHHw9xWram3DCSHQru27dviDt27Bi1q04L0cx3UtfSdISi71ha1s3O2ti2bdtoXaWz6VlpSlMRm+pRbvj2gQceCLHtqwBTp04Ncdo/V61aVdF+iDR0J5xwQrRs0/VsPyo3S2Q59jhVbhbL2vweiFRKV4xFRERERNCJsYiIiIgI0MBSKZo1axZmf7vmmmsK29mZpF588cVonU1veOGFF0I8b968qN306dNDbCs5QDyEY4dj0yFSm44xYsSIEJ9xxhlRu3HjxoXYDj2Vc/7554f4nXfeidZ169YtxGmKhE0fsUPa6UxBQ4cOrdH+iFQq7SebN28u2c5WoYA4ZSj9vtq0CztkW264tWh2OyhOsyg3RGt/Q9I0qHvuuadw22nKiEhj1b9//2jZHn9s/037/Jw5c0I8cODAwu3bVMhy/UYpgLI36YqxiIiIiAg6MRYRERERAXRiLCIiIiICNLAc40rZWdxOP/30aJ1d/vznP7/P9qmuPfjgg/vkdTSDkNS1ND+4KG83LWNm8xLTbVQ6e55dLprdLl0ul4tsSzlOnDgxxNU5+qWkr2VnxRRpSmxesS11aEueQuU5xnZWW5vT36VLl6idcoxlb9JZkYiIiIgIOjEWEREREQEaaSqFiDRctuQSxLPY2VKLX/nKV6J2TzzxRIjT9INKU36K0icqnUUrfZ01a9aE+JRTTgnxeeedF7X793//9xCnaR/pzJUijUlR+VKACy+8MMR33HFHiNP0KTtbbVrO1EpnvCy1D7BraoVIXdIVYxERERERdGIsIiIiIgLoxFhEREREBFCOsYjUsXSKdZtzW27K1x49eoT4rbfeitbZEk/lpm2uVFHeZJofbUvK9ezZM8Tdu3cv3Haapzx//vxa76dIfSuXY3zBBReE+De/+U2IW7ZsGbW79957Q/yd73yn8LVsGbZy5RbTco4idUlXjEVERERE0ImxiIiIiAigVAoRqWMnnnhitGxnjGvdunWI09nj3nzzzb27Y3XIzuQF0KFDhxCn5dmOOeaYfbJPIntDuXKG5557bohtCbW0D1RabvGII44I8auvvhpi+7sBsGjRooq2J1IbumIsIiIiIoJOjEVEREREAKVSiEgdS1MH7Cx29m71SodXG6K0ooYdOt66dWu0rl27dvtkn0T2hnQmxyL9+/cP8aRJk6J1GzduDPELL7wQ4hNOOCFqZ6tSbN68OcRpn1q+fHlF+yRSG433yCQiIiIiUod0YiwiIiIigk6MRUREREQA5RiLSB3r169ftDx69OgQ27JL5XJvt2/fHi3bPEc7E9feZl/L7sPgwYOjdh/60IdCvHr16mjd8ccfv5f2TmTvS2edK3LFFVeEeNiwYdG6iy++OMRpXrF16aWXhnjNmjUhbt++fdTugx/8YEX7JFIbumIsIiIiIoJOjEVEREREAHD7clhyd5xzy4D59b0f+5n+3vsedblBfY71qk4/T32W9UafY9Oiz7Np0OfYdBR+lg3qxFhEREREpL4olUJEREREBJ0Yi4iIiIgAFZ4YO8eFzuGdY9juW4NzzHOO7iUeX1+Tnatp+zLbudw5+has+3vneM053neOscm6f3OO2c4xyznONo+fkz822zm+bh7/vXNMd47vm8e+7RwXlNm30c5xa/LYA84xscL3dopz/LngPd9YyTZq077Mdjo7x+fNcg/n+Oueblf2nHPscI5pzjHDOe52jra7aX+7c3wsj/+W9o+9qSH1y7xvLMv/7V53jiuKnmeevz7//wDnmFGzd18z6mONn3N0y79f05xjsXO8Z5Zb7n4L+4ZzXO8cC5xjdfJ4a+e4J+97E53jYLPuW/njM53jjPyxXs7xfP5b9GHT9iHn6F3m9b/qHB93jptNf9xk/q0u3Bvvuyac40bnKK5JJw1epVeMLwEmABfvrmEDdTmUPjEGZgAfBZ61DzrHcLL3ezhwDnCTczRzjmbA/wDnAsOBS5xjuHMcCeA9RwIfdI5OztEHOMZ7Hiizb98Afm5etzNwFNDZOQ6p8Tutf51h54mx9ywDFjnHifW3S5Lb5D2jvOcIYCvwj/W9Q9XyfmU1qH4J/MF7RgGnAN93jl61fKt1yjmaq481ft6zIu+bo4CbgR9XL3vPVgDncM7tu1Fe50rOc/AAcFyJxz8LLPaewWT98Af5No4k68fDgQ8Bv8jfw/8DbgVOBP41b3shMMl7FhfsTwvgUrK++I/5v9X5wCzzb/WnCt7DXpP/Dv0c+Ld9+bpSt3bbyZyjPdmX9x8wJ8b5lcq/5X8lzsyvyrjkuW2c46+lrrA4x9ec4+X8Ss6/l3n9/3aOqc7xpHP0yB8b5RyT8uf+yTm6FD3usiteY4Hf539RtrHb9543vGdWiZe+ALjLe7Z4z1xgNnBM/t9s75mT/2DdlbfdBrTJO31LYAfwXeCaMu+tA3Ck91SZh/8OeCjfrv33vt05fuYcLzjHnPx9pds72jlecY6ByeM9nOPe/N/75TIH0IPyz2uWc1xrnv+V/C/7Gc5x1W4evx4YlP9b/zB/7H6yH0JpOJ4DBjsXX9HMr8h8p9wTneMS53g1/9z/M3/sc85xg2lzuXPZiaVzfMI5Xsq/E7+sPgl2jvXO8V3neBGIZsFogP2yer+WAm8D/Z3jO87xVfO8Gc4xoMx2WzvHr/N/u1ec49T88Red43DT7m/OMcY52jnHbXmffcXlV7jzf9u7neMh4LH8aepjTZBzDM6/VzcDU4E+eX+q7n/fz9s1d+YqrnNc7HaOeFyct61yjqdN+x/l/XK6c3wmf/wM53jCOe4CXkn3x3smQskT1wuA3+TxHyGM5FwA3Ok9W73nbeAdYAx5vwRaATtcdtL7ReBHZf45zgRe9p4du/k3m+Qc1znHs8DnnGNQ3qemO8djLh89do67nOM887zqUZ6DXHY1e1r+73xs/vh5+bZfcY47q88lXHaF/1vO8QJwfv67NcA5upbbT2m4Kvnr8yPAX73nTWClcxxl1o0GriL7a3AgRCdc7clO8O7wnv+1G3SOs4AhZAezUcAY5zipxGu3A6Z6z1HAMxBO1n4LXJ1fBXq13OPecw8wGfh/+V+Umyp4zwD9gHfN8oL8sZKPe88bZJ1+KtkPw2DAeb/rj4sxFnYZZr0EuDP/75JkXR/gA8B5ZCeggcuGbm4GLvCeOcnzfkp2BeJoshPvWyntGLKD6yjg751jrHOMAT4FHEt2peAKlw0zl3wc+Drwdv5v/bV8u5MBTVXUQLjsKsq5ZH2kps/tC/wncBrZ9+Ro5/gIcA/ZlaFq44E/OMdheXxifoVnBztP4NoBM7znWO+ZUOEu1Fe/BCD/o3Mg2Ql5TX0BwHtGkPXt3zhHa7KT+Ivy7fcB+nrPFOCbwFN5vz0V+KFzVE8XeDxwmfecli+rjzVdw4Ffec9owAHXkX0fRgMn2pO7AtcCp3vPSAipBp8FlnrPMcDRwBfczvSH44B/zb+nlQr9L//DdIPLRj+L+uv/kR3HHga+A3wJuG03x+cTgSkV7k877znJe35Odlz8RX5ecD/lT74BPgncl/9ejQJec1l6x1eBU/PPYWa+z9XWes8J5or1NJI/9qXxqGSY4RLgJ3l8V748NV9+yXsWADjHNGAAhAPcA8AN3vP7Ets8K/+v+uDUnuxE+dmk3fvAH/L4/4D7nKMT0Nl7nskf/w1wd9HjFby/IqXmwfSU/mPCA3gfXU19CLjSOb4JjAQeT/9AIDvRXWae04vswD3Be7xzbHeOI7wPB+n7ved94HUXD+UeBtwCnOU9C0vs3xnAcLfzHXV0jg7esy5p97j3rMj35T6yk3AP/Ml7NpjHP0j271Pq8QdLvP5SilNZZN9pk/dTyK4Y/4qafy5HA3/Lh+9xjt8DJ3nP/S4byTgOeAs4FHie7GRwDPBy/v1rQ/Z9gOwk+d4avv4+75e58c7xAWALcKX3rHSVzZRrfYA8PcN7ZjrHfGAo2Qn742QnMBex83frLOB8c1W6NYSTl8e9Z6XZtvpY0/W297ycx8eS/bG0HMA57gBOgrI55s8Dv3WOu4H78sfOAg5zLoxKdiI7BgNM9J53ariPRf2y5OPeswoYB1l+NVnqwcfyq9ydyc4dXkqe14cSV7EL3GXisWTvF7Lzgm/t5rkvkaVotSM75k53jnPI/kCZmPf7lsDfzHP+kGxD/bERK3tinH9hTwOOcA4PNAO8c1lOENlBotqOZHvPA+c6xx3ekxZLdsAPvOeXNdzffVl0eQFwkFk+EMJJZ9HjAORDnpPJrogd4T0XOcezzvF779lomm4iO9hVGw90Aebmna8jWTpFdUe2/972B2dRvp3R6b7kDgCOr+BqefrvW/TDlr7+7rSGiq/Uy96zKb8KEjjHduKTytaUV+5z/wPZid1Msj+avMvSq37jfcmcu827GxYtoT76JWR5jV9MHquTfzvvec85VrgsH3M8cKVp/3dpSkk+tLsh2Yz6WNNlP+ui/vd+ss5+F68gO6E+D6jKv2cO+Lz3PGk34rKb49LvViWq++Vil90s2M571jhXtr9Wuxb4D+ATwCSyP5bvJrugY5Xql0WqL9gUnbCD6b95KscBAN7zuMvSnD4E3OWyVM/3gb94z6fKvZ6h/tiI7S6V4mPAb72nv/cM8J6DgLlkVz525xpgBXBTiXWPAp92Wf4yztHPOXoW7F91Lu3Hya6krgFWOReGDS8Fnil6PI/XAR0q2GfrQeBi52jlspvghpD9JfkyMMQ5Dsl/AC7GXCXNO9g/Az8E2rKzE1bnOFpvkF0hrnYJcE7+bz2A7EpbJTc8ribrxN93jlNKrH8Mdh7UnYtPjowznaNrnjv1EbI/bp4FPuIcbfO/oC8ku9pY9Hipf+uhFAxNS71bAvR02V3xrWC3w7IvAic7R3eX5Qpfws5+dh/Z9+YSdl5BeZLsSlBPgPz71X8P9rc++mWReWQ3ypKnmO3uZtlnydNInGMo2dXf6pPeu8huQurkfUhxeRT4UvXBPU9VKqI+tn+YBJya99fmZN/zZ/KRxFXOMcRl+fS2OsNA75kEfBtYRZbK8Cjw+XwbOMehLrn/poYeBC7L44vYmfv+INmNsC2dYxDQH5MO4bJKV93zVKq2ZCeg70PJfam0Xwb5RbmX2XkecSk7R6bnkR1jIUsxrO5nA4BF+YW735JdcJoAnJ6vwznaO1d2X9QfG7HdpVJcQpLLSvbX3MfZdeiglKuA25zjBu/DVWa857E897B6WGI92V+LS5PnbwAOd44pwBqyqymQdcCbXVZuag6Ev+KKHr89f3wTyZVTl90J+3OgB/AX55jmPWd7z2vO8UfgdbK/LL9QfXXLOb5I9sPSjCwv6jWzz18gu0K20TmmA845XgUe9j4ucZMPp3Zy2c0+3cgOlJPM+rnOsTa/QlSW9yxxWdmbR5zj08nqfwL+J9+f5mQ/DKUqEkwAfkf243OH90zO3+/tEIa1bq3Ozyzz+PMuu6HrkTzP+FTgL7t7D7Lvec825/gu2QnvXLKrveXaL3KOfwOeJjuQPOzz6g7es8o5XgeGVw+Des/rzvEt4LH8gL2NrI+UnQa1ofTLEulG1r3AJ12WnvIy8Ga590R2keDm/HW3A5d7H0aB7iG7F+A/TPv/IEtjm56fHM+j+A8X9bH9gPcscI5ryIbxHfCQ9+Fzv5ospeIdsv7RKn/8x/kfkQ54zHtmOMcbZMebafkxeCkUly+s5hw/Ijvx7ZhfDb7Ze64jS+X7P+eYDSwnv6DjPVXOcT/ZSe12sqvU75tNfg/CvSh3kP1x/S9kVWFSD5Olf9XU58jOQ75NduPg5fnjvwDud45zgUcgjF6dCfyzc2wD1gKfyH/3rgDuyf/w9mT/3rvca+Cy+wb6AdNrsa/SAGhK6HrmHF8G1nlfeENco+eyu4MvyPPKRBq8xtYv1cdkf+AcDwJXlbjBvMFwjkvIrtJ/r773RWpHM9/Vv18Q5w43KS4rsfcjHbClkWk0/VJ9TPYjV9Pwb2rzZKM/0kjpirGIiIiICOBU7WAAACAASURBVLpiLCIiIiIC6MRYRERERATQibGIiIiICKATYxERERERoLIpofeZ7t27+wEDBuzz192+fXu0vGzZztlgmzVrFuIDDij+O8K2K8fe7Ni8efzP36HDznkxnKv5fLO1MW/ePJYvX16nL1abz7GqCpKPIWjeHEaO3PP92h9MmTJlufe+R11tr776ZDkbNuycZOr999+P1qXLRWy7Fi1ahLh9+/Z7uHd1Y3/4HPcnTfXznDVr56SM9piVHr/sca9ly5YlHwfYtm1biMsdb+3zhgwZUtiurjWEz1HHyrpR7rNsUCfGAwYMYPLkyfv8de2JMMAvf7lzpurOnTuHuE2b4omBOnXqFOL0R2HHjp2z3m7dujXEPXvGk/2dcsopIbY/HnvT2LFj63ybtfkcy/0dsH071MPXolFyzpWdOKOmKv0s7YlmekArqnxT2z/+Jk6cGOKNGzdG62z/sv0utWXLzkpsPXrs/G086aSTarVPda2+PkfZO5rq52mPWfbiUKtWraJ2mzdvDrE9EbSPAyxZsiTE9kJR2pft8sMPP1yznd4DDeFz1LGybpT7LBvUiXF9ufvuu6Pl6667LsRdunQJcZ8+faJ2c+fODXG/fv1CPHTo0KjdG2+8EeLWrXdO9X7GGfFU8PZH4dJLL61o30UaAnuSW64EZLmT4XXrdk4y99RTT0Xrpk6dGuJHHnkkxIceemjh9tevXx/iFStWRO26desWYntw/t734pr8H/7wh0N8/vnnh/jggw8ueBciTdfatWuj5dde2zm5pP0DM7VpU5hslrfffjvE9ngI8R/Vbdu2DbH9g3d3ryWyp5RjLCIiIiKCToxFRERERACdGIuIiIiIAMoxBna9+c7eHFDuztjevXuH2N4MkOYzrlmzJsQdO3YM8XvvvRe1GzZsWGU7LNLAlMsxLsorvuWWW6Jle4d7Wl3C9o3x48eHeNq0aVE7e9OPrTaT5iLbG3vatWsX4vS3YP78nfdnfPnLXy75HIDrr78+xH379kWkKUpvlrN92x4D05vH7bK9bye9qc7mMNtjb1q5odyN8CJ7SleMRURERETQibGIiIiICKBUCmDX1AdbCsaWlunatWvUzpaXskOzq1evjtrZoeWioSKAESNG1GS3RRoM+x0vV5LtpptuCvHKlSujdYccckiI7aQbEA+52vrfJ598ctTuvvvuC7FNdUqHdm3fs/3OloKDePIAW6vcplgAfOtb3wrxbbfdhtSP3r3BVL2M9OoFixfv2/1pau69995o2R47DzzwwBCnKRI2NcqmO6UpU7asm02FsumIAAsXLgzxlClTQjxmzJjyb0CkArpiLCIiTULRSfHu1omIVNOJsYiIiIgISqUAoH///tFyVVVViO00lzaG+M50O1SbDiPZId1Vq1aFuNyd9yKNSblUinfffbdkPHDgwKidnakuZfuanSFy0KBBUTu7/NZbb4U4TYM69thjQ/zss8+GOK0oYe/Ct9NPp3fFLzZj9L/73e+idXYWy0pTTkQaoltvvTVatrPB2hSnJcnl+ebNd55q2N8AO7sdxMdYOyuefT7A0qVLQ/zSSy+FWKkUUhd0xVhEREREBJ0Yi4iIiIgAOjEWEREREQGUYwzsmutnyzfZ3MZ0Ri9byq1c7vDQoUNLvm6aH5nmUYk0FuVmiJw9e3aIbQ6hLccE0L59+xBv2bIlWmfz9m27tDTiueeeG+IJEyaEOM0Jtq9tY3s/AMCGDRtCbMszbt26NWpnS1C98sor0TqbY6y8YmnM7OyUAGPHjg2xLbW2bdu2qJ09Jtr+m/Yj2xdteUQbQ/x7Y0u3idQFXTEWEREREUEnxiIiIiIigFIpgF2HgQ866KAQDx8+PMTpMOjdd98dYjuL12uvvRa1O+mkk0Jsy8n069cvameHldIyNiKNle0PtgRTmi5hU5XS778dirXpGHYmSYjLR5111lkln5MuDx48uOQ+QFyGzQ7z2jJuKVs+SqSxW7RoUYjTUqS2RJstoZYeU205U1uuzf4eQJxmYdMx0rQr+zybxiRSF3TFWEREREQEnRiLiIiIiABKpQDgsMMOi5affPLJkuvSIZvDDz88xMccc0yIP/vZz0btDj744BAfeOCBIe7SpUvULr1zXqQpWLBgQYg7duwY4jSVwurVq1e0bGeds8OqLVq0iNrZtA1bXcZWjYF4hjt7V3ta5cLO4GUrVqTpUoccckiIu3XrFq2zKVJ2SFmkMbDpROVS/GwaUnosW758eYhtJYsZM2ZE7ezslzatIk3hKJohT6Qu6IqxiIiIiAg6MRYRERERAXRiLCIiIiICKMcYiPMXIZ7tzuZXpTnBls17THMnbakpmw+VznRnS0CpBI00VjYvN2VzCNN83iOPPDLEae5wmmNYLS3DZvuN3X46w5bNh7RloWxpqnR7dhvpvlvpzJfTp08Psc2vFGkM3nzzzRCn/dIeK620tKntV3bG2NGjR0ft7Mx6/fv3D3Gam2+PnTpWSl3TFWMREREREXRiLCIiIiICKJUC2HU4yKZW2Bl8bFkniNMnRo0aFeJ0GGnTpk0htsOx6fBwOkwl0hjNmTMnWrZll2y60IYNG6J2tt/YmSQhTncoN+tc0Qx5aZ+0s3TZdem27eva3wX7niBOn0pTpObOnRtipVJIYzNz5swQp+XabB+2/S1NNerRo0fJbR933HHR8rRp00Js+2WanmjXqQSi1DVdMRYRERERQSfGIiIiIiKAToxFRERERADlGAO7Tl9p84rTXELLrkvLzlg2N9G+VlpmRjnG0hS8++670bItUZiWMrPmz58f4gEDBkTrbB6hzc23ef4AHTp0CLHtT3bb6X7YnOB0eln7WrZ0Y3pfgn2ttB/bElQijc3s2bND3KlTp2idvWfGfu/T+3Euv/zyktv+9Kc/HS3ffPPNIS73W2HzmdOSjSJ7SleMRURERETQibGIiIiICKBUCmDXoRg7JGTLwqQln4rSLNLUDFvyyQ7Bpq+rISFpCtJhVJua1LFjxxCnJZjWrVtX8jkQp0zYfpKmUtjn2e2nw7I25WLVqlUhTlMpbKlFu+/Lli2L2tkh5vS1qqqqEGms1q5dG+L02GaPifY4Z2OAq666quS2jz766MLtFZVehDgNUcdNqWu6YiwiIiIigk6MRUREREQApVIA0L1792i5aDjH3oELuw67VrPDtADe+5LP6devX9QuHT4WaYzWr18fLduKEl26dAlxWiniggsuKNyG7ZM21SlNx7DLdjg3nY2uaCa9NF3K9tdhw4aF+IEHHoja2b6bVqWw6RgijY3tO2n6oO0v9nveu3fvqN3AgQMrei17LLbH3q5du0btVqxYUfJ1ReqCzsRERERERNCJsYiIiIgIoBNjERERERFAOcYA9OnTJ1q2ucQ2P9jOYAe7lqSplpaQsiXabMmncjP7iDRWNmcX4hJPaa6vNXz48BA/99xz0bqi0ohpXv7q1atDbPOZ03Y2D9juk+3vqaFDh4Y4zWu0z0tntFyzZk3hNkUaum7duoU4PbZZ9r6Ac845p1avZXOTbRm29D6glStXhljHUalrumIsIiIiIoJOjEVEREREAKVSANC2bdvCZTuEmw7Z2OEcy6ZOQFxCyg6z2iEqkcbMDrGmKUY7duwIsU05SMua9e3bt2S7lE1pSlMzNmzYEGLbv9IybHbZlpNL2X0fPHhwyX1I26Xv3w4x27goPUSkIbHfUztLJMT9fvbs2SH+7//+78Lt2eNomuJ0yCGHhHjBggUh7tGjR9TO9jfbTqQu6IqxiIiIiAg6MRYRERERAZRKAcR3v0KcCmGHfdI7ctPhnWpDhgyJlu0d7EUzbok0ZsuXLw9xmgZh0xbsEGiaSmH7V9rXbMqErRqTpiPYNCjb19IqEj179gyx7f/pvtt1NtWj3CyVtgoHxO9/8eLFIbapGSINlU3/S49ZNjXI9h1bYSZlfwPSfnT44YeHeO7cuSFOZ5NdtmxZiG31GZG6oCvGIiIiIiLoxFhEREREBNCJsYiIiIgIoBzjkmx+oy3JluY9FuU2pflV7777bojXrl0b4jQXUaSxsjPOpf2kdevWJdsdfPDBUTubR2jLrgH06tWr5PbTEoo2J9jmQ6Y5xradzV9OS62tW7cuxDaf0u5Puj2bQwlx7uXSpUtDrBxjaQxGjBgR4hdffDFaZ/uYvbfGzmCXKpefP27cuBD/7Gc/C3FaHtHm6nft2rVweyK1oSvGIiIiIiLoxFhEREREBFAqRUkrVqwIsR0eeuSRR6J2V155ZcnnH3XUUdHySy+9FOJ+/fqFOB0GFmmsbEmytISaLfc0a9asEA8bNixqZ5+XzmhnlZtlzu6Hfd00bckOAdvtpTPk2VQqW8bRDi9DnHKRpljZbdp0DJHGYPz48SH+9a9/Ha2z/dSmCT711FNRu7POOivE5Wa1tL8JBx10UIjT9Au7Ddv3ROqCrhiLiIiIiKATYxERERERQKkUJT3zzDMhnj17dojTVIrf/e53JZ9/xBFHRMt2OPbGG28M8ciRI6N2Y8aMqfnOijQANv0oTYOwFSHWrFkT4vT7b2ezssOyEKcj2PSJLVu2RO3szHd2P9KhWLtPNqUpnY3PVpt45513Qjxo0KCo3QsvvFBy2xAPD6fvS6Shs30g7R82Nci2S4+NNpWiXJpU9+7dQ2wrT8yfP7/wdW3VG5G6oCvGIiIiIiLoxFhEREREBNCJsYiIiIgIoBxjYNfyMbZ8k80xtqXboDi3Kc2hsnmVtnRbOkOYSGM1derUEKc5tnZ5yZIlIU7Lmk2ePDnENlcY4hxhG6ezzLVs2TLEtn+l7eyyLetmY4j7clVVVYg7duwYtbPl4NL3b2ftsu/xYx/7GCKNSVpu0H7X7fHQHudqy5ZUnDJlSrTO3meQ9jeRPaUrxiIiIiIi6MRYRERERARQKgWw62xXW7duDbEdpkmHWYvY50M87GPTKtJZu0QaKzsrnB0CBXjvvfdCbGepSsu12VSFzp07R+tsOoKVpkHZ8m02XcKWkoJ4lj2bfpG2s78N8+bNC/H5558ftfuHf/iHEF900UXROpsW0qdPn13fhEgjceKJJ0bLd9xxR4i7du0aYtunamvAgAEhXrVqVbSuqJ+L1AVdMRYRERERQSfGIiIiIiKAUilKssNAdqYqO1xcTjo7kL2z3aZP9O7du7a7KNKgfOpTnypcZ+9knzNnTojT2ePuu+++EKcVK+w27Ex1acrF8uXLQ2xTmtL0DluxwsbpDHk9e/YM8aRJk0J85ZVXRu3srH02TQM0M5c0HV/84hej5XvuuSfEtu+sXr06amf7/cCBAyt6rQ4dOoTYpmBB/BuQ/laI7CldMRYRERERQSfGIiIiIiKAToxFRERERADlGJdkZ7GyuYmV5gqmpWpsSSmbG1UXJW1EGjqbc3vkkUeGOM0bXLFiRYht6Scozs1Py7jZbdh+l/Y1mw9pSz+V65P2taZNmxatGzduXOHzRJqKfv36Rcs2x9/eB5CWLLUz4VWaY1w0iyXEfTZ9LZE9pSvGIiIiIiLoxFhEREREBFAqRUmLFy8OsZ1Vx6ZBlJOWa7LDtnZ7NmVDpKlIZ6Oz/cbOLDdhwoSonS1rmLKzx9ntzZ49O2pXNExr+3S6DZsulZZktH3UDiM/++yzUTubSpG+/3RmTZHGxH6f0+/ymWeeGeJ77703xGlK0gMPPBDiiy++uKLXtcfRhQsXFu5TpcdlkUrpirGIiIiICDoxFhEREREBdGIsIiIiIgIox7ikXr16hXjp0qUhtvmR5aRTVBaVhrLTzYo0FWkeYlG/mTVrVrRsSz/ZfgJx/rF93iGHHBK1sznC7733XuH2bF7ipk2bQpzmB9tcSRunOctW+v7L5WiKNHRF9whAnFtvp4dO759ZsGBBjV+3U6dOIU5Lstlj7MqVK2u8bZFydMVYRERERASdGIuIiIiIAEqlKOncc88N8eTJk0NcaSpFhw4domU7JGRLQ/Xv37+2uyjSaNgShbYPzZ8/P2pn0x2GDh0arbPPGzZsWIjTGfJef/31ENu0BTtzHsSpGba/2r4K8RCu3b90xj27rlWrVtE6pVJIY2ZTAVMf+MAHQmzLGa5evTpqZ1OPqqqqQjxy5MjCbXfs2DHEaX9r0aJFiG0Klkhd0BVjERERERF0YiwiIiIiAiiVoqTWrVuH2KY+VJpKkbJ3vdshoQMPPLBW2xNpTIrSB77//e9Hyz/84Q9D/Mgjj0Tr7NCsrUSRzpZn+5qt+rJq1aqo3dq1a0uuS6tN2GHa7t27h/iLX/xi1C5Nn7DKDUXXl69//etl119//fX7aE+koas0/efggw8O8bRp06J1NvXh8ccfD3G5VIp169aF2Pbr1JIlSyraP5FKNbxfbBERERGReqATYxERERERdGIsIiIiIgIox7ikT37ykyGeMGFCiG0Zt5o4//zzSz4+YsSIWm1PpDEpyrFNZ8e65pprCrfxzjvvhNiWZEvzC23usJ2xK2VzHm1s8yQBTjzxxBC3b9++cHsi+7tvfvObIe7du3e0zvaxk08+uaLtjR8/PsR2NlqIc/9PP/30Gu2nyO7oxFhERGql3E18uoFPRBojpVKIiIiIiADOzspU35xzy4D5u20odam/975HXW5Qn2O9qtPPU59lvdHn2LTo82wa9Dk2HYWfZYM6MRYRERERqS9KpRARERERQSfGIiIiIiKAToxFRERERIC9eGLsHN2cY1r+32LneM8st9xbr1tTznG9cyxwjtXJ462d4x7nmO0cE53jYLPuW/njM53jjPyxXs7xvHPMcI4Pm7YPOUdc1DF+na86x8ed4+b83+Z159hk/q0u3Bvvuyac40bnOKG+90MaFuf4pnO85hzT8+/qsfnj85yje4n25ztHyfpeznFK0XfMObo4x5/y13nJOY4w685xjll5f/y6efz3efvvm8e+7RwXlHk/o53j1jzu5Rx/do6qvE8+bPbzzwXPv9U5hhesu8o52prlJ5yjS9G+yP5Fx8vQVsdLqX/e+73+H/jvgP9qiccd+AP2xT7kr9e8xGPHgz8Q/Ork8X8Cf2MefwL87/P4SPBTwbcEPwj8W+APAP8V8J8C3wn8c3nbC8F/s8z+tABfBb6ZeWww+Gk1eQ97+d+sGfhDwT+0L19X/zXs//J+MxF8q3y5O/i+eTwPfPcabKt50W9Evv6H4K/N42Hgn8zjZuDfBj8w749V4IfnfbS6vz6X98k+u/sOg78b/Mg8/iX4fzbrjsz/fwr4P9fw36pZ+m8C/rJyvw36b//9T8fLwv3R8VL/7ZP/9nkqhXMMzv9KvBmYCvRxjk84x6v549/P2zW3f5U6x8Xmas7Fedsq53jatP9RfkVpunN8Jn/8jPzqzF3AK+n+eM9EYHGJXb0A+E0e/xE42zx+p/ds9Z63gXeAMcA2oA3QCtjhHC2ALwI/KvPPcSbwsvfs2M2/2STnuM45ngU+5xyDnONv+ft8zDn65u3uco7zzPPW5/8/KP/rfFr+71x9Ze+8fNuvOMedztEmf3xx/lf+C8D53jMLGOAcXcvtp+xX+gDLvWcLgPcs956FZv2XnGNq/n0bBuAclzvHjXl8e95fnwb+APwj8OX8O/rB5LWGA0/mrzOT7LvYCzgGmO09c7xnK3AXWf/cBrRxjgOAlsAO4LtA4dR6ztEBONJ7qsz7W1C93numm+bt86tjM/Mr0y7fxt+cY2wer3eO7zrHi8A3gb7A09W/V8CDwCVl/n1FdLyM6Xgp+0R95RgPB37lPaMBB1wHnAqMBk60X9YC1wKne89ICEMnnwWWes8xwNHAF9zO4ZzjgH/1nprMwdwPeBcgP+hucI7O9vHcgvyx/wPOAx4GvgN8CbjNezaVeY0TgSkV7k877znJe34O3Az8wnuOBO6n/I8JwCeB+7xnFDAKeM1lw1VfBU7NP4eZ+T5XW+s9J3jPn/LlacDxFe6rNH2PAQc5x5vOcZNzpPO8Lveeo4BfkH3PShkKnOE9f0f2nf6x94zynueSdlXARwGc4xigP3AgBX3Re94gOwBPJTtIDwac97se6I2xwAyz/D/Ar5zjaZeljPQ160YDV5H9jg0k68epdsAM7znWe74LLCTra6cCeM8qoJVzdCuzTyKg42U1HS9ln6ivE+O3veflPD4WeCq/4rQNuAM4aTfPfx74bf5XbvV7OAv4lHNMA14EOgND8nUTveedGu6jK/GYL3rce1Z5zzjvGQu8SvYX84Muyzu8Jz+gp/oAyyrcn7tMPJbsgA/ZX+m7+/d6CfhH57gGONx71gMfIPvBnZj/m40HBpjn/CHZxlKITg5kP5Z/h8aQHWCXAX9wjstNk/vy/08h/l5Zd+/u6k/ueqBL/j39EtmVrO0U91G856r8JPu/gf8ArslPcP/oHFeUeF7UF73nUbKT3v8FhgGvOEd1MfiXvGeB97xPdgAs9f52APfu5n2pT0kldLzM6Hgp+0TzenrdDSYu1XEA3k/WtTbxFWQ/EOcBVc5xZN72895nQ65h41myv329Si0ADgIWu+zmh3bes8a58Hi1AyEaQobsL/T/AD4BTCI7QN4N2Y0HxqbkfZWzAaB62DZRPUvLdvIfvnxo6gAA73ncOU4FPgTc5Rz/Tvbv+xfv+VS51zNa5/srAkB+Uvs34G/O8SpwGXB7vnpL/v8dFP/OVNQvvWctZN/T/Ps/N/+vLbvpiy672W4y2RXcI7znIud41jl+7z0bTdNd+qL3rCQ78bjDZTfcnQSsMO+t3PvbXMFJv/qUVELHy4yOl7JPNIRybZOAU112V25z4GLgmfxqzCrnGJLnCtq7TQd6zyTg28AqsqGZR4HP59vAOQ6tzgGqpQfJDvQAF5ENHVc/folztHSOQWTDumF4x2X5lN29ZwLZgfv9/L9S+/IG2TBvxbzHAy8DH8sfuhR4No/nkV3FA/g7CLmPA4BF3vNL4LdkQ3ATgNPzdThHe+fK7stQ4qFm2Y/l/WuIeWgUeza16TqgQ8FrdXY778z/DPBsfrL8MjDEOQ7J119M1j+rn9cC+Gfgh2R9sfqAWJ17bEV90TlOc3kVCZflHw+CGl9FK3x/+QG7N1mfFamUjpc1oOOl1EZ9XTEOvGdBPmTxN7Iv5kPe85d89dXAX8kOSK+TJeoD/Ng5DsnbP+Y9M5zjDeBgYJrL/kZcCsWlmao5x4/IOnLH/K/bm73nOuAW4P+cYzawnOwHCO+pco77yTrpdrK/ut83m/we8LU8voNsSPlfgG+UePmHgV/tbh9L+Bxwm3N8m+xGiMvzx38B3O8c5wKPQLhidSbwz86xDVgLfMJ7FuVDyvfkJxWe7N97dvpiztGa7Md0erpO9lvtgZ/neYTbyb43n92D7T1E9l28APhSkmd8GNlQ8A6y34F/APCe7c7xRbKDfDOyHMXXzPO+APzGezY6x3TA5Ve2H/Y+LjflPTOdo5NzdPCedWQHzBudC1eVbvWel53jlFq+v1uAR5xjUZ5nPAaY5D3ba7k92Q/peKnjpex9LisxIvXFOR4ErvKeOfW9L0Wc4xKyqw7fq+99EdlbnOPLwDrvs7v59/Jr/RR4MB3KFpFiOl7KvtAQUin2d1fT8JP0PfDT+t4Jkb3sF8T5w3vTDJ0Ui9SYjpey1+mKsYiIiIgIumIsIiIiIgLoxFhEREREBNCJsYiIiIgI0ADKtVndu3f3AwYMqO/diOzYsbNGf7NmzaJ1W7bsvE9n+/adVZeci2uK2+U2bfakVGTdmzdvHsuXLy8qGl8rDfFz3F9MmTJlufe+x+5bVqahf5YrVqyIljds2Fln394/kfbd1q13zhPQvXv3vbR3tbe/fY5NnT7PpkGfY6yqCraXKTjZvDmMHLnv9qcmyn2WDerEeMCAAUyePHmfvJY9aKYnstaqVatC3KVLl2jd22+/HeLly5eHOD0It2rVKsQjRtRk+vm9b+zYsXW+zX35OdZU796wZEnpdb16weLF+3Z/6ppzbk8m2djFvvws339/Z3nT9KbgtE9V++1vfxstT5w4McT2j9W07w4bNizEn/70pwv3qdLfiaLn1OR5yXMa7edYnxpq/9bn2TToc4zt7qdt+3ZoqG+v3GepVArZrxQdNHe3TkQaPvVvEdlTDeqK8d5kUyIgvgKVXuGxV3i3bdsW4jQNYtOmnVOhd+7cueRzAFq0aBHiK664IsQ33HBDRfsusj844IDK/k6fPn3nhFKXXXZZtO74448vuT3bBwF+/OMfl9xGemXaXu2t9Opxba4Qi4hIw6ArxiIiIiIi6MRYRERERATQibGIiIiICLAf5RgX3dUO8Ic//CFavuaaa0Js8xnvvvvuqN3Xvva1EL/yyishfuKJJ6J2Z5xxRog///nPh3h7UuekefOdH0dt7oYXaSpmzpwZLS8xd0717NkzxC+++GLU7tprrw3xmjVrQpzeH3DrrbeG+Nlnnw3xhAkTonZXX311iFu2bFnRvouISOOlK8YiIiIiIujEWEREREQE2I9SKcqxKQwAffv2DfG3vvWtEI8bNy5q99e//jXEc+fOLdz+TTfdFOJKZ7lR+oQ0dVOmTImW77///hAvXLgwWnfiiSeGePXq1SHu2rVr1O7QQw8N8dKlS0OcplKMNNMxbd26NcQdO3aM2tmSiieffHKIDzvssKhdQ5w9T0REak5XjEVERERE0ImxiIiIiAjQBFIp0lnrbAqCHSKdOnVq1M4Ox27evDlaN3v27BDPmDEjxA8//HDUzs5216dPnxC/+eabhfs7a9asEG/ZsiVaZ1M47Ox5vXr1itpVOkOYSENjqzycfvrp0TqbjmBTIgCOOOKIEM+bNy/Ev/vd76J2Y8aMCfHQoUNDnPa1Bx98MMRnn312iNMUiUmTJoXYVpuxjwN85CMfCfGQIUMQEZHGSWdYIiIiIiLoxFhEREREBNCJsYiIiIgI0ARyjMuVNXv9GP+dbwAAIABJREFU9ddD/PLLL0frbA6jzUUEGDVqVIjfe++9EK9fvz5qZ8tLjR49OsTLly+P2m3atCnE7dq1C/GKFSuidm+99VaI7SxbLVq0iNqpNJQ0Jq+++mqIbW7vf/7nf0btbCnDtITiwIEDS7ZbtWpV1O5Tn/pUiOfMmRPijRs3Ru2mTZsW4mOPPbawnc3779evX8nnA/zoRz8K8S9+8QtERKRx0hVjERERERF0YiwiIiIiAjSBVIpy7DDr4MGDo3U2LaJHjx7RurVr14a4W7duIU5TGCZPnhzil156KcS2tBTAsmXLQrxu3boQd+nSJWpnX8uWZLOpGCKNjZ3hzs4Wedttt0XtHnjggRDbvgBxGbWZM2eG+KGHHora2b5ry7otWbIkamfTlmw5RFtOEeJ0DDvL3vDhw6N2H/rQhxARkcZPV4xFRERERNCJsYiIiIgI0ARTKWyKhE1bsDPTQXx3/IgRI6J16Ux41dq3bx8t25n1bLpDWkVix44dIbZVNNq2bRu1s8v27vj0TnmRxuSpp54K8SGHHBJiW/0FoFOnTiFO+5pNT5o/f36I03592mmnhfjtt98OsZ1JEuJKGTZFKk25sGkW6TasBQsWhDitSqMqMiIijYeuGIuIiIiIoBNjERERERFAJ8YiIiIiIkATzDFevXp1iLds2RLi3r17R+1sLqEtpwbx7HTNmjULcevWraN2HTt2DLHNK/beR+1s6SmbR/n+++9H7eyyzV9Ocxvt+2rVqhUiDZktofbuu++GeOzYsVE7my+c5vl37tw5xLYMY5rPP2TIkBCvWbMmxGk+vy3LZu9FsK8DcZ8/+eSTQ3zvvfdG7Wz5t3RGS+UYi4g0HrpiLCIiIiKCToxFRERERIAmnkrRsmXLEKdDpHbWOZuakK6zaRF2NjqIh3vbtGkT4jTlwrazZd3S4V2b3rF9+/bCfbdD0+msfSINTVEaxMMPPxy1s9/ldLZHmwplZ7SzcbpsZ8izs9ZBPKPdZz7zmRAvXLgwajdt2rQQP/PMMyF+4YUXona2L6e/JyIi0njoirGIiIiICDoxFhEREREBdGIsIiIiIgI0wRxjm5toc4xt2bW0XTqFq811tHnFdjrnVPPmO/8p7RTQEJdhs+XV7HMgzk1O1xW1E2noxowZE+LLLrssxGmers37XblyZbRu0aJFIbZ5ynYKeIjvMbBl2NI+aUuq2emcbdk1iKdjt78Taak5m0ed5jOLiEjjoSvGIiIiIiLoxFhEREREBGiCqRS2NFq5WetsaTQ7NAvxsKgdcrWz0UGc7mBfy6ZwQJyOYdMq7Mx5EJeDGj16dIjTFI50Zj2RhuTVV1+Nlu+8884QX3LJJSFOZ360JQrtDJEA7du3L7ku7ZPlZoy0imajTFOYbN+1/fqcc86J2i1evDjETz/9dLTu0ksvLdwPkYYmnbnRpjjZ1CKAd955J8RHHHFEiG+55Zaone0Dffv2DXHaz22pVCv9rUhLpxaxx8pyqZAilq4Yi4iIiIigE2MREREREaAJplLYoVQ7G1WafmBnj7OzakF8Z7sdfkmHb+ywqx3qSYdsWrRoEWI7XJy65557Qjx06NAQ26EniNNFRBqaDRs2RMs2zeD2228PcTrz3bXXXhti+/0H6NWrV4htisR7770XtTv++ONDbPtrz549o3a2csSQIUMK29k0qwsvvDDEb7zxRtSuqqoqxEcddVS0TqkUsjcUpdQVpQyklVls+t9TTz0V4p///OdRu7fffjvEad+26UWDBg0KsU1VBDj55JNDfOONN4b4iSeeiNo9+OCDIT7uuONCXC51wh7z0zRGpU9IbeiKsYiIiIgIOjEWEREREQF0YiwiIiIiAjTBHOMtW7aE2JZ+SfOxZs6cGeK0lJudnc7OkJfmaFl2XZoPZfOPbdmp1J/+9KcQ/8u//EuI07ypdLYvkYZk+PDh0fIPfvCDEJ911lkhtjNMAtx7770hTss4HXjggSG2/euOO+6I2g0cODDENjfSzpwH8Nxzz4XY/k68++67UTs7e541bty4aPnUU08Ncfr+RfamSkuZpbO/Tp06NcQ/+clPQnzooYdG7caPHx9iO4slxKVN7T0DEydOjNr97//+b4g7dOgQYnvvAMR5/IccckiIv/71r0ftzj///BCnx0eRPaUrxiIiIiIi6MRYRERERARogqkUtjyLnVnOplgAzJs3L8R2aCdta0uj2bJrEA9Z2TgdsrLKlZCzZeNsGaojjzwyapcOnYk0JG+99Va0/Oabb4bY9o2lS5dG7WwpwzRtyaY02W2kqQ+vvfZaiG26VNr/bd+z5d/sTF4AK1euDPHhhx8e4nQI2L7n6dOnR+vS/itSF6qPdeWON+XYtAg7250tZVgTl112Wck4NXfu3BBfd9110bpp06aF2KYM2nSsdBt9+vQJse2vEPfz9DfFHkeLfg8ATjvttBLvQpoyXTEWEREREUEnxiIiIiIiQBNIpUhngbPDJba6hJ3pLrVx48ZouV27diG2s9ulqRTpkEu1dHY7m95h76BNZ+1auHBhiBcsWFC4v0qlkIYsTaWwVV9sn/njH/8Ytbv++utDbNMWIL773X7/bWoSwMc//vEQv/LKKyX3AeKh2HPPPTfEduY8iIdmv/zlL5fcNsS/IenvhJ1J074PkdraunVrOEbYVCWI+0SbNm1CnFaruOqqq0JsU41eeOGFqJ39/qbHW9uf7bH3pZdeitrZ2S9tiuOwYcOidmeeeWaI7YyUtioNwP333x9iW2EmTYu0fTE9btrjtF1n3y/A0UcfjexfdMVYRERERASdGIuIiIiIADoxFhEREREBmkCOcbnZ6GwuU5qHZdk8LIhzk+320xnnbJkcm6NUbuY7m9fUr1+/qJ0tAZXmaVo2Zzl9/7Ut3SNSV6ZMmRIt2/JPtizUrFmzonY2n/+pp56K1tnZuGw/fOaZZ6J2o0ePDrHt82neoN2Pk046KcTpjF32noCDDz44xGmOse3Ly5cvj9YtW7YsxMoxlrrQrFmzMItqmvdrSw7ae1XS49KIESNC/Ktf/arwtWz+cTrLnL0fp2fPniG+6KKLonZ2FjtbXq22rrzyyhDb+4fsbwjser+PZUu0paVTLfXZ/Y+uGIuIiIiIoBNjERERERGgCaRSpOxwkS1bM3Xq1MLnpKkURbNspWWYitIW0uEcu0/lhmyqh8Zg12Fmqyg1o9w+iewracmz4447LsQzZswI8Qc+8IGoXZcuXUL86quvRuu2bt0a4qIZqyBOLbL936YzpO1sH0pLMNqhY9s/0/KPdlh63bp10To7xCxSF5o1axaG+MeNG1fPe1O/bMqkSF3QFWMREREREXRiLCIiIiICNIFUinTo0w6z2uoNdgarVDpbzoYNG0Jsh3DTChB2mLXc3a82vcGmaaSpGd26dQtx0ax6UHlqhkh9mDZtWrQ8ePDgkuvSqiyLFi0KcTorpL2T3aYq2DvwIb4L385ul84kaWeqW7JkSeH2bJ8cOnRoiO3vAsQzc82fPz9at2rVqhB36tQJERFpuHTFWEREREQEnRiLiIiIiAA6MRYRERERAZpAjnGa62dzjG3ZNJvbm0rz/hYvXhxim8+bznxnZwSy7WxuM8T5wnb/0jIzdj/SXEfLvi+7PZGG4M9//nO0bPPgf/rTn4b47LPPjtqNGTMmxOksXUcddVSI33333RAfc8wxUbvDDz88xLZvpH3c3hMwcuTIEKf3ItgScrbk21e+8pWonS2vmOZHf+Mb3wjxgAEDEBGRhktXjEVERERE0ImxiIiIiAjQBFIp0nJlaRpDNVsKCmDIkCGFz7Hl1WzaQjqjnV22pdzKlVBLh4itww47LMQzZ84sbKdUCmnI/uu//itatjPh2XSkQYMGRe1Wr14d4rRcYevWrUNcPeMXQO/evaN2tgSc7RsLFy6M2tmZ62z/P+igg6J2mzdvDrFN2/rMZz4TtbOz+KV9Mp3hT0REGi5dMRYRERERQSfGIiIiIiLAfpRKkVZ5sDNVpduw1SZsikRa2aJolr10KNWuK1cdo3379iVfN51xz6Z6lJtxT6Q+zJkzJ1q2aRD2u3zooYdG7Z588skQ33fffdG6qVOnhtimRdx+++1ROzvLnK1e8cYbb0TtbIqE3V46a9+KFStCfNZZZ4XYVqiAePa8tFKOTRHp0aMHIiLScOmKsYiIiIgIOjEWEREREQF0YiwiIiIiAjSBHONUWuapWprbO3jw4BDbnF2AVq1ahdjmB6ft7Lo0r9BKn1ekXbt2Jfd348aNUTtbrq3c64rUhw0bNkTLNh/XxmPHjo3a2dntbDlFiEueVVVVhdjmLwNcfPHFIX7ttddKbhviXOePf/zjhftkZ8I755xzSm4b4jJ06fsvd1+BiIg0LLpiLCIiIiKCToxFRERERIAmkEphyy5BcdrCvHnzouUTTjghxHPnzo3W2Vny2rRpE+IuXbpE7Wzahh2aTUuo2XZFqR7pa61Zs6bktmHXGfhEGpJ169ZFy7Zs2uzZs0Pctm3bqN2jjz4a4vQ7b/vU4sWLQzx8+PDC/bDbHzFiRLTOlpSzM+n17NkzamfLsNnfBVtaEeJykOn7T3+jRESk4dIVYxERERERdGIsIiIiIgLoxFhEREREBGgCOcZpPm/R9LNpnp8ty5ROCd2yZcuS27ClmyDOM7TTQKflmmzO4QEH7PxbJN0nW1Kqd+/eIbY5mhBPpVsuZ1mkPqT5vMcdd1yI33zzzRC3aNEiard27doQ2z4Icc79xIkTQ9y9e/eo3RNPPBFiW0Jt4MCBUbsXX3wxxGeeeWaI075m700YOnRoiE8++eSo3euvvx7ijh07RusGDRqEiIg0DrpiLCIiIvL/27vzeCuKM//jnwdQuGwCgoJEFlFERUDFfU/UmIxLjGb8adwnyRjjmsTEiTFGTdSMUceYUeM+ibtxiWvcUZKIooAsCgoKiiCCigqySv3+6LrN08U5517gXu72fb9evHhOd53uPkvdrtP1dJUIahiLiIiIiADNIJXCzz6XPp41a1YepzPEHXHEEfV7YM6GG25Yq3I+vcN3Az/77LOFcr6rOk3bEGloffr0KTx+5pln8tgPa+bTigDGjx+fx5tssklhnZ/90ac3dOvWrexx+DSrdPY5/9inOqWzTPrUCp9y5WfHhOKwbr179y6sS4d5FBGRxktXjEVEREREUMNYRERERARoBqkUM2bMKDz2d6/Pnz8/j88777x1dkx14Ywzzsjj/v37F9b5mb/8aBigbltpeOmoFFdffXUev/zyy2Wfd9xxx+XxqFGjCuv8jJY+zShNU5o2bVoe+1Ev0hQJ/9indKQpV74+DRo0KI992kf6uF+/foV1abqXiIg0XrpiLCIiIiKCGsYiIiIiIoAaxiIiIiIiQDPIMfazz0FxJjg/A9U+++xT6236YZkaKj/w8MMPz+N0FjA/G59IY9OmTfHPyre//e089jM6pgYPHlwyTp100kl5vMMOOxTW+frvh3xL83579eqVx1tvvXXZcgcffHDJY0j36/OUN91008I65RiLiDQdumIsIiIiIkIzuGIsLcc555xTdt2ll166Do+kcR2LSFOn+iQijYX5tIGGZmZzgRk1FpS61DeE0KMuN6jPsUHV6eepz7LB6HNsXvR5Ng/6HJuPsp9lo2oYi4iIiIg0FOUYi4iIiIighrGIiIiICNCEGsZm9DTjLjOmmfG6GY+ZMXANttPFjFMqrD/DjIlmTDLjTLd8qBkvmjHBjIfN6ByX727GeDNGm7G528cTZpQdp8mMv5qxWYw7mvGn+NommfGCGTuv7muL2/qFi9eP29JNllLnzDg3fl/HmzGu+jtrxnQzupcof4gZJe+yMmMfM3Yrs66rGQ/E/bxsxmC3rlx9/V0s/2e37Fgzzki379b3MuORGLc34/ZY3yea8Y9YT/uZMbHM8y80Y78y604wYxP3+C4ztih3LNKylatbdbDdEWYMX5MyZpxqxlQzgq/fZpgZf4jrxpuxvVt3vBlvxX/Hx2Vtzfh7rFenuLLXm7FdheP6lhm/ivGW8TjHmfGGGdev3jtRdh/7VP8NqE0ZMw4y44K62Lc0Hk2iYRwbmA8AI0JgQAhsDfwC2HgNNtcFSjeM4wn3+8BOwFDgIHfyuhE4JwS2jcdydlz+E+DweDw/jMvOAy4OgZIJ3GZsA7QOgbfdtj8GtgiBbYATYNWGRS3lDeMQWAo8Axy5htsSKcmMXYGDgO1DYAiwH/BepeeEwEMhsMoQA/GH2z5QumFM9p0eF/dzHHBVfF7J+mrGBsBusXxrM7Y1o4qsXl1T4RB/DNwQ4zOAOSGwbQgMBv4DWFb2mdnr+1UIPF3i9bWO+97ELb4W+Fml7UnLtCZ1ax35J9mxpDeLfQPYIv77Adl3GzO6AecDO5PV0fPN6Ap8HXgVGBLLY8ZQoFUIjK2w/5+xsv7+AbgyBIaFwFbA1Wv96tbMo8AhZrRvoP1LPWgSDWNgX2BZCFxXvSAExoXAyPhr9bL463OCWdYIjFd3njFjTFx+aHzqpcCA+EvzsmQ/WwGjQuCLEFgOPA8cFtdtCbwQ46fIGsOQnSyrgPbAMjMGAL1D4PkKr+e7wN/icQ4g+8PxyxBYEV/b2yHwaFz/4/jaJiZXxB4049V4VaH6j8ulQFV8bbfHog/G/YnUpV7AvBBYAhAC80Jgllt/mqt7gyC/avrHGN9qxhVmPAfcDZwMnBW/u3sm+9qa7AceITAZ6GfGxpSvryuA9eMP6iqyOno28IcQKjZuDwf+7l7f+9UrQmBK9Wsla2zfEOvek7HRXf2ajojxdDN+ZcY/gKOA4cDt8fVVASOB/Uy9ObKqsnUrfqdGx/PB9fE7Xn2V93eW9ai8WV2HzKiKvRPjzbibrD4Q111rxivxe1zjVc8QGBsC00usOhT4cwiEEBgFdDGjF1kD+KkQ+DgEPiE7bx7IynOm/+5fBNnV4FIs6x1eEgLz3Hs00x3bhFiunxkj49+eMRZ7oeJV3hGW9dROtqw3qPq9OzAu+wfwbbfPncz4lxlj4/9blnhPAjCC7IeMNBNNpWE8mOwXZinfBoaRXTHaD7gsVsrFwGEhsD1Zw/ryWBHOAabFX5pnJ9uaCOxlxobxF+A3gU3dukNi/B23/BLgeuBM4I/Ab8muGFeyu3s925BdDVtlOjszdgBOJGs47wJ833U1nRQCO5CdcE83Y8MQOAdYFF9bdWN4IrBjDccjsrqeBDaNJ+FrzNg7WT8v1r1rgZ+W2cZAYL8QOBy4jpVXgEYm5V4jnrDM2AnoC3yFMvU1BD4H7gPGAu8AnwI7hpD9GC3FjP7AJ67xezPwc8vSp35jxbSHLYD/jb0781n5Izm1OAT2CIHbgFeA78bXtyj+CJ5K9ndLxKtUt/4YAjvGXowqig2yNiGwE9m56Py47IfAF/HK828BP2XjuSEwnOzK7d5mDFnD4+1N8Yr2zLis3PKngJ7AS8B/m3EI8Grywzq1OzDGPb4SeNaMx804y4wucfmHwP7xb8+RZFeWq21H9t5sDWwG7G5GO7JeooOBPeNxVZsM7BUC25E12i8uc2yvxOdKM9FUGsaV7AHcGQJfhsAcsqtGOwIGXGzGeOBpsgpZMfUiBN4AfkdWcf9OdkJeHlefBPzIjFeBTsDS+JxxIbBLCOxLVtlmkc0Ce7cZt8UrW6lewNxavrYHQmBhCCwA7mdlBTzdjNeAUWSN9JL5irHBvdSMTrXYn0itxO/jDmRdoXOBu804wRW5P/7/KtCvzGbuLfWDsIRLga5mjANOI2vwLq9UX0Pgv2Mj9CfEq1FmfM+Me8z4ZYl9FOpkCIwjq8+XAd2A0WZsFVe/E9fX9PruruF1fUgxvUKkprq1rxkvmTEB+CrZhZVqpercXsBtcbvjgfGu/L+bMYasPm1D1mBcE6XupQnllofA8hA4OjY47yVrrF4ee5D+GhvKqbR+3kLWY3QvWRrWKDPaAusBN8T3597kNb0cAjPjj9JxZO/RILL6/Fa8+nubK78BcK9l9xRcSfG99lSPm5mm0jCeRPGXrlfuBrfvAj2AHUJgGDAHaFfTjkLgphDYPgT2Isv7fSsunxwCB8SrtHcC0woHkV2N/iXZSfj8+O824PQSu1nkjmUSMNSs5GdR8rWZsQ/Z1fFdQ2Ao2R+2Sq+tLdkVdJE6E3+MjgiB84FTKV45rb7y+iXlZ9hcWMv9fBYCJ8Z6fBxZvX4nritZX6u5HpY3geNC4N+BwbbqjW++Tlbvd0EI3B8Cp5DV5W8mr21tX1+7uF+RglJ1K17dvAY4It7rcgPF72y5OrfKvS6xh+SnwNfi1eRHqcX5sYyZrOxBhaw3Z1aF5d4pwP8Bu5JdbDoSSv5wLVU/Z4XAzSFwKNkP4sHAWWTn+qFkvanru6eUq7flJnO4CHguXp0/ON2/o3rczDSVhvGzQFszvl+9wIwdYxfTC8CRZrQ2owfZL+SXyX7tfRgCy8zYl6z7FeBzKH/11IyN4v99yLpv70yWtyKruNclTz0eeDTmUrUny3NcEePUG5CNYBEC08i6Yi5wOU9bWJYT/QLwLcvukO9Alj85Mr62T0LgC8vyN3dx215mxnru9WwIzK0ht1JktVh2V7hvXA5j7WZwKlsvLRvlpfoE9z3ghRD4LK4rWV+d6tzF9YDWcVmpevkm7sqvZaPNdI3x+mRXnur69Q0k+2EskqtQt6obZvPM6AhZPnsNXiDeY2LZzarV6RKdyX64fRp7Nb+xFof8EHCcZff77AJ8GgKzgSeAAywbVaYrcEBcRjyermSpIH9m5TkzULoBmp8z43MPrD7PmdET2JDsnoANgNnxqvCxrKzz5UwG+lt2rw9k9wNU24CV9xmcUGEbA6H0SDXSNDWJhnHs4jgM2N/ikGbAr8l+fT5A1j30GlkD+mch8AFwOzDcLMvtI6sAhMBHwD8tu3khvfkO4D4zXgceBn4UG7oAR5nxZtzOLOCW6ifE/MbjWXnH7BVkOY6XEO/QTTxK1v1T7XtkuU1TYxfQDcCsEBgD3ErW0H8JuDFkd+3+HWgT00QuIkunqHY9MN5W3ny3L/BYiWMQWRsdgf+zbOjE8WQNx1+vxfYeBg6z0jffbQVMMmMy2QncD7lWrr5ixreA0fHK0nzIhlsk6859ze8gBBYC08zyk+8A4PlYfizZj9f71uL13QpcF19fVWyMLIoNCBGvZN2K3+EbgAlkN1WPrsW2rgU6xu38jOxcQvz+jyX7YXYz2YgTFZlxuhkzya78jjfjxrjqMeBtspz5G4ijPoXAx2Tnp9Hx34VxWbVfAb+J5/cnyK7wVp//Ui8A29nKIVAPACbGdMIngLPjef8a4HgzRpE1WCv22oTAYrKUlUctu/nO//j9b+ASM/5J5Qb2vmTndGkmNCV0A7DsrvTngN1rmWO5Nvu6H/ivEJhSn/sRaerMOIws9apUV25d7+ss4LMQuKm+9yXSHJhxFfBwKDEkYkOJP3DvCIGvNfSxSN1pEleMm5sQWESWg9y7PvcTu4AfVKNYpGYh8ACUHI6qPswny60Ukdq5mNKpiQ2pD9lcBtKM6IqxiIiIiAi6YiwiIiIiAqhhLCIiIiICqGEsIiIiIgKoYSwiIiIiApSfsalBdO/ePfTr16+hD6NFmT59OvPmzSs3e+Aa0eeYee01WL689Lo2bWDo0Lrf56uvvjovhNCjrrbXGD/L9957L48XLSpOONWtW7c8XrFiRR6bFb/in3ySD3fMxhuvnLV9gw02qLPjXBst4XNsSfR5Ng/6HIsqneOg/s5zdaHSZ9moGsb9+vXjlVdeaejDaFGGDx9e59vU55ixCj83li+H+niLzGxtZmdbRWP8LM84Y+X8HhMmTCisO/bYY/N4wYIFedymTfFP3f33319yewcddFCtjsE3ugFatarbzreW8Dm2JPo8mwd9jkWVznFQf+e5ulDps2xUDWMREYARI0YUHl9zzTV53LZt2zz++OOPC+VOP/30PG7deuVkVe3bF4c/3WWXlbOo33PPPXn80EMPFcpdeumleeyvRtd1Q1hERBoH/XUXEREREUENYxERERERQA1jERERERFAOcYi0kCmTJlSePy73/0uj998883CuiFDhuTxG2+8kcdVVVWFct27d8/jefPm5fHgwYML5fyoFP7GPJ+/DHDmmWfm8eabb57HJ598cqHcRhtthIiINH26YiwiIiIighrGIiIiIiKAUilEpI59+eWXhcd+2LRrr702j0eNGlUo16FDhzzeaaedCus6duyYx4sXL87jyZMnF8r51Aqf3pAe0+jRo/P4P/7jP/K4a9euhXKfffZZHs+ePTuP//M//7NQ7rrrrstjP2EIFMc81jBvIiKNm/5Ki4iIiIighrGIiDSwnj2zWbRK/evZs6GPTkRaEqVSiEid8qkTKT+Fc8+kxeOfl07h7EeROOSQQ/L49ddfL5Tz6Q6XX355Hl944YWFcgcccEDJ/fo0DSjOmNe5c+c8TqeEvuOOO/L4rLPOKqxT+kTN5sxZs3UiInVNf7FFRERERFDDWEREREQEUMNYRERERARQjrGI1DOfH+xzeHv06FG23PLlywvrOnXqlMdz587N43322adQbo5LSL3nnnvyuH///oVygwYNyuOFCxfm8dKlSwvlli1blsd+KLg0P3rmzJl5XGm4OhERadx0xVhEREREBDWMRUREREQApVKISD175513Si5Ph0ZbsmRJHqfpB37mu3fffTeP/cx0AL169cpjnz7xwQcfFMpNnz49j32aRjprnZnlsU+R+Pzzzwvl/Gv59NNPC+u6deuGiIg0DbpiLCIiIiKCGsYiIiIiIoBSKUSknr3//vt57FMO0vQGP9JDmiLxxhtv5PH8+fPz2M90B8WRI3y5sWPHFsp17949j/0IFe+9916hnE+fWLBgQcljTU2ePLnweLfdditbVkREGhdKqD6qAAAgAElEQVRdMRYRERERQQ1jERERERFADWMREREREUA5xiWFEErGrVqt/e+IF154IY/32muvtd5ebfnZvQA6dOiwzvYtLZvPMW7btm0ep99JP9vdhhtuWFg3Y8aMPPYz5LVr165Qzm9/o402yuOtttqqUG699dYruY10CLmBAwfm8dNPP53Hfvg4KOYsT5o0qbBOOcYipfnzKxTvGdhkk03yOP1bccUVV+TxqaeemsfpeW399dcvu29//4BmpxRPV4xFRERERFDDWEREREQEUCpFSX62Kx9Xcvrpp+exn5kLYM8998zjZ555Jo/9zFwAm266aa325buc27Qp/xFedtlleXzvvfcW1j377LMArFixolb7FFlTPj3BD3k2derUQrlFixblcb9+/QrrfGqFT4P46KOPCuV8msUXX3yRx+lMdZtttlnJ7aVdqn4WuxdffDGPBw8eXCh3wAEH5HH6ukRamjRFwp9H33777Tw+88wzC+VOPvnkPB4zZkwen3HGGYVyd999dx4/+uijeXzHHXcUyh100EF5nA7t2L59+zz+wQ9+kMdpGlf6WqT50xVjERERERHUMBYRERERAdQwFhEREREBWlCOcZpLuyZ5xD43CmDHHXfM46OPPjqPt99++0I5n7fo85dOO+20QrkHH3ywVsdRKa/4L3/5Sx7fddddeexzO2HltLXp8FQidc1P7+yHXUq/kz7nPl03YMCAPPZDsr388suFcnPnzs3jrbfeuuz2li1blsc+t9nnHabHdNNNN+XxueeeWyjn85nToaVEWppK51Sf3//QQw+VLXf//ffn8f77719Y54dEXLJkSR6n9+k8//zzeZwO7ehVOqdKy6MrxiIiIiIiqGEsIiIiIgI00VQKP3xK2mVTbl2lWeuWLl1aePzBBx/k8XbbbZfH6dAyP//5z/N4yJAheTx9+vRCOd+16mfg8jNpAXTt2jWPf/GLX+Txt771rUI5P7zUP/7xj8K6a665pmS5oUOHFsr17t17lTIi9cHXB58GkQ6N9t3vfjePL7300sI6/z31ddmnaUBx+LYPP/wwj1977bVCOV9f/exYfihEKA7z5oeQS1MufKqGhncSKa96qFCAadOmFdb16dMnj2+99dY8Tmeu9GmHfra7tD3gh2jbY489Cuv8vh9++OE8PuaYYwrl/Ax50jLoirGIiIiICGoYi4iIiIgATTSVotIdr+XWjRw5suxzzj///MLj6jQDKN6Jno5sMXPmzDxO7473/F3vvpv13/7t3wrlNthggzy+9tpr8/jmm28ulOvUqVMez5s3r7DOd0XtuuuuefzSSy8VylV3QaubSOqb787s3r17Hs+fP79QzteTLbbYorDOpzhUj6gCq6ZB+TrkUzhmzZpVKLf77ruXfM6MGTMK5Xxd86PSpDPp+Tve0xEw/IgVaQqGyJoql7Ljz4G+THr+SlOZyvF1z4/mUmkbPj0J4JJLLsljX4/SkSJ69uyZx3/605/y2I8ABcV69NWvfjWPu3XrVijnUw39iDVQTM+477778jhNpdCIFS2PrhiLiIiIiKCGsYiIiIgIoIaxiIiIiAjQRHOMK5k6dWoe+xzGO++8s1DO5ymed955hXV+eDU/dFs6o5XPvfK5Umners/t8jPN+Rl7AL7zne/k8SGHHJLHU6ZMKZTzw8ykM/3st99+eexzJ+++++5CueocsNrO+idSW2ner3/sh1pL82394zRP19flvn37llwOxSHa/Db8sItQrIe+nN82FIeD69ixYx6nuYw+19/nSULxb4if9UtkbdTmb3elMrXJUYZijm1t8239UGtQzPffdttt8zg9p/qZYXv16pXH/n4egFNOOSWP58yZk8eDBg0qlPPnw86dOxfWnXTSSXns/27cdttthXJpzrE0f7piLCIiIiKCGsYiIiIiIkAjS6VYsmQJb731FgB33XVXYd1GG22Ux74bNB02yQ8n47s7991330I5P/xLOtSa7+713S/p0DQ+ZeLjjz/OY991mh6jH5IqTaXw63y37ZZbblko52fw8bPlpcfhZwfyXVQAkyZNAorvpUhd8OlMUJztztfPTz/9tFDOd52mXbY+bamqqqrsNvzMd77Ov/nmm4Vy6TCH1dL0Dl/n/TH4YdzSx/4YYNW/USJ1YXVnWKzt8Gwp/72/7rrrCuvGjh2bx34oxhNOOKFQzg+pdscdd+Tx66+/Xijn/z7stttuZY/pf//3f/P4rLPOKnk8UDx/+yEaoTi0qY9feeWVsvuVlkFXjEVEREREUMNYRERERARoZKkUH374YT7j22uvvVZY57tjvbTL1Y/E4Ge6SbtcfWpGhw4dCuveeeedPJ44cWIep3fG+jvifRpEmp5Qbna59DX5LuLhw4fn8ejRowvl/vjHP+axT/sA2GabbfLY312cltt8881LHoPI2kpHiiiXSjFkyJBCOT+aQ1rXfGqRH0Ui3Zf/zvvtVadolToO3yXtR6GAYjdyjx498jitT+XSoGDVvz0idWF1RxRKz0M+tcKn3aV1z6cnpKPFHH/88Xn8/PPP57GfVQ6Ks93583J6rvTn5Ur8a/cjSqSv0c86mY6UccABB+Sxr7M+rQLg3XffrdUxSfOhK8YiIiIiIqhhLCIiIiICqGEsIiIiIgI0shzjrl27csQRRwCrziz13nvv5fEnn3ySx+lQSLNmzcpjn2/sZ95J1/mcYijOxuNzmNO8Qr8NP8yTn9kHisNG+aGc7r///kK5J598ktrwr9nnUKV87nT1THfVqnPFajuTkUht+Zw/KD/UWjpDnM/7TXMPN9544zz2wxym319f7tlnn83jdFgoPwOdH/Iw3a8/Xp+TmdYnn/PoXwcU849F6lqlYdv8rKuVhmsbN25cHqd1YL311svjs88+u7DOzyjpzzdvvPFGoZzPz/c5y+mx+1nnTj755LLH6/n6NmPGjMK6gQMH5nF6T8MDDzyQx8cee2weDxs2rFBuwoQJtToOaT50xVhEREREBDWMRURERESARpZKUVVVlQ831rdv38I6PyuWlw7P4ruB/BAxaffu448/nsfpLD2+y8XPGJd2n66tgw8+uPD473//ex4PHTo0j9MUDt8llg4N5bumfErI7NmzC+WqUzDSbl+RtZXOKudnhfPft/79+xfK+e7XdFgonz7hUzB8ihUU0xZ8OpZPiYBit69f59M+oPxwhmm98eXS7mHNLin1ofp7Vm44UCimGqVDEU6bNi2PfQpCmgro05B+/vOfF9bdc889Jbe/6aabFsr58+hzzz2Xx34GWiiep30qlJ85L+XPlXPmzCmsO/LII/M4Pd9+4xvfyOOjjz46j9P0TNXflkdXjEVEREREUMNYRERERARoZKkUrVu3zkd6SLt9nnnmmTz23Z3+jlmALl265PHgwYPzOB294dRTT81jf4c6wNKlS/PYdwunXSye78JN70L3Xau+a6t3796Fcr47duTIkXnsu4qg2I2b3mnsu9X8a067pn3XlkhdSr//7dq1K7mue/fuhXK+G9WP+ALFlCE/2106KoVPH/IpFx9//HGhnO8e/eCDD/LY//2A8nU+Tbnwj9Nj8n9PROpK9UgotR1ZKE3x+dvf/pbHU6ZMyeM0dcCPWOFngoXiKEt+RruHHnqoUO7MM8/M4xEjRuTxBRdcUCjn6+JFF12Ux2kqhZ9NstJseX57KX9Mnh81A1YdzUKaP10xFhERERFBDWMREREREUANYxERERERoJHlGHvpcC/p42pTp04tPPY5jG+99VYe+7xEKA6B5vOroDg0VOfOnfM4zWf2s135HMh01j6fE+zzvNL8Jz87kN+Xn70o3YafBTDlh8lKj2nAgAHAqsNYidQ1//33ubhpnu6kSZPyOB2i0D/2ddnXQSjOYuf3m9Zd/733uf1pzr7PD/b1Nb0vwUtzPivNTimyJhYuXMiLL74IwHXXXVdY5+8nqTRzq1/nzxXp0KY+7z4d9nPUqFF57IdA9efQlM/997nCKZ+/vPPOOxfW+fP8/vvvn8e+/gPcddddeXzGGWcU1m2xxRZ5vP322+dxOnveVVddVfYYpXnSFWMREREREdQwFhEREREBGnEqRW1tvvnmtSqXzuYjIvUjTW/waQw+5cjPdAew22675fGgQYMK63wag0938ENEQbF72A9dmM4O5tMsfHduOqSVn+3SpzSlM9/5Y/LD08GqKSMia6uqqiofRux73/teYZ2vEz7VLh1G0T/2Q7Sl5fx3+5e//GVhna8TPu0wHQ7UD4HmUzN+8pOfFMr5dMJKKRe//e1v83jmzJl5nM6Q6+tzus6nU/mZMNO/Paq/LY+uGIuIiIiIoIaxiIiIiAjQDFIpRKRxSdMRfHqDT7NIR0r54Q9/mMdvv/12Yd2YMWPy2He3TpgwoVDu9ddfL7n9NJXCd9P6VI9Zs2YVyh133HF5vMsuu+Rx2rWbHoeXjgYgsrZatWqVd//vueeeDXw0654fAUOkrukvtoiIiIgIahiLiIiIiABqGIuIiIiIAMoxFpE6lg7X5vlc3z322KNsuXRmuXIzze29995lt+GHkkpn4lrbGR99njNUfs3pzJUiItJ46YqxiIiIiAhqGIuIiIiIAEqlEJE61rZt28LjcmkGfpi0VDq8mp99yw8HVymFwQ+TtqapE+X21alTp7LHl6ZOLF26dI32LSIi656uGIuIiIiIoIaxiIiIiAighrGIiIiICKAcYxGpY/PmzSs8XrZsWR77XFw/VfTq8Lm+6fTTlXKO14TPF/bHnuYY++Hg0nWVcqlFRKRx0RVjERERERHUMBYRERERAZRKISJ1LB1qzacSLF++PI979eq11vuqbepEpZSLSsO/lUulSId/8+ki/jXCqqkVzck555xTdt2ll166Do9ERKRu6IqxiIiIiAhqGIuIiIiIAEqlEJE65mecA/j888/zeP78+Xmcplx46exxPo1hTVRKuViTkSzSETX8a0lHoejQocNqb19ERBqGrhiLiIiIiKCGsYiIiIgIoIaxiIiIiAigHGMRqWMnnnhi4fGrr76axz7HeIcddii7jTWdFa+upfnS1dKh5vzj9Ni7dOlS9wcmIiL1QleMRURERETQFWMREWkmNOGIiKwtS2eEakhmNheY0dDH0cL0DSH0qMsN6nNsUHX6eeqzbDD6HJsXfZ7Ngz7H5qPsZ9moGsYiIiIiIg1FOcYiIiIiIqhhLCIiIiICqGEsIiIiIgKsg4axGeeaMcmM8WaMM2PnOt7+PmY8UofbO8OMifGYz3TLh5rxohkTzHjYjM5x+e7xtY02Y/O4rIsZT5hhFfbzVzM2i/FJcbvj474PravXE7ffz4yJa/H89c14wUyjmMhKZvQ04y4zppnxuhmPmTFwDbbTxYxTKqw/K9bHiWbcaUa7uHxk/JsyzoxZZjwYlx8ey480Y8O4bIAZd1XYh5nxrKvX9fLazOhhxt9XdzvSstTXedOMEWYMX5MyZpxqxlQzghnd3XIz4w9x3Xgztnfrjjfjrfjv+LisrRl/j/XZ143rzdiuwnF9y4xfxXjLeJzjzHjDjOtX750ou48a2xO+jBkHmXFBXexbGo96bRibsStwELB9CAwB9gPeq899ro60oWfGYOD7wE7AUOAgM7aIq28EzgmBbYEHgLPj8p8AhwO/AH4Yl50HXBwCJe9sNGMboHUIvG3GV4BzgT3ie7QLML6OXuJaM6N1CCwFngGObOjjkcYh/uh7ABgRAgNCYGuyOrDxGmyuC5RuGJvRGzgdGB4Cg4HWwP8DCIE9Q2BYCAwDXgTuj0/7CVk9+jNwdFz2G7J6Wc43gddC4LP6fG0hMBeYbcbua7AtaQEa8Xnzn2THko6i8A1gi/jvB8C1AGZ0A84HdiY7p55vRlfg68CrwJBYHjOGAq1CYGyF/f8MuCbGfwCujPV/K+DqtX51a+ZR4BAz2jfQ/qUe1PcV417AvBBYAhAC80JgFoAZ0824wIwx8WrpoLi8gxk3xyuwY6uvnsarniNj+TFm7JbuzIwd43M2q7CdE8y414yHgSeTTWwFjAqBL0JgOfA8cFhctyXwQoyfImsMAywDqoD2wDIzBgC9Q+D5Cu/Ld4G/xXgj4HNgQXyPFoTAO/FYR5jxOzNeNuNNM/aMy1ubcVl8bePN+M+4vKMZz7j3dJUrz/G9GRvfq3Lb2ceM58y4A5gQn/pgPG4RgH2BZSFwXfWCEBgXAiPjFaTL4hWhCWbZD6oK389LgQHx6s9lJfbVBqiKP2TbQ/Y3pJoZnYCvkn1HAVYAbVlZJ/cEZofAWxVej6+T9f3aVJekkkrnzV/Fv9cT4xVWi8vLnSuqLOv5GG/G3WTnKuK6a814xbIr0zVe9QyBsSEwvcSqQ4E/h0AIgVFAFzN6kTWAnwqBj0PgE7Lz5oGsPGf6C1MXQXY1uBTLemuWhMA89x7NdMc2IZYr2U6I57QRlvXUTjbjdvfeHRiX/QP4ttvnTmb8K54v/2XGliXekwCMIPshI81FiN/m+vgHoSOEcRDehHANhL3duukQTovxKRBujPHFEI6JcZf43A4Q2kNoF5dvAeGVGO8D4REIu0F4FUKfGrZzAoSZELqVON6tYrkN4/5ehHB1XPcvCIfG+McQPo/xMAijIDwH4SsQ7oKwRQ3vy/MQto1xawhPQHgXwi0QDnblRkC4PMbfhPB0jH8A4ZcxbgvhFQj9IbSB0Dku7w5hKgSD0A/CRAhbQhgLYVgN29kHwkII/d2xtIYwtz6/L/rXdP5BOB3ClWXWHQ7hqfid2Th+t3vV9P2ssK8zICyAMBfC7SXWHwfhr+7x/vFvwcMQNoj1q2sNr2cGhE7r4rVB6A1hQkN/hvrXOP9R+bzZzcV/qT5fVDhX/BjCzTEeAmE5hOF+W/G7PALCELet4RWObzqE7u7xIxD2cI+fgTAcwk+rzy9x+XlxWRsId8Rz0dEQDoFwfg3vyYnVr889/hTC4xDOgtAlLq/UTviU7BzdiuzcvgeEdhDei2UNwj0QHonP6QyhTYz3g3Cf29Yj7li+S2wn6F/z+FevV4xDYAGwA1l3yVzgbjNOcEWquz5fBfrF+ADgHDPGkf0Sawf0AdYDbjBjAnAvsLXbzlbA9cDBIfBuDduB+Cu2xPG+AfyO7Jft34HXgOVx9UnAj8x4FegELI3PGRcCu4TAvsBmZFezzIy7zbjNrGT3a6/4fhACX5L9ij4CeBO40oxf1+I9Oi6+tpeADcm6sQy42IzxwNNAb1Z2//YguyJ2TAiMq2E7AC+HeOXaHefSeHVOpJI9gDtD4MsQmEPW87Ijlb+fJVnW9Xoo0B/YBOhgxjFJsaOAO6sfhMBTIbBDCBwMfAt4DNgyXi26wUp3e3YLgc/X0Wv7ML4WkVXUcN7c14yX4nnwq8A27qmlzhV7AbfF7Y6nmKb372aMAcbG7fhz6uoodS9NKLc8BJaHwNEhsB3ZufxM4HIzroh19JASz8vPmfG13EJ23r8X2AcYZUZbKrcTXg6BmSGwAhhH9h4NAt4JgbdCIBDfq2gD4F7L7s+5kuJ77ak+NzP1fjNVbFCNAEbEL+vxwK1x9ZL4/5fuWAw4PASm+O3ExuIcstzfVsBit3o2WcN3O1Z2s5bbzs7AwgrHexNwUyx7MbG7JgQmkzUkq7t1/i3ZrgG/JMvD/SNZblU/svzIc5PdLIrHW73PALwMvGzGU8AtkDeOy71Hp4XAE8kxnEDWAN4hBJaZMd3t51OyPLXdgUk1bGcfSr9HbSm+79JyTSL7MVdKuZtOv0v572c5+5GduOYCmHE/sBvxBGbZzXU7sTLlaeVBZA3g48m6dJ8ka2AfHY/jhqT4cjNaxZNmfb+2dmR/A0RKKnXetOzm0WvI8u3fi+dE/x0rda4AVr3XxYz+wE+BHUPgEzNupea6WM5MYFP3+Ctk5+GZZI1Wv3xE8txTgP8DdiW72HQk2f0CDyXlFpE1VHMhSy+5Gbg5Nl4HAwdTvp2wxMX+PSo3y9lFwHMhcJgZ/UocezXV52amvm++29JW3rwGMIyapz98AjjN5f9U36W6AVme4ArgWLKbcKrNJ2uoXhwbdZW2U9MxbxT/70OWb3RnsrwVWQP4uuSpxwOPhiyXqj1ZnuOKGKfegHwEi03M3cVL7d+jH5qxXtzGQDM6kL1HH8YT875AX/ecpWRXz44zy29IKredVcQGyNwQWFbDsUnL8CzQ1ozvVy+wLG99b7Jc/CMty2HvQXbV6mXKfz8/h7I9Ee8Cu5jRPtblr5HVn2rfAR4JoeQPtp8BV8XvbBXZCbBcnZxC1uOzLl7bQFjzUWKkeatw3qxuuM4zoyPlf7x5LxDz2S27uXxIXN6Z7OLHp7FX8xtrccgPkZ1XzIxdgE9DYDbZ+eUAM7rGnp8D4jLi8XQly839MyvPmYHSDfT8nBmfe6A7b/Uk6+18n8rthFImA/0tuzcIst6nahvEbQKFnu6U6nMzU99XjDsCV5vRhSwlYSrxLtQKLgL+BxgfT4TTySrPNcB9ZnwHeI7kimYIzDHjYOBxM06qsJ2a3BcbgcuAH8WGLsBRZvwoxveTXdUFClemDoiLrgDuI2uM+opW7VGyX9JPk3X9/N6MTch+3c4FTq7hGG8kuxo9Jr62uWSN3tuBh814hayraLJ/UggsNOMg4CkzFlbYTin7knVJixACwYzDgP8x4xyy7+50sm7RF8iuAL1GdqL7WQh8YFb6+xkCH5nxz3jV5/EQ8hFfCIGXzPgrMIbsb8hYKAzN9P/IbnAriPVpeAh5z8vlwCiyH9GlvuPVdXLqOnht+8b9iZRS8rwZAvPNuIHshujpwOhabOta4JaY4jOO7EccIfCaGWPJekfeJhtxoiIzTif7sdmT7Lz6WAh8j+y88M14nF8AJ8Z9fGzGRe44L0xSGH8F/CbWtyeAH8XXll50gqzeXW6GxR7WA4CrzPIfxGfHelixnZAKgcVm/AB41Ix5wD/IrjwD/Dfwf2b8mOzHcjn7Av9VaT/StFiWPC7rkhlVZJV299hl1ujFLuz/SlNTRJoDy+6i/3MI7L8O9vUCcKj70S0iNTDjKuDhEHi6oY+lWrzafkcIfK2hj0Xqjma+awAhsIgsB7l3Qx9LbZixPvCgGsXSXMWu3xssTvBRX2L6xRVqFIustospnQbVkPqQjZsuzYiuGIuIiIiIoCvGIiIiIiKAGsYiIiIiIoAaxiIiIiIiwDqY4GN1dO/ePfTr16+hD6NFmT59OvPmzSs3acEa0efYcF599dV5IYQedbW9xvhZLlmycpz+tm3brvX2Fi1aOTZ/VVXVWm+vLjSnz/G112D58tLr2rSBoUPX7fE0hOb0edbGvHnzCo+Xl/kCtGpVvDa3/vrr53GXLl3q/sDWUkv7HJuzSp9lo2oY9+vXj1deeaWhD6NFGT58eJ1vU59jwzGzmiaHWS2N5bP88suVoxpOnz49jwcMGFCidOXnA7RuvXLc/wkTJuTx4MGDC+XM6vQ3Y601p8+x0lu4fDk0gq9XvWtOn2dt3HBDcWLJ+fPn57FvJHfs2LFQ7itf+UoeH3bYKpNZNriW9jk2Z5U+S6VSiIiIiIjQyK4Yi4iUsmzZypnI33vvvTyudMXYD0XprxCnZs2alcfbbrvtmh6iSKOWDs1arjckLeev8K633nqFdb4npk2blc2JNMWp3L7S5T6t6cADD8zjxx9/vOTz0+PzxyCypnTFWEREREQENYxFRERERAA1jEVEREREAOUYi0gT0K5duzy+8cYb8zgd0mnYsGF5XGlEib/97W95fNVVV+Xx17/+9bU6TpHGqlKO8YoVK/I4HUItzSv2Tj311Dz2ecW9evUqlPPDsC1evDiPly5dWijXqVOnPB43blzZ/Xo+r7jS6DMitaUrxiIiIiIiqGEsIiIiIgIolUJEmgA/XNvIkSPzePTo0YVyQ4YMyeMTTzwxjy+88MJCOd+dm07qIdIcpSkSvk5VSpd47LHH8vj3v/99Yd20adPyuFu3bnmcpjH17t07j/3wiGnqg3+eT/1IUzPOPvvsPD7zzDPzWKkTUhd0xVhEREREBDWMRUREREQApVKISBPgu3p79uyZx37WK4DJkyfn8Y9+9KM89qNaAHTt2jWPe/ToUWfHKdJY+ZEnoHz6xFFHHVV4fM899+Rxx44dC+vat2+fxz4NYsGCBYVys2fPLrkvP9MdQFVVVR77NIslS5YUyp177rl5fNlll+Xx1VdfXSh3xBFH5HH6t0Kz5Ek5umIsIiIiIgU9e4JZ6X/u+kSzo4axiIiIiBTMmbNm65o6NYxFRERERFCOsYg0MT4P8f333y+s8zNn+Vnx/KxcUByurUOHDnV9iCJNynPPPZfHDz74YGFd375989gP8Qar5u1WS2e0mz59eh5vvfXWeZzmDs+fPz+P/X0B6T0Cvs76YzrppJMK5fxMmJtvvnlhnR8OrtIsmdLy6IqxiIiIiAhqGIuIiIiIAEqlEJEmxnfF+pm3oPwQVOlyn0rhZ+VKqbtVmot05jvvT3/6Ux6ns8f5dIl0pjpfP/xwcGl984/9zHdpilO5+uaXp8fkt52+xrPOOiuPH3744cI61WcpR1eMRepJSx3qRkREpKlSw1iknrTUoW5ERESaKqVSiEijk3ad+m5Pf0d6OntVua7YjTfeuFDuo48+KrsvkZbAf+//8Y9/5LGfzQ6Koz6k6Qd+G75cmiLh0zN8ysXChQsL5fyIM37bleqoT6vo3LlzYd0LL7yQxxMmTCis23bbbctuU1o2XTEWEREREUENYxERERERQA1jERERERFAOcYi0ghVGkpp6tSpeVxpCCo/q9bnn39eWLfhhhvm8YwZM9boOESasrvvvjuPP/744zxO83R9TnBaHzbYYIM8/uKLL/I4nSHPD/Pm7xHw24ZinfWz3VXKba603D++/PLLC+tuvfXWktsQ0RVjERERERHUMBYRERERAVmGex4AABY/SURBVJRKUaNrrrkmjydOnFh2XSWaPUuk7jz33HN53KdPn8I6PwtW2k3r+Xo4efLkOjw6kabhX//6Vx774dTSNAhv/fXXLzxetGhRyeelM9/5IdW6dOlSdvv+XOnTL9KUqXLnVL8fKL6ukSNHlt2viKcrxiIiIiIiqGEsIiIiIgKoYSwiIiIiAjTiHGOfuwTFqSIrlUtzoMrxuUepRx55JI9nzZqVxxtttFGh3HHHHZfHv/3tb/N40003LZQrl1fsc6hW5/hEWpq33norj3v06JHH6dSznh9KKq2D/vHs2bPr4hBFmpQxY8bksc/hTYc88+fUtB4tXrw4j/3wammub7n6lm6v3Pl76dKlZcv5faXH7v8+pFNdi5SjK8YiIiIiIqhhLCIiIiICNOJUCp+mAHDqqafm8d57753H5VIs1oYfhm2nnXbK47Sb5ytf+Uoe+1mE0pSLww47LI87deqUx2m6hE+tKDezT000HJw0R77b13erpt/3ckNG+S5fKHYdz5w5s86OU6SpmDZtWh77c1F67vHDHqbDprVps7IJUSmlwZfz20iHhktTMMrtt1y5ND3R73fBggUlnyOS0hVjERERERHUMBYRERERARpZKsWKFStYuHAhsGr35kMPPZTHX3zxRR4PHjy4UK5bt2557O9CTWfBevfdd/P4lltuKazr2bNnHnfv3j2PH3744UK5Qw89NI/nz5+fx4899lihnJ9Za7PNNsvj/fffv1Cub9++rK6066hct5dGuZCm7KWXXspj/71Ov/++C7fSnfY+BaNXr155PHXq1EK5zTfffA2PWKRxmzNnTh7781xt0xugWMd8nUpTnPw2/DkqLee358ulM+n5Y6xt+uD06dMLjz/77LM87ty5c622IS2DrhiLiIiIiKCGsYiIiIgIoIaxiIiIiAjQyHKMFy1axMSJE0uuq849Brj99tvzeMiQIYVyfkg1H6e5gxMmTMjjdFadPffcM4/9MFFf//rXC+V8DrPf14EHHlgo9+GHH+bxm2++mccvvvhiodxWW22Vx9tss00eDx8+vFDOz/yV5g4rl1iao0mTJuWxz0NMh1D0QzL53MNKM3H5fMWPPvqoUE45xtJc+bx7f95Iz4e+rqQ5/ZXyij2fL+zzmf39Quljf0zpPUKeP6ZK5VJTpkzJ4x133LHWz5PmT1eMRURERERQw1hEREREBGhkqRRffvllPuzZxx9/XFjnZ7D59NNP8/iBBx4olOvatWse+y5SP+McwK677prHAwcOLKzzXbV+OLh58+YVyvluHz9MXHrsPuWiT58+JWMoDh8zcuTIPB49enTZ7XXp0qWwzg/55mfgGzRoUKFc27ZtEWkq/FBLPn0iTZHwj/3fjLR7uNxz3nrrrcK6nXfeebWPVaQxev/998uu82kQazrraiV+mz7dIa2//pydznZXjn9OmlpV6bW88847eaxUCvF0xVhEREREBDWMRURERESARpZK0apVKzp06AAUR28AOPHEE/O4X79+eZymLSxevDiPfZpBu3btypYbP3582WPq2LFjHvsUBih2z37wwQd5nHbn+Fl1/HN86gQU79b1qRkpf+x+xAuAWbNmlTze3/zmN4VyxxxzDFCcsU+ksfIzVW655ZZ5nM7S5fnuYZ9WAeVniPSj1Yg0J34UhkrSkR1qm9JQiR9hwo/8ko6i5M/T/jgqHZNPx0jPvZVGqZg9e3ZNhy0tlK4Yi4iIiIighrGIiIiICKCGsYiIiIgI0MhyjOfPn89DDz0EQK9evQrrfO6sz83dbLPNCuX8EGg+98g/H2DJkiV5nM7mkx5TNT9MHMB6662Xx35otEo5xl6as7zxxhuXPKZ0qCmfh5XmTvv3xr/mdFaiK664AoA5c+aUPDaRhpTWSZ9X7/MLKw3D5vML0++/r/8+z9HfKyDSnLz99tu1Kpfm4/shz9J65OtipXKeHyo0ree+ztZ2vz5Oy1XKMZ47d27ZddKy6YqxiIiIiAhqGIuIiIiIAI0slWLJkiVMnToVgAEDBhTW+RnoJk6cmMczZ84slCs3XFmlLpV0ne+e9XHaTeO7hHy3TDqrXFVVVR779IuUn1nPH9Pnn39eKOfTO9J1fng53/2czuhVvY1KXdEiDWXGjBll1/l6vXDhwsI6X7/Kdcumj306kh8WTqQ5SYf2LCc9z/l0h3R4tdoqN/NdWi/9vn2cplz4c6xPpUiHb6x0vk2HehWppivGIiIiIiKoYSwiIiIiAjSyVIpWrVrl3aSjRo0qrPNd/r7rM00F+OKLL/LYjwbhZ5UDWLBgQR5XGpXCdx2ld+v6x747Jx2VwvNdOz7tAYpdXf51pDPk+RSJtOvIH5MflcM/B+CCCy4A4Pzzzy97rCINZfLkyWXXVeo69XXPl0vruO/C9XXm/fffX/2DFWkCpk2bVnadrytpusSiRYvyuFJqQiU+fWKTTTbJYz8LHhTPU5VmrvTn/a5du5bdnj/edBsalULK0RVjERERERHUMBYRERERAdQwFhEREREBGlmOcZ8+fbj66qvz2OvWrVse+2HN0hxjn2Po83TToVk6deqUxz4XF4r5Vj4vKR3Wzede+XyoNMfYH2O5bVda5187QJcuXfI4nfnOl91yyy3zeP/996eUP/zhDyWXizSk2ub6pnXXqzQslM9N9nU3Hf5QpLnw500onmN8fUjPc75cWo88vy4t589ts2fPLruvcs9Jz5V+Ftp99903jx999NFCOf/3Ic2PTvORRarpirGIiIiICGoYi4iIiIgAjSyVonXr1vnQKxdffHEDH42INJQ0paG23b6+69SvS2fz8nyXbaXUDJGmLK1TPrXApx327du3UM6nHb700kuFdb17987jJUuW5HGl+lZpnefrr6+jUBxu1fNDt0ExXSJNx6g0TKu0bLpiLCIiIiKCGsYiIiIiIkAjS6UQEYFVR6Xw3b6+izXtDi3XTZt2xfrHfnu+OxiKaRtrOuuXSGOQplJUVVXlsR+1adiwYYVyPgUhnZHWjz5RKUXCl6uUruS3US5Ot+fTJwYOHFgo9/TTT+dxOvttpRExpGXTFWMREREREdQwFhEREREBlEohsopzzjmn7LpLL710HR6JiIiIrEtqGItIo/PZZ58VHrdt2zaPK82+1bp165Ll0hxFn2Oc5h97Pvdy4403rnDEIo1bmo9fLmfezyQHMGnSpLLbrFR3PF///PBvfpg4WLPhEjfccMM8TvOIfY5xeqyV/o5Iy6ZUChERERER1DAWEREREQGUSiEijVA6s1Vth0rz3aM+9ikWlbbnh2cDmD9/fh4rlUKaMp+OBOVnfjv00EMLj8eNG1d2m+VmoUzTFvw6Xy+XLl1aKOef58ulwyh666+/fh7vtddehXWXXHJJHqfpVJ07dy67TWnZdMVYRERERAQ1jEVEREREADWMRUREREQA5RiLSCO0ePHiwuMOHTrksc+NTPMkfS6jH/opza/0Occ+z7F///4Vj0OkqfK5uKmOHTvmcTrk2cKFC/M4zdP19a22Uyz7qanTXGRfnytNCe35XOG0nvu/AenxlcuxFtEVYxERERERdMVYREREpNnQ7K1rRw1jEWl0/vnPfxYe+9myvKqqqrKPfddxOjyb75r1w0KlqRNTpkzJ46FDh9Z02CKNlk9HguKQiJVShnzdSVMVys0gmQ6P6OubT2lIUyT8Y7+9Nm2KTZV27drlsZ8lM50x00uP3c+YJ+IplUJEREREBDWMRUREREQApVKISCN08sknFx77Gaz8KBL+DneA2bNn53G3bt3yOJ3RzqdZ+DSNL774olCua9euq3PYIo3WY489Vng8b968PF60aFHZ502dOrVW2680WoxPV/JpEWkqhU/B8CNK+Oenxo8fn8fnnXde2f2K1JauGIuIiIiIoIaxiIiIiAighrGIiIiICKAcYxFphC688MLC42233TaPX3/99TxOcyMHDhyYx8OGDcvjNHe4ffv2eeyHZDvqqKPW8IhFmpZ0hrtyfD6+HyYNikO5+TjN6fe5vn4blXKRvbScvy9g0KBBZY9dGl5THFNZV4xFRERERFDDWEREREQEAGtMw5mY2VxgRkMfRwvTN4TQoy43qM+xQdXp56nPssHoc2xe9Hk2D/ocm4+yn2WjahiLiIiIiDQUpVKIiIiIiKCGsYiIiIgIsA4axmaca8YkM8abMc6Mnet4+/uY8UgdbWvLeIzV/z4z48y4bpgZo+LyV8zYKS4/PL6+kWZsGJcNMOOuCvsxM541o3N83KjfIzN6mPH3ujwmafzM+DJ+HyeZ8ZoZPzZbNz+mzRhkxotmLDHjp8m6A82YYsZUM85xy/ub8ZIZb5lxtxnrx+WnmTHRjMfcsj3MuKLC/qvMeN6M1mb0M2ORGWPNeMOMl804vr5ee9z/7834an3uQ5onM3qacZcZ08x4PX7vB9b8zFW208WMUyqsPyv+bZhoxp1mtIvLbzXjHXceHRaX18W5sl5em85x4tXrSc6MXYGDgO1DYAiwH/Befe5zdZgVx3EOgSkhMCwEhgE7AF8AD8TV/w1cENf9Kj4G+AmwC/Bn4Oi47DdAcdL2om8Cr4XAZ03hPQqBucBsM3Zv6OORdWpRrA/bAPuTfW/PTwul9aiOfAycDvw+2Vdr4H+BbwBbA0eZsXVc/TvgyhDYAvgE+I+4/HvAEGAs8HUzjKx+XlRh/ycB94dA9QCq00JguxDYCvh/wFlmnJg+qQ7fi6uB8gOAipQQv9sPACNCYEAIbA38Ath4DTbXBUo3jM3oTVY/h4fAYKA1Wb2odnb1uTQExsVla3uurLfXpnOcePV99acXMC8ElgCEwLwQmAVgxnQzLjBjjBkTzBgUl3cw42YzRscrNIfG5f3iL80x8d9u6c7M2DE+Z7MK2znBjHvNeBh4ssKxf43sZFh9x2iA7FcrsAFkrwNYAbQF2gPLzNgTmB0Cb1XY9neBvzWx9+jBeNzSAoXAh8APgFPjVZxVviNmnB2/S+PNuCAu62DGo5ZdcZ5oxpFx+aXxis94s2Ljt3p/ITAaWJas2gmYGgJvh8BS4C7g0HjS/Crw11ju/4BvueetR6yjwLHAYyHwSYWX7OtoemxvAz8maxhgxq/NuN6MJ4E/W3aV+TL3XvxnLNfLjBfiVbSJZuwZy94aH08w46y4jxnAhmb0rHCMIql9gWUhcF31ghAYFwIjY729zH3XqutiRzOeceeZQ+NTLwUGxO/rZSX21Qaoij8G27PynFjO2p4r6/u16RwnmRBCvf2D0BHCOAhvQrgGwt5u3XQIp8X4FAg3xvhiCMfEuEt8bgcI7SG0i8u3gPBKjPeB8AiE3SC8CqFPDds5AcJMCN1qOPabIZzqHm8F4V0I70F4H0LfuHz/uN+HIWwA4QkIXWvY9gwInZrSewShN4QJ9fl90b/G9Q/CghLLPoGwcfodgXAAhOshGIRW8fu2F4TDIdzgnr8BhG4QpkCIo+KELhWO4dcQfuoeH1FdD+LjYyH8EUJ3CFPd8k0hTHRlxkK4DUInCM9AWK/CPteH8IF73K96W25ZFwiL3DG+CqEqPv4BhF/GuC2EVyD0h/ATCOfG5a3jsewA4Sm/XRffAOHwhv4e6F/T+QfhdAhXlll3OISn4ndv43g+6wWhDYTOsUx3CFNjPV7le59s7wwICyDMhXC7W35rrN/jIVwJoW1cvrbnynp9bTrH6V/1v3q9YhwCC8hSEn4AzAXuNuMEV+T++P+rQL8YHwCcY8Y4YATQDuhDdsXnBjMmAPdC3n0KsBVwPXBwCLxbw3YAngqBj8sdt2V5iIfE/VT7IXBWCGwKnAXcFF/jUyGwQwgcTHaF6jFgSzP+asYNZrRnVd1C4PMm9h59CGxS8g2TlsRc7L8jB8R/Y4ExwCBgC2ACsJ8ZvzNjzxD4FPgMWAzcaMa3yVKW1mT/1UKF5YTAX0KWBnEM2ZXePwDfiHX0Sls1b7o7MH81j+OhEKien/oA4LhYr14CNiR7L0YDJ5rxa2Db+DfgbWAzM64240Cy96aa6pzUpT2AO0PgyxCYAzwP7Ej2Xb7YjPHA00BvakhPMKMrcCjQn+w72sGMY+Lq/yKr/zsC3YCfw9qfK9fBa1N9E2Ad3HwXv6gjQuB84FTgcLd6Sfz/S8hz8ww4PKzMT+oTAm+QNUbnAEOB4cD6bjuzyU6027ll5bYDsLCGw/4GMCZWsGrHs7KRei9Zl+7KnWWV+njgGuASshzFVyndNbPcn4ybyHvUDvITv7RAZmxG9j38MC7y3xEDLnHfpc1D4KYQeJPsh98E4BIzfhUCy8nqz31kJ8jVuellJrCpe/wVsi7ceUAXW5njW73cH/8mwI4h8Dfgl8CRZPXra8k+FpF93yvZDvK6Aqu+F6e596J/CDwZAi8AewHvA38x47iQpXMMJfth+iPgRrcd1TlZXZPI6lsppX48QnaO6gHsELJ7aOZQ8/d/P+CdEJgbAsvIzo27AYTA7HjhbQlwC3V3rqzv16b6JkD933y3pRlbuEXDqHmWlyeA02LOIGZ5Q24DsnykFWQ5gq3dc+YD/0b2y3CfGrZTG0cBdybLZgF7x/irsEpe1M+Aq+IfiSqyq1UroOSv4CnAZvG4msp7NBCYWMNxSTNlRg/gOuCPIVBqVqAngJPM6BjL9zZjo9gY/SIEbiO7kW77WGaDEHgMOJPsO19bo4EtLBuBYn2yG34eisf0HHBELHc8q+YIX8TKG33K1tHYWG1tVvoEaka/+FquLnOMTwA/NGO9WH5gzLXuC3wYAjeQ9Thtb0Z3oFUI3BePbXu3HdU5WV3PAm3N+H71AsvuK9kbeAE4Mua19yD7kfYy2XnjwxBYZsa+QN/41M+BTmX28y6wixnt4/nja8Qfimb0iv8b2Q/f9Du8RufKdfDaVN8EoF7uJvc6Aleb0QVYDkwlSxmo5CLgf4DxsWJNJxu14RrgPjO+Q3YCLFzRDIE5ZhwMPG7GSRW2U1H8Nbs/ZDfMON8HropXpBb71xFP/sND4Ndx0eXAKLLG6LdY1aPAPmTvR1N5j/aNxy0tR1VMB1iP7Lv5Fyg9xFkIPGnGVsCLll27WQAcA2wOXGbGCrIb335IdkL6W2x4GllPR4FlN529QnbD6wrLhk3cOmR3p59K1vhsDdwcApPi034O3GXGb8hSOm5y29suHufYuOgmsqvY70F2o2DiSbLu2afj4wFmjCW7qvQ5cHUI3FLmfbuRLO1pTKxXc8n+DuwDnG3Gsvj+HEfWtXuLuyr2X/F414vv3Stl9iGyihAIZhwG/I9lQxkuJvu7fiZZ43FX4DWyxujPQuADM24HHjbjFWAcMDlu6yMz/mnGRODxEDjb7eclM/5Klja1nKy+XR9X3x4bpxa3d3L189bmXLkOXpvOcQJoSugGEX9R/zkE9m/oY6ktM14ADg2V7+QXaRZiQ/rHIXBsA+3/MLIhHCsNZSXSrK3Lc6XOcVJNM981gBCYTXaTXOcaCzcC8df/FfqDIS1FvLL8nFkhHWldakN2NU2kxVpX50qd48TTFWMREREREXTFWEREREQEUMNYRERERARQw1hEREREBFDDWEREREQEUMNYRERERARQw1hEREREBID/D+o5nyHWlWYPAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 864x720 with 30 Axes>"
+      "cell_type": "code",
+      "metadata": {
+        "id": "IjnLH5S2CaWx",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "class_names = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',\n",
+        "               'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Brm0b_KACaWX",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Explore the data\n",
+        "\n",
+        "Let's explore the format of the dataset before training the model. The following shows there are 60,000 images in the training set, with each image represented as 28 x 28 pixels:"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Plot the first X test images, their predicted label, and the true label\n",
-    "# Color correct predictions in blue, incorrect predictions in red\n",
-    "num_rows = 5\n",
-    "num_cols = 3\n",
-    "num_images = num_rows*num_cols\n",
-    "plt.figure(figsize=(2*2*num_cols, 2*num_rows))\n",
-    "for i in range(num_images):\n",
-    "  plt.subplot(num_rows, 2*num_cols, 2*i+1)\n",
-    "  plot_image(i, predictions[i], test_labels, test_images)\n",
-    "  plt.subplot(num_rows, 2*num_cols, 2*i+2)\n",
-    "  plot_value_array(i, predictions[i], test_labels)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "R32zteKHCaXT"
-   },
-   "source": [
-    "Finally, use the trained model to make a prediction about a single image."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "yRJ7JU7JCaXT"
-   },
-   "outputs": [
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(28, 28)\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Grab an image from the test dataset\n",
-    "img = test_images[0]\n",
-    "\n",
-    "print(img.shape)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "vz3bVp21CaXV"
-   },
-   "source": [
-    "`tf.keras` models are optimized to make predictions on a *batch*, or collection, of examples at once. So even though we're using a single image, we need to add it to a list:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "lDFh5yF_CaXW"
-   },
-   "outputs": [
+      "cell_type": "code",
+      "metadata": {
+        "id": "zW5k_xz1CaWX",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "train_images.shape"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(1, 28, 28)\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Add the image to a batch where it's the only member.\n",
-    "img = (np.expand_dims(img,0))\n",
-    "\n",
-    "print(img.shape)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "EQ5wLTkcCaXY"
-   },
-   "source": [
-    "Now predict the image:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "o_rzNSdrCaXY"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[9.4569641e-09 9.1678389e-09 8.5359018e-09 2.8125953e-11 4.8381224e-08\n",
-      "  1.5418796e-03 7.6329041e-09 2.6696799e-03 5.2743690e-08 9.9578828e-01]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "predictions_single = model.predict(img)\n",
-    "\n",
-    "print(predictions_single)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "6Ai-cpLjO-3A"
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAEbCAYAAADkhF5OAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAdMElEQVR4nO3debgcVZ3/8fdJQiTsS4BAWCKQsLuxRhaRBCFE9i0CGhRkDcoyCoMiAUED/tx/oKAgEMRhFAHB0ShugKIYnHEU/angjOuAMoPDPIoLk/P743vaW1wTyL1d3edy8349z33S3bdzT1V11afOVtUp54wkqf/G1F4ASVpRGcCSVIkBLEmVGMCSVIkBLEmVGMCSVMm4obx54sSJecqUKT1aFEkanR544IHHcs7rDX59SAE8ZcoUFi9e3N5SSVKXJk2CRx/tbRkbbACPPDL8/59S+tnSXrcLQtJzWq/Dt5dlGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVMm42gsgqR3nnXdez8tYsGBBz8tYkaSc8/K/OaXfAj/r3eI8zUTgsT6VZdkjo3zLtuzRWvZmOef1Br84pADup5TS4pzzTpa94pRv2Za9IpTdZB+wJFViAEtSJSM5gK+27BWufMu27BWh7L8asX3AkjTajeQasCSNagawJFViAA9DSik903ONHiml1Vb0z3dFX/+OlNKY8m9r22NUBfDSNkzbO09KKeXScZ5SekNKaffc54705jr1+uDo98GXUlqn8Xirfpa9lGWZCiwEXtSn8kbclamD9vc1ellOr/52G1JKawOd9W9tfxhVAZxzzimlmSmlk1JK8zqvtV0GQEppNjAD+EWbf//ZpJTGNJbhcGC7HpbVPPiOTikd2quyShljgH1SSh9IKZ0CnNvLg/7Z5Jx/AvwbcF5K6QW9LCultCawc3m8b0pp216Wt7wan/9JwFUppXE9qNRMA16TUhrf5t9t2Z7E/ngRsLC1llHO+Tn/w8Bsjp2AHwLnAPcDNw1+T0vlbQF8A7iyPB/T5t9fzmXYDbgNWLsPZf0dcB+wzaDXx/SovH8G/gvYpDxfqd/7U3PdgAXALcALeljmNOBc4Hbg/wGr9nOdn2XZ9i7LtVab27j8uyfwKeDbwFHA82qv7zMs85eA3wF7tfU3R0UNOOecU0q7ACcAb885vzvnvAuwTkppYec9w/37SznT/Qr4GPCylNJhOeclZRl63oxK4eXAPcDncs6Pp5RW7mF5WwKvzDlPB35eamdvBsg5L2mpjGaXyvOIHf1e4J0ppXE557+0Uc7yLksOS1JK6wLknM8DfgBc1HZNuLPuOecfA5OBXYB/BP7UZjnDWabyeF1gv7JcU9sqoxwvewIfAq4B/gXYCzh6pNSEl3I8f4D4bI5LKW3dShld5NKIklJ6DXAB8Gng0pzzEyml1YF/AI7LOT8+zL/bbIbPATYAHgT+FdgHmANcl3O+rYXVeNZlaLz2MWDfnPPG5fnYnPP/tllWSmk1IANfAH4NPA6MJw7Gz5RgarO8bYAncs6/Ks8/AYzLOR+ZUtqbqB0t6rbM5VyuecCuRBfTNTnnh1NK84kun3fmnL/TQhnNdZ8LzAS+TATdfxEtuF+nlCYC/9lNJWKYy7QK8CRx45o3AasSrb4HWyrrzcBqOee3lRPvCcChwEeBW3POf26jnGEuW3M7HE7cOfL3Oec7U0rvAjYEzgIOA/6Yc75+WAXVrtZ30RzonDw2A1Ypj2cCXwVmEzvNzsD3gfVbKO9kotvhSOD3wMHAWkQAf4WoJfZsPcvjQ4HjgZ3K8xuImsPY8nxsi2XNI05oY4CtgXcB25bfHQ5c2Hx/C+t5FnA3Ufu9qpS7OnFC/Q7RLbFFn/at15dl2Rh4iKj17Fl+9y5iYK6rpjKwRuPxbsAniDCi7FvvA94AnE/UvFbux7o3lukc4HpgETCdGHi6AHg/LXXFAAeVv79t47UvAu8Fdujn+j7DMr4B+BbwjrIvXldefw9wY9k/hr09qq9glxtnVtk4Hy8bZ7Py2reBW4luggO7LGMMMKnsjOsCry4h0Qm91Usob9LjdT2nBP35ZZ33K69fB/ycFvtjgZOAbwIbL+V384DvAtu3WN5xwD3l8TuIE9y1jd8fAUzp4bbduYTe84DVSshOKgffXUQf8KJGCE/ssrwtgL8HVgbWLvvqYuCljffMLoF3X1uBN4TlOwb4Ynn8APCh8nhb4PLyM36If7NTYdqRGLzelGhNvQN4C9GqmgZ8juhvv6Cf67yMZV65fDZblufjS9acW55vTZeVu6or2OXGeT7RL/fS8mGeUnbi9YADiT7Eo4f5t/+mZleC77ZyII4pr53dq4ODp9dGN6AMKBJNwX+iUQMDPgxs3kKZY8pO96myDdcrgXtNKXdiOTi6Ct/B2xd4QfkMTycGe9YEHiZOquP6sC8dQwzazi7Px5eQXNR4z8PAOymtrRb23bWIWuWWRMXhhrI/bdF43xj6MBjHoJM3cBrwcqJV8vnOvkacoCYzxBNQI3xnAT8G3go8Sgya70gMPn6TqFhsTVRoLqfLFl0L++UqwNc6+0VjHd7TWpn9XMEuN85KwITGjrAxcOOg9/wf4MTy+LVETXjG0gJ1eT6EEgjnEqPi55e/t3353ZHA9yhnxx6u9/PLgbiQaArfSZkVQNTGJ7e10zFQqz++rOtngUuAU4Ery3J02/RulrcmpSle/vYNwKzy/OJyUK7Xw23bnOnwduKkfWR5vikxG2E3YH/ixNPmtl4duJQ4uU0Btiqf8VnA1F7uU8+wfPuXY+s0YpD3U4197e+BDw7lWBr0t7ejdCMRg3qPlu07o/x+PaI1sB9RsWqthTWMz2Y6URtfo2yThymtE6J76naiotJ1F1zfP+RhbpzViBHSXYFXAe8mugMeBN7aeN9bgAsbz48DNh1mmeeUA/IF5fmEsgPeUELwr2Hcw/WeSnQxbEjUQO8Hdiy/ey3Rv/033QTDLOvVJWwPIWom21GmuBH93HfTYm2MmNp2G9GHfSxxQn0TcAXRv/zpttZtOZblNKIP9uPEoNuh5fVTgK8TzfDtuixjaa2qTco+++ESwtPKNjmd/tT8X8JAt8rqRHfH2PJZfAM4D9gBmFs+p22H8Le3IAaoDm68Ng3YHVhcnp8L/BnYpzxfg+j/72pbd7lNzijH9vXEeNIrgAOImU9XEieH5d4Oz1perRUdwgZZq4TDkUQT5aeNA2QqUQv9YPn9dzsf5jDKaZ4BVwU+WXbKjUv57y471eZEf9WGfVj3LYma13SihtCpFV5NnHxa2VFL0NxLDIr8HDi5vD4WeF0pq9tuhx3LdluLmD1yfzngjioH3fHECfaNwB39OAiJls0WRNdVZ87xq8oBeER5vj7d9vM1uoeAM4mxibcRXUsTy+Mryr61JbBRH9Z9HNGy+TKwe3ntfspcX2AbYjbCR4l+0OX+PErQfr8cM98ATmn87kQG5s+/rJS/W+P3fZ3zPWi5pxIn20lE98NMYgB4KtFC2ZaWx3qqrOgQN8oLgZvKRvgAMQA2s3NQlI11BdGEnN1CeVuVfz9XguBW4KKyo7yvjztCp5/5teXAWJto9uxEtAaGvSPw9JPNSsSZfSJxormLga6IyUQrYusu12c2cXKcS5zQjgYWNn7/CuICms07y9TDbTu4n288Ufvdk1LrJE50/wPs30J56wI/Ivo9dyGa9scBlwGfIVo36xIDfe+hDzXfQct2UtnPZxDT66DMuADWKf8ud8unhNQ/Uwa/y7qeCryoPN+T6Ep7P3Gi22Vpn0uf1n9Ms2ziBPjZQe+ZT+nW7Mky9Hulh7mhTicGvyYSTeSFlAE2oh9xg8Z7h/1BErWPTxIDUKsSteop5XeziRPBhB6sXzMQtyG6Hb5ADM6sSfQ/79uDsl5F1PDOJZrazUGnM4ig72p2BVHLeQjYtfHai4gmXvO1a4E9uv0Mh7DuUyh9usSAzwWNz/qAEhLd9vm+smzbfYgm/CLKdEWiRTOf6HKYDKxDl7MrhroNyvM1iC6Y+4ElRBfbl4gpVh8hWkFDGUPZA1jSeP6vRGXmX8pnPJaoQM2nhRNcG9uCMiOjPL4NuL7xnkuBS3q2DDU3wDNsmL856IlBgM4o9YklpBYAv6XMi22h3PWJEfHrgDmN188ianCtz03kbwelxhHN9AuImtnlRF/UVS2Xe3A50DYmTjRfZKDWModoQnY9GESM7L+xPO7UMNckph9dRvQFH08MdPSsz3fQdj6b6Fa5o5Q/oXzmC4GbiS6JrmaVlPD9LgNdGZPL3/1I4z3rElPe/oE+jPgP2gYziP7YDcrzU8t+9rqyT0xhmPOuiZkCPyVaU28rr40nZkCcs6xl6tdPWfeZ5fEZxMnhRqLLZC2i229ROQa/S2kV92RZ+r3yy7FxnldCcAJxDfql5fU5wIJBH/JJtFAzpDGbgKiZHFkOyM6I+LtpseN9GctwGjHrYCHR7bASUSM/hKhB/oLoM+x+5DW6Mb5E6ZtjoJZ9I1Hz/hYtTTUj+ucv6bzGQLNvbaJZ/lFiJkBfBl6IfuYbidklWxN9fp15nS8u+0JXF3wQ3WJfAXYuz1ct/+5J3NxnXuO9fan5Dlq+eUSN9wLgJ5SBamIs4B5Kn3CXZcwAnuLpM01OGBzANX6Ilt8SYp73lWU/2L7shzcQM3JOLsdhV91vz7ostTfGMjbQqcAjRC1l1/LaGKI/dv5S3j+kUGqEQ+ff/wv8B2XwowTdVcQAQk+aSTy9NnIAUePcgjipXErMBOhMu9uULgb9iD7l3Yim8JpEv+PVRI1nh/Ke8SUMprUZCKXMuxiYvTGGgZrwWaW8nt+ApYT/C4km8bUM9HNvVsLo/S2WtTZxItuB6LefX7b1zcRskl8AF/V6nZexbDOJ7qZVgTcTg66/Y6D//fW0NNBU9uuHyuMtiWlnr6ix3s39oPx7GPAHylgE0fJcg5h6t3PflqfmxljKxunUjjYjpno9BKzZ+P36xGWKu3ZRRjP4Nmw8Ph/4WSOE5xFdHK2PSBNXXs1tBOxc4LLyeCViEvzNtNAkJ/quv0OcvO4C/p04229MDC5+kB7WPsuBPp/oStmx8fqcslw9u4KQpU/96lxm/FIG5rg+n6ixttXCSMQ0xkXAL4nW1IlEk38B0e1xLz2c47ysbUCcZDcs+9xd5bWFxHSw1j8LYh7tH4jKVNU+38Zn0wnhw4ma8Msav78JOKxvy1N7gwzeUYhm4NeJ/rG30uiDKcHxBoZ5hdug8s4grii7jahxjyfmPf6yHCQP0qPLX4mulW8TNwmC6BL4FrB34z13NHeMYZazPzFtrbmDXVhCeBvihHZhCYhpPfxsJxNTrb5GXCxzCVEb6stke+JS5pOAF5bnJxM11D0aIdzq7ANi7vp0Bt1ikWji7ttG0C/HMjQrG1vRuJ1oObZOL49PICo8PbmoiOiOOLQfn/XybpdG3hwL/KVsj4NK3vTtQpiRsDFWY6A5uA8xAb956d9FxLSWznzUM2lcfDHMMmcS84cnE31+84GLy++OImorrff9EE3SV5fHexHN0rlEk/WUcnCeUALjO3QxCk/UdJYwMOq+cuN3FxF9fxOIy4DfBEzq8ec8oQTe/BKAvQz8VRqPzyT6NS8karmdOc4nEie96b1c70HLdSTR59zTqyeXUu7ZRJ//54nZHesQFZmriamdd/f68y/LUWPAball0riHd/lclhD9wX25+Oevy9HvDTJoI3SufFm3PJ9eNsTbB73vZGK0eFYLZY4vIXtl47U9icsLh3XV3BDKPqacYI4pz/cuIXw00f97YFmO6yi1tS7Lm11ONJ3t26yJfRV48eDXn+s/ZZ3fR5xcdwVuLq//XTmpXc3A4ONrev2Zl3I2LCeCri9oGUbZ+xL3jYZoeSwqj9chBqMu6/cy9XHdmy2AWeW434qBrr9mTfgAejjbYZnLOAI20vrEBOjDy/O9gD92QqrxvvGNx0OZlzil8fjkshNuS/TBzWr87tP0Z8DtMGJ6Waf74eVEzezY8nwsLV6IUHa8hxm4rLjT5L6dPt9lqw/7Umfq1yHl+YQSxLPLCWccUQN/kFIT7tNyTSjL0Neabyn7JUTr8RKiT7rz+fet5l9hnQf3e59N1PIXEK2emc33DiVP2v6p8iWA5U7zKcc3SfwmpbQ/8MaU0pKc860ppf2AW1JK43PO1wHkxs2Zc9lyy1HOAcD7U0ovIYLoxcTVPj9LKd1A3H1/W6Lfd0tiJkLrOsubUtqeuPrpz8CxKSVyzjemlJaU5VySc/4E0PWN1Rtlf67cXHxxSmmnHN+g8RpiqtQjbZVTW0ppEjHwdWLO+dsppQlEayoR/d1fyDk/lVL6KXEw3tqvZcs5P0lMMeypwTfuL8fZU0T31mNEBSOnlE4E5qaUDgJ+t7zH03PIusBj5TsGNyeuttsrpXQm8aUCX04prQQ8VX3dK5+pNmo8PpQYpOnUhGcQo6cbMYyrsRi4q9Ju5flNwG8YuOn15FLGzcTXovS0NkjsCB8hQmIsUVv7BAPdEbsDm/Ww/FlEd8SpxPS6UdXsZOlTv+4i+j07V3ldSwz+9az/eST8EPfTuIaY57smcTnwvcQVpRcTU/Gq3fCmh+udiBb174GDymvrEDN9biKuyOtMgZxD4wraasvc5w20EfC68ng/ok/uDgYGijpXZ80pz4f1hZPEvQUeJeb0TSuvrVHKunXQe/86L7XNHWEZrx9BTKM7sxHCdwJH9Wn7v5KofY/Wg29ZU78uJS50OZ4K3QB9WPfmoOMeDNxv4nKipr96OSbOLttiVJ6AGOjPPRr4Twau7FxQTkCdb3SZWyojXV1q3sZPX78TLqW0D3FW/ioxKf5SYj7mDsQ3IixMKR1BBNQRwKM5x5dd5uVc0JTSDKJGexHRzF4fuDPnfE/5ivMriLm2r1revzlU5YsknyqPDycGet5bnh9CDIx8P+f8odL98r1cvget11JKq+Sc/9CPsvqtfIfdDsRtHm/POf+pvH498R12t9Rcvl5IKc0m9qfLifGT04DLc3x32XrEdMvtgTNzzj+vt6T9VY6rfyQqdT8kWkSTiVsX7EpUelr5bruu9PkMtQqxs9wC3NF4fS4xG6JTOx727f+Iixw6N0/eirhL2gIGbrm3BjH397oereO+RNfCeUSzf1eiyXdy4z0XEbX/U3qxDP487fPoTP3qy/fJ9XndOoOOB5fnm5R97cON96xLhPMniYpHa19dNVJ+ePrlzsdQLncmKnFPMHCTp5cSM416PvNluZe9TxuoU9Ner/w7i+ifPaPxntcT90ltpVnAwFV1U4l+rwWNYF6d3lzhtj/R33hGCf6PEQN/e5QQOLW87yjiJtzV+6BG6w8Vp371af2Wdb+JPRgB95vo43Z4IdG321n/NwHHN35/GNEdMWIuBGn+9K0LojSVLiNC6jfERRcnAV/KOV9R3jM596ApnlKaSpwZJxJfY/StHpSxDjHSfHDO+Y6U0qaUO13lmNmxO1Hzv5vYaQ7MOf+47eVQKLMg9gF+lHN+qPbytC2ltDYxgHwOcVHNecS88keJk8/ziS82vbDWMvZLSukOYgzgUKKr4Se5zJ4qvz+cmBu+DfCHnPOSCou5VH0J4JTSHsQMgNfmnL+ZUloFyMQAyTnERPEP9HgZtiY+oGtyzr/pURmziebe9JzzEymljwN355yvKr/fmKgRfy/n/O+9WAatGMoUs7OJwbXtiBkf9xL9nQcSlYFDiJrfb2stZ6+U9R+Tc/7f8vwWYoD54fLvD4E/lbd/nQjeJ2ss6zPpVwAfTPRPLSYCqHPrxeuIM/Vvc86L+7AcK+Wc/9LjMmYRl3cuImZ9HJtzfjKlNLazs0hteIZBxxuIG+zclfvVxO2j5qB8s9WcUrqK6Mq8ipiKtiZxEcz5eYQOQLYewOXChh1yzjc3Xtub6JtZhfjiw18S9zx4V875/lYXYARIKc0k5qROynGhyco55z/WXi6NfimlI4nuiKNHaddLM3znETfTeYC4tcAPUkpXEHd1O6i8Z3xuXMQ10oxp84+llKYRAbtq47WxOeevEpcBH5Jz/ijxHVlb0OIVXyNJzvku4tLTr6SU1jd81WsppQ3LlV7zgbmjMXzhaVeVHkL08c8j+n9PTilNzzmfDoxJKX26cSXgiNXapcgppa2Iiwo+lXO+try2Us75LymlycRI9OdTSgcS07Auzjk/0Fb5I02OS4DHA59PKe0UL42+5qBGjN8Rg3EHj9bw7SjjORcDN+WcHyiXl78RmFMqfK9MKW1UjrcRfcy1UgMu3Q43EveZ/e8y4k8J30nE941NLW//FTH/9bZyhhq1cs63A3vluOfFiN4R9NyWc34y5/zZ0Ri+KaUNBr30BHHzrGNLrfdx4mvD/gwcVLr8ft3v5RyOrvuAy3SffyK+2+tOYlbDeOLqs3tTSocSl0p+vNuFlbRiKbXdHxDTyH6Yc/5IeX1l4iZDM4B35JzvK4OSK+ecH6u2wEPUyiBcSmlSzvmR8ngromN8JaI74oHG+8aMpDl4kka2lNImxLdGf4bo832UuMT4Kznn36eUTifu/fDmnPM36y3p8LQ6C6ITsOXCh1cTN5z5Qs75a60VImmFklJ6L2VKJ3Fp+Rzi6+PPJqaZbQTcl3P+RbWFHKZWZ0F0arc5558QX68zDpidUlqrzXIkjX6NMaJzicG0icS3l+9A3Fb0LUQYL3ouhi/0+EKMUhPuBLIkDUkJ4fHEXRQ3J77h47wyiD+NuIjr8ZrL2I2+3o5SkoajjC3dA3ww5/z22svTlla7ICSpF3LOPyK6IsaWe8mMCgawpOeK+4Aday9Em+yCkPScMdq+0cUAlqRK7IKQpEoMYEmqxACWpEoMYEmqxACWpEoMYEmq5P8DG+xHPgtxVAwAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cIAcvQqMCaWf",
+        "colab_type": "text"
+      },
+      "source": [
+        "Likewise, there are 60,000 labels in the training set:"
       ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plot_value_array(0, predictions_single[0], test_labels)\n",
-    "plt.xticks(range(10), class_names, rotation=45)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "cU1Y2OAMCaXb"
-   },
-   "source": [
-    "`model.predict` returns a list of lists, one for each image in the batch of data. Grab the predictions for our (only) image in the batch:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "2tRmdq_8CaXb"
-   },
-   "outputs": [
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9\n"
-     ]
+      "cell_type": "code",
+      "metadata": {
+        "id": "TRFYHB2mCaWb",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "len(train_labels)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YSlYxFuRCaWk",
+        "colab_type": "text"
+      },
+      "source": [
+        "Each label is an integer between 0 and 9:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "XKnCTHz4CaWg",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "train_labels"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TMPI88iZpO2T",
+        "colab_type": "text"
+      },
+      "source": [
+        "There are 10,000 images in the test set. Again, each image is represented as 28 x 28 pixels:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "2KFnYlcwCaWl",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "test_images.shape"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rd0A0Iu0CaWq",
+        "colab_type": "text"
+      },
+      "source": [
+        "And the test set contains 10,000 images labels:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "iJmPr5-ACaWn",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "len(test_labels)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ES6uQoLKCaWr",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Preprocess the data\n",
+        "\n",
+        "The data must be preprocessed before training the network. If you inspect the first image in the training set, you will see that the pixel values fall in the range of 0 to 255:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "m4VEw8Ud9Quh",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "plt.figure()\n",
+        "plt.imshow(train_images[0])\n",
+        "plt.colorbar()\n",
+        "plt.grid(False)\n",
+        "plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Wz7l27Lz9S1P",
+        "colab_type": "text"
+      },
+      "source": [
+        "We scale these values to a range of 0 to 1 before feeding to the neural network model. For this, we divide the values by 255. It's important that the *training set* and the *testing set* are preprocessed in the same way:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "bW5WzIPlCaWv",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "train_images = train_images / 255.0\n",
+        "\n",
+        "test_images = test_images / 255.0"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Ee638AlnCaWz",
+        "colab_type": "text"
+      },
+      "source": [
+        "Display the first 25 images from the *training set* and display the class name below each image. Verify that the data is in the correct format and we're ready to build and train the network."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "oZTImqg_CaW1",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "plt.figure(figsize=(10,10))\n",
+        "for i in range(25):\n",
+        "    plt.subplot(5,5,i+1)\n",
+        "    plt.xticks([])\n",
+        "    plt.yticks([])\n",
+        "    plt.grid(False)\n",
+        "    plt.imshow(train_images[i], cmap=plt.cm.binary)\n",
+        "    plt.xlabel(class_names[train_labels[i]])\n",
+        "plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "59veuiEZCaW4",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Build the model\n",
+        "\n",
+        "Building the neural network requires configuring the layers of the model, then compiling the model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Gxg1XGm0eOBy",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Setup the layers\n",
+        "\n",
+        "The basic building block of a neural network is the *layer*. Layers extract representations from the data fed into them. And, hopefully, these representations are more meaningful for the problem at hand.\n",
+        "\n",
+        "Most of deep learning consists of chaining together simple layers. Most layers, like `tf.keras.layers.Dense`, have parameters that are learned during training."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "9ODch-OFCaW4",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "model = keras.Sequential([\n",
+        "    keras.layers.Flatten(input_shape=(28, 28)),\n",
+        "    keras.layers.Dense(128, activation=tf.nn.relu),\n",
+        "    keras.layers.Dense(10, activation=tf.nn.softmax)\n",
+        "])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gut8A_7rCaW6",
+        "colab_type": "text"
+      },
+      "source": [
+        "The first layer in this network, `tf.keras.layers.Flatten`, transforms the format of the images from a 2d-array (of 28 by 28 pixels), to a 1d-array of 28 * 28 = 784 pixels. Think of this layer as unstacking rows of pixels in the image and lining them up. This layer has no parameters to learn; it only reformats the data.\n",
+        "\n",
+        "After the pixels are flattened, the network consists of a sequence of two `tf.keras.layers.Dense` layers. These are densely-connected, or fully-connected, neural layers. The first `Dense` layer has 128 nodes (or neurons). The second (and last) layer is a 10-node *softmax* layer—this returns an array of 10 probability scores that sum to 1. Each node contains a score that indicates the probability that the current image belongs to one of the 10 classes.\n",
+        "\n",
+        "### Compile the model\n",
+        "\n",
+        "Before the model is ready for training, it needs a few more settings. These are added during the model's *compile* step:\n",
+        "\n",
+        "* *Loss function* —This measures how accurate the model is during training. We want to minimize this function to \"steer\" the model in the right direction.\n",
+        "* *Optimizer* —This is how the model is updated based on the data it sees and its loss function.\n",
+        "* *Metrics* —Used to monitor the training and testing steps. The following example uses *accuracy*, the fraction of the images that are correctly classified."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Lhan11blCaW7",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "model.compile(optimizer='adam',\n",
+        "              loss='sparse_categorical_crossentropy',\n",
+        "              metrics=['accuracy'])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qKF6uW-BCaW-",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Train the model\n",
+        "\n",
+        "Training the neural network model requires the following steps:\n",
+        "\n",
+        "1. Feed the training data to the model—in this example, the `train_images` and `train_labels` arrays.\n",
+        "2. The model learns to associate images and labels.\n",
+        "3. We ask the model to make predictions about a test set—in this example, the `test_images` array. We verify that the predictions match the labels from the `test_labels` array.\n",
+        "\n",
+        "To start training,  call the `model.fit` method—the model is \"fit\" to the training data:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "xvwvpA64CaW_",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "model.fit(train_images, train_labels, epochs=5)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "W3ZVOhugCaXA",
+        "colab_type": "text"
+      },
+      "source": [
+        "As the model trains, the loss and accuracy metrics are displayed. This model reaches an accuracy of about 0.88 (or 88%) on the training data."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "oEw4bZgGCaXB",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Evaluate accuracy\n",
+        "\n",
+        "Next, compare how the model performs on the test dataset:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "VflXLEeECaXC",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "test_loss, test_acc = model.evaluate(test_images, test_labels)\n",
+        "\n",
+        "print('Test accuracy:', test_acc)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yWfgsmVXCaXG",
+        "colab_type": "text"
+      },
+      "source": [
+        "It turns out, the accuracy on the test dataset is a little less than the accuracy on the training dataset. This gap between training accuracy and test accuracy is an example of *overfitting*. Overfitting is when a machine learning model performs worse on new data than on their training data."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xsoS7CPDCaXH",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Make predictions\n",
+        "\n",
+        "With the model trained, we can use it to make predictions about some images."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Gl91RPhdCaXI",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "predictions = model.predict(test_images)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "x9Kk1voUCaXJ",
+        "colab_type": "text"
+      },
+      "source": [
+        "Here, the model has predicted the label for each image in the testing set. Let's take a look at the first prediction:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3DmJEUinCaXK",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "predictions[0]"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-hw1hgeSCaXN",
+        "colab_type": "text"
+      },
+      "source": [
+        "A prediction is an array of 10 numbers. These describe the \"confidence\" of the model that the image corresponds to each of the 10 different articles of clothing. We can see which label has the highest confidence value:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "qsqenuPnCaXO",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "np.argmax(predictions[0])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "E51yS7iCCaXO",
+        "colab_type": "text"
+      },
+      "source": [
+        "So the model is most confident that this image is an ankle boot, or `class_names[9]`. And we can check the test label to see this is correct:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Sd7Pgsu6CaXP",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "test_labels[0]"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ygh2yYC972ne",
+        "colab_type": "text"
+      },
+      "source": [
+        "We can graph this to look at the full set of 10 class predictions"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "DvYmmrpIy6Y1",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "def plot_image(i, predictions_array, true_label, img):\n",
+        "  predictions_array, true_label, img = predictions_array, true_label[i], img[i]\n",
+        "  plt.grid(False)\n",
+        "  plt.xticks([])\n",
+        "  plt.yticks([])\n",
+        "  \n",
+        "  plt.imshow(img, cmap=plt.cm.binary)\n",
+        "  \n",
+        "  predicted_label = np.argmax(predictions_array)\n",
+        "  if predicted_label == true_label:\n",
+        "    color = 'blue'\n",
+        "  else:\n",
+        "    color = 'red'\n",
+        "  \n",
+        "  plt.xlabel(\"{} {:2.0f}% ({})\".format(class_names[predicted_label],\n",
+        "                                100*np.max(predictions_array),\n",
+        "                                class_names[true_label]),\n",
+        "                                color=color)\n",
+        "\n",
+        "def plot_value_array(i, predictions_array, true_label):\n",
+        "  predictions_array, true_label = predictions_array, true_label[i]\n",
+        "  plt.grid(False)\n",
+        "  plt.xticks([])\n",
+        "  plt.yticks([])\n",
+        "  thisplot = plt.bar(range(10), predictions_array, color=\"#777777\")\n",
+        "  plt.ylim([0, 1])\n",
+        "  predicted_label = np.argmax(predictions_array)\n",
+        "  \n",
+        "  thisplot[predicted_label].set_color('red')\n",
+        "  thisplot[true_label].set_color('blue')"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "d4Ov9OFDMmOD",
+        "colab_type": "text"
+      },
+      "source": [
+        "Let's look at the 0th image, predictions, and prediction array."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "HV5jw-5HwSmO",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "i = 0\n",
+        "plt.figure(figsize=(6,3))\n",
+        "plt.subplot(1,2,1)\n",
+        "plot_image(i, predictions[i], test_labels, test_images)\n",
+        "plt.subplot(1,2,2)\n",
+        "plot_value_array(i, predictions[i],  test_labels)\n",
+        "plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Ko-uzOufSCSe",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "i = 12\n",
+        "plt.figure(figsize=(6,3))\n",
+        "plt.subplot(1,2,1)\n",
+        "plot_image(i, predictions[i], test_labels, test_images)\n",
+        "plt.subplot(1,2,2)\n",
+        "plot_value_array(i, predictions[i],  test_labels)\n",
+        "plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kgdvGD52CaXR",
+        "colab_type": "text"
+      },
+      "source": [
+        "Let's plot several images with their predictions. Correct prediction labels are blue and incorrect prediction labels are red. The number gives the percent (out of 100) for the predicted label. Note that it can be wrong even when very confident."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "hQlnbqaw2Qu_",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Plot the first X test images, their predicted label, and the true label\n",
+        "# Color correct predictions in blue, incorrect predictions in red\n",
+        "num_rows = 5\n",
+        "num_cols = 3\n",
+        "num_images = num_rows*num_cols\n",
+        "plt.figure(figsize=(2*2*num_cols, 2*num_rows))\n",
+        "for i in range(num_images):\n",
+        "  plt.subplot(num_rows, 2*num_cols, 2*i+1)\n",
+        "  plot_image(i, predictions[i], test_labels, test_images)\n",
+        "  plt.subplot(num_rows, 2*num_cols, 2*i+2)\n",
+        "  plot_value_array(i, predictions[i], test_labels)\n",
+        "plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "R32zteKHCaXT",
+        "colab_type": "text"
+      },
+      "source": [
+        "Finally, use the trained model to make a prediction about a single image."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "yRJ7JU7JCaXT",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Grab an image from the test dataset\n",
+        "img = test_images[1]\n",
+        "\n",
+        "print(img.shape)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vz3bVp21CaXV",
+        "colab_type": "text"
+      },
+      "source": [
+        "`tf.keras` models are optimized to make predictions on a *batch*, or collection, of examples at once. So even though we're using a single image, we need to add it to a list:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "lDFh5yF_CaXW",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Add the image to a batch where it's the only member.\n",
+        "img = (np.expand_dims(img,0))\n",
+        "\n",
+        "print(img.shape)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "EQ5wLTkcCaXY",
+        "colab_type": "text"
+      },
+      "source": [
+        "Now predict the image:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "o_rzNSdrCaXY",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "predictions_single = model.predict(img)\n",
+        "\n",
+        "print(predictions_single)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "6Ai-cpLjO-3A",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "plot_value_array(1, predictions_single[0], test_labels)\n",
+        "plt.xticks(range(10), class_names, rotation=45)\n",
+        "plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cU1Y2OAMCaXb",
+        "colab_type": "text"
+      },
+      "source": [
+        "`model.predict` returns a list of lists, one for each image in the batch of data. Grab the predictions for our (only) image in the batch:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "2tRmdq_8CaXb",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "prediction_result = np.argmax(predictions_single[0])\n",
+        "print(prediction_result)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YFc2HbEVCaXd",
+        "colab_type": "text"
+      },
+      "source": [
+        "And, as before, the model predicts a label of 2."
+      ]
     }
-   ],
-   "source": [
-    "prediction_result = np.argmax(predictions_single[0])\n",
-    "print(prediction_result)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "YFc2HbEVCaXd"
-   },
-   "source": [
-    "And, as before, the model predicts a label of 9."
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "collapsed_sections": [],
-   "name": "basic_classification.ipynb",
-   "private_outputs": true,
-   "provenance": [],
-   "toc_visible": true,
-   "version": "0.3.2"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.8"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+  ]
 }

--- a/site/en/tutorials/keras/basic_classification.ipynb
+++ b/site/en/tutorials/keras/basic_classification.ipynb
@@ -3,7 +3,7 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "name": "Copy of basic_classification.ipynb",
+      "name": "basic_classification.ipynb",
       "version": "0.3.2",
       "provenance": [],
       "private_outputs": true,
@@ -987,7 +987,7 @@
         "colab_type": "text"
       },
       "source": [
-        "And, as before, the model predicts a label of 2."
+        "And the model predicts a label of 2."
       ]
     }
   ]

--- a/site/en/tutorials/keras/basic_classification.ipynb
+++ b/site/en/tutorials/keras/basic_classification.ipynb
@@ -1,994 +1,1244 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "basic_classification.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "MhoQ0WE77laV"
+   },
+   "source": [
+    "##### Copyright 2018 The TensorFlow Authors."
+   ]
   },
-  "cells": [
-    {
-      "metadata": {
-        "id": "MhoQ0WE77laV",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "##### Copyright 2018 The TensorFlow Authors."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "_ckMIh7O7s6D",
-        "colab_type": "code",
-        "cellView": "form",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "vasWnqRgy1H4",
-        "colab_type": "code",
-        "cellView": "form",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "#@title MIT License\n",
-        "#\n",
-        "# Copyright (c) 2017 François Chollet\n",
-        "#\n",
-        "# Permission is hereby granted, free of charge, to any person obtaining a\n",
-        "# copy of this software and associated documentation files (the \"Software\"),\n",
-        "# to deal in the Software without restriction, including without limitation\n",
-        "# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n",
-        "# and/or sell copies of the Software, and to permit persons to whom the\n",
-        "# Software is furnished to do so, subject to the following conditions:\n",
-        "#\n",
-        "# The above copyright notice and this permission notice shall be included in\n",
-        "# all copies or substantial portions of the Software.\n",
-        "#\n",
-        "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n",
-        "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n",
-        "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n",
-        "# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n",
-        "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
-        "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
-        "# DEALINGS IN THE SOFTWARE."
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "jYysdyb-CaWM",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "# Train your first neural network: basic classification"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "S5Uhzt6vVIB2",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/basic_classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/keras/basic_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/keras/basic_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-        "  </td>\n",
-        "</table>"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "FbVhjPpzn6BM",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "This guide trains a neural network model to classify images of clothing, like sneakers and shirts. It's okay if you don't understand all the details, this is a fast-paced overview of a complete TensorFlow program with the details explained as we go.\n",
-        "\n",
-        "This guide uses [tf.keras](https://www.tensorflow.org/guide/keras), a high-level API to build and train models in TensorFlow."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "dzLKpmZICaWN",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "from __future__ import absolute_import, division, print_function, unicode_literals\n",
-        "\n",
-        "# TensorFlow and tf.keras\n",
-        "import tensorflow as tf\n",
-        "from tensorflow import keras\n",
-        "\n",
-        "# Helper libraries\n",
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "print(tf.__version__)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "yR0EdgrLCaWR",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Import the Fashion MNIST dataset"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "DLdCchMdCaWQ",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "This guide uses the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset which contains 70,000 grayscale images in 10 categories. The images show individual articles of clothing at low resolution (28 by 28 pixels), as seen here:\n",
-        "\n",
-        "<table>\n",
-        "  <tr><td>\n",
-        "    <img src=\"https://tensorflow.org/images/fashion-mnist-sprite.png\"\n",
-        "         alt=\"Fashion MNIST sprite\"  width=\"600\">\n",
-        "  </td></tr>\n",
-        "  <tr><td align=\"center\">\n",
-        "    <b>Figure 1.</b> <a href=\"https://github.com/zalandoresearch/fashion-mnist\">Fashion-MNIST samples</a> (by Zalando, MIT License).<br/>&nbsp;\n",
-        "  </td></tr>\n",
-        "</table>\n",
-        "\n",
-        "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. The MNIST dataset contains images of handwritten digits (0, 1, 2, etc) in an identical format to the articles of clothing we'll use here.\n",
-        "\n",
-        "This guide uses Fashion MNIST for variety, and because it's a slightly more challenging problem than regular MNIST. Both datasets are relatively small and are used to verify that an algorithm works as expected. They're good starting points to test and debug code.\n",
-        "\n",
-        "We will use 60,000 images to train the network and 10,000 images to evaluate how accurately the network learned to classify images. You can access the Fashion MNIST directly from TensorFlow, just import and load the data:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "7MqDQO0KCaWS",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "fashion_mnist = keras.datasets.fashion_mnist\n",
-        "\n",
-        "(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "t9FDsUlxCaWW",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Loading the dataset returns four NumPy arrays:\n",
-        "\n",
-        "* The `train_images` and `train_labels` arrays are the *training set*—the data the model uses to learn.\n",
-        "* The model is tested against the *test set*, the `test_images`, and `test_labels` arrays.\n",
-        "\n",
-        "The images are 28x28 NumPy arrays, with pixel values ranging between 0 and 255. The *labels* are an array of integers, ranging from 0 to 9. These correspond to the *class* of clothing the image represents:\n",
-        "\n",
-        "<table>\n",
-        "  <tr>\n",
-        "    <th>Label</th>\n",
-        "    <th>Class</th>\n",
-        "  </tr>\n",
-        "  <tr>\n",
-        "    <td>0</td>\n",
-        "    <td>T-shirt/top</td>\n",
-        "  </tr>\n",
-        "  <tr>\n",
-        "    <td>1</td>\n",
-        "    <td>Trouser</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>2</td>\n",
-        "    <td>Pullover</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>3</td>\n",
-        "    <td>Dress</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>4</td>\n",
-        "    <td>Coat</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>5</td>\n",
-        "    <td>Sandal</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>6</td>\n",
-        "    <td>Shirt</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>7</td>\n",
-        "    <td>Sneaker</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>8</td>\n",
-        "    <td>Bag</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>9</td>\n",
-        "    <td>Ankle boot</td>\n",
-        "  </tr>\n",
-        "</table>\n",
-        "\n",
-        "Each image is mapped to a single label. Since the *class names* are not included with the dataset, store them here to use later when plotting the images:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "IjnLH5S2CaWx",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "class_names = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',\n",
-        "               'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "Brm0b_KACaWX",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Explore the data\n",
-        "\n",
-        "Let's explore the format of the dataset before training the model. The following shows there are 60,000 images in the training set, with each image represented as 28 x 28 pixels:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "zW5k_xz1CaWX",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "train_images.shape"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "cIAcvQqMCaWf",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Likewise, there are 60,000 labels in the training set:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "TRFYHB2mCaWb",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "len(train_labels)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "YSlYxFuRCaWk",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Each label is an integer between 0 and 9:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "XKnCTHz4CaWg",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "train_labels"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "TMPI88iZpO2T",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "There are 10,000 images in the test set. Again, each image is represented as 28 x 28 pixels:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "2KFnYlcwCaWl",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "test_images.shape"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "rd0A0Iu0CaWq",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "And the test set contains 10,000 images labels:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "iJmPr5-ACaWn",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "len(test_labels)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "ES6uQoLKCaWr",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Preprocess the data\n",
-        "\n",
-        "The data must be preprocessed before training the network. If you inspect the first image in the training set, you will see that the pixel values fall in the range of 0 to 255:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "m4VEw8Ud9Quh",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "plt.figure()\n",
-        "plt.imshow(train_images[0])\n",
-        "plt.colorbar()\n",
-        "plt.grid(False)\n",
-        "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "Wz7l27Lz9S1P",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "We scale these values to a range of 0 to 1 before feeding to the neural network model. For this, we divide the values by 255. It's important that the *training set* and the *testing set* are preprocessed in the same way:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "bW5WzIPlCaWv",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "train_images = train_images / 255.0\n",
-        "\n",
-        "test_images = test_images / 255.0"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "Ee638AlnCaWz",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Display the first 25 images from the *training set* and display the class name below each image. Verify that the data is in the correct format and we're ready to build and train the network."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "oZTImqg_CaW1",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "plt.figure(figsize=(10,10))\n",
-        "for i in range(25):\n",
-        "    plt.subplot(5,5,i+1)\n",
-        "    plt.xticks([])\n",
-        "    plt.yticks([])\n",
-        "    plt.grid(False)\n",
-        "    plt.imshow(train_images[i], cmap=plt.cm.binary)\n",
-        "    plt.xlabel(class_names[train_labels[i]])\n",
-        "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "59veuiEZCaW4",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Build the model\n",
-        "\n",
-        "Building the neural network requires configuring the layers of the model, then compiling the model."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "Gxg1XGm0eOBy",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "### Setup the layers\n",
-        "\n",
-        "The basic building block of a neural network is the *layer*. Layers extract representations from the data fed into them. And, hopefully, these representations are more meaningful for the problem at hand.\n",
-        "\n",
-        "Most of deep learning consists of chaining together simple layers. Most layers, like `tf.keras.layers.Dense`, have parameters that are learned during training."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "9ODch-OFCaW4",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "model = keras.Sequential([\n",
-        "    keras.layers.Flatten(input_shape=(28, 28)),\n",
-        "    keras.layers.Dense(128, activation=tf.nn.relu),\n",
-        "    keras.layers.Dense(10, activation=tf.nn.softmax)\n",
-        "])"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "gut8A_7rCaW6",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "The first layer in this network, `tf.keras.layers.Flatten`, transforms the format of the images from a 2d-array (of 28 by 28 pixels), to a 1d-array of 28 * 28 = 784 pixels. Think of this layer as unstacking rows of pixels in the image and lining them up. This layer has no parameters to learn; it only reformats the data.\n",
-        "\n",
-        "After the pixels are flattened, the network consists of a sequence of two `tf.keras.layers.Dense` layers. These are densely-connected, or fully-connected, neural layers. The first `Dense` layer has 128 nodes (or neurons). The second (and last) layer is a 10-node *softmax* layer—this returns an array of 10 probability scores that sum to 1. Each node contains a score that indicates the probability that the current image belongs to one of the 10 classes.\n",
-        "\n",
-        "### Compile the model\n",
-        "\n",
-        "Before the model is ready for training, it needs a few more settings. These are added during the model's *compile* step:\n",
-        "\n",
-        "* *Loss function* —This measures how accurate the model is during training. We want to minimize this function to \"steer\" the model in the right direction.\n",
-        "* *Optimizer* —This is how the model is updated based on the data it sees and its loss function.\n",
-        "* *Metrics* —Used to monitor the training and testing steps. The following example uses *accuracy*, the fraction of the images that are correctly classified."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "Lhan11blCaW7",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "model.compile(optimizer='adam',\n",
-        "              loss='sparse_categorical_crossentropy',\n",
-        "              metrics=['accuracy'])"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "qKF6uW-BCaW-",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Train the model\n",
-        "\n",
-        "Training the neural network model requires the following steps:\n",
-        "\n",
-        "1. Feed the training data to the model—in this example, the `train_images` and `train_labels` arrays.\n",
-        "2. The model learns to associate images and labels.\n",
-        "3. We ask the model to make predictions about a test set—in this example, the `test_images` array. We verify that the predictions match the labels from the `test_labels` array.\n",
-        "\n",
-        "To start training,  call the `model.fit` method—the model is \"fit\" to the training data:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "xvwvpA64CaW_",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "model.fit(train_images, train_labels, epochs=5)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "W3ZVOhugCaXA",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "As the model trains, the loss and accuracy metrics are displayed. This model reaches an accuracy of about 0.88 (or 88%) on the training data."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "oEw4bZgGCaXB",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Evaluate accuracy\n",
-        "\n",
-        "Next, compare how the model performs on the test dataset:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "VflXLEeECaXC",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "test_loss, test_acc = model.evaluate(test_images, test_labels)\n",
-        "\n",
-        "print('Test accuracy:', test_acc)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "yWfgsmVXCaXG",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "It turns out, the accuracy on the test dataset is a little less than the accuracy on the training dataset. This gap between training accuracy and test accuracy is an example of *overfitting*. Overfitting is when a machine learning model performs worse on new data than on their training data."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "xsoS7CPDCaXH",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Make predictions\n",
-        "\n",
-        "With the model trained, we can use it to make predictions about some images."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "Gl91RPhdCaXI",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "predictions = model.predict(test_images)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "x9Kk1voUCaXJ",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Here, the model has predicted the label for each image in the testing set. Let's take a look at the first prediction:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "3DmJEUinCaXK",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "predictions[0]"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "-hw1hgeSCaXN",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "A prediction is an array of 10 numbers. These describe the \"confidence\" of the model that the image corresponds to each of the 10 different articles of clothing. We can see which label has the highest confidence value:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "qsqenuPnCaXO",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "np.argmax(predictions[0])"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "E51yS7iCCaXO",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "So the model is most confident that this image is an ankle boot, or `class_names[9]`. And we can check the test label to see this is correct:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "Sd7Pgsu6CaXP",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "test_labels[0]"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "ygh2yYC972ne",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "We can graph this to look at the full set of 10 class predictions"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "DvYmmrpIy6Y1",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "def plot_image(i, predictions_array, true_label, img):\n",
-        "  predictions_array, true_label, img = predictions_array[i], true_label[i], img[i]\n",
-        "  plt.grid(False)\n",
-        "  plt.xticks([])\n",
-        "  plt.yticks([])\n",
-        "  \n",
-        "  plt.imshow(img, cmap=plt.cm.binary)\n",
-        "  \n",
-        "  predicted_label = np.argmax(predictions_array)\n",
-        "  if predicted_label == true_label:\n",
-        "    color = 'blue'\n",
-        "  else:\n",
-        "    color = 'red'\n",
-        "  \n",
-        "  plt.xlabel(\"{} {:2.0f}% ({})\".format(class_names[predicted_label],\n",
-        "                                100*np.max(predictions_array),\n",
-        "                                class_names[true_label]),\n",
-        "                                color=color)\n",
-        "\n",
-        "def plot_value_array(i, predictions_array, true_label):\n",
-        "  predictions_array, true_label = predictions_array[i], true_label[i]\n",
-        "  plt.grid(False)\n",
-        "  plt.xticks([])\n",
-        "  plt.yticks([])\n",
-        "  thisplot = plt.bar(range(10), predictions_array, color=\"#777777\")\n",
-        "  plt.ylim([0, 1])\n",
-        "  predicted_label = np.argmax(predictions_array)\n",
-        "  \n",
-        "  thisplot[predicted_label].set_color('red')\n",
-        "  thisplot[true_label].set_color('blue')"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "d4Ov9OFDMmOD",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Let's look at the 0th image, predictions, and prediction array."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "HV5jw-5HwSmO",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "i = 0\n",
-        "plt.figure(figsize=(6,3))\n",
-        "plt.subplot(1,2,1)\n",
-        "plot_image(i, predictions, test_labels, test_images)\n",
-        "plt.subplot(1,2,2)\n",
-        "plot_value_array(i, predictions,  test_labels)\n",
-        "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "Ko-uzOufSCSe",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "i = 12\n",
-        "plt.figure(figsize=(6,3))\n",
-        "plt.subplot(1,2,1)\n",
-        "plot_image(i, predictions, test_labels, test_images)\n",
-        "plt.subplot(1,2,2)\n",
-        "plot_value_array(i, predictions,  test_labels)\n",
-        "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "kgdvGD52CaXR",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Let's plot several images with their predictions. Correct prediction labels are blue and incorrect prediction labels are red. The number gives the percent (out of 100) for the predicted label. Note that it can be wrong even when very confident."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "hQlnbqaw2Qu_",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Plot the first X test images, their predicted label, and the true label\n",
-        "# Color correct predictions in blue, incorrect predictions in red\n",
-        "num_rows = 5\n",
-        "num_cols = 3\n",
-        "num_images = num_rows*num_cols\n",
-        "plt.figure(figsize=(2*2*num_cols, 2*num_rows))\n",
-        "for i in range(num_images):\n",
-        "  plt.subplot(num_rows, 2*num_cols, 2*i+1)\n",
-        "  plot_image(i, predictions, test_labels, test_images)\n",
-        "  plt.subplot(num_rows, 2*num_cols, 2*i+2)\n",
-        "  plot_value_array(i, predictions, test_labels)\n",
-        "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "R32zteKHCaXT",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Finally, use the trained model to make a prediction about a single image."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "yRJ7JU7JCaXT",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Grab an image from the test dataset\n",
-        "img = test_images[0]\n",
-        "\n",
-        "print(img.shape)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "vz3bVp21CaXV",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "`tf.keras` models are optimized to make predictions on a *batch*, or collection, of examples at once. So even though we're using a single image, we need to add it to a list:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "lDFh5yF_CaXW",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Add the image to a batch where it's the only member.\n",
-        "img = (np.expand_dims(img,0))\n",
-        "\n",
-        "print(img.shape)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "EQ5wLTkcCaXY",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Now predict the image:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "o_rzNSdrCaXY",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "predictions_single = model.predict(img)\n",
-        "\n",
-        "print(predictions_single)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "6Ai-cpLjO-3A",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "plot_value_array(0, predictions_single, test_labels)\n",
-        "plt.xticks(range(10), class_names, rotation=45)\n",
-        "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "cU1Y2OAMCaXb",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "`model.predict` returns a list of lists, one for each image in the batch of data. Grab the predictions for our (only) image in the batch:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "2tRmdq_8CaXb",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "prediction_result = np.argmax(predictions_single[0])\n",
-        "print(prediction_result)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "YFc2HbEVCaXd",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "And, as before, the model predicts a label of 9."
-      ]
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "cellView": "form",
+    "colab": {},
+    "colab_type": "code",
+    "id": "_ckMIh7O7s6D"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "cellView": "form",
+    "colab": {},
+    "colab_type": "code",
+    "id": "vasWnqRgy1H4"
+   },
+   "outputs": [],
+   "source": [
+    "#@title MIT License\n",
+    "#\n",
+    "# Copyright (c) 2017 François Chollet\n",
+    "#\n",
+    "# Permission is hereby granted, free of charge, to any person obtaining a\n",
+    "# copy of this software and associated documentation files (the \"Software\"),\n",
+    "# to deal in the Software without restriction, including without limitation\n",
+    "# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n",
+    "# and/or sell copies of the Software, and to permit persons to whom the\n",
+    "# Software is furnished to do so, subject to the following conditions:\n",
+    "#\n",
+    "# The above copyright notice and this permission notice shall be included in\n",
+    "# all copies or substantial portions of the Software.\n",
+    "#\n",
+    "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n",
+    "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n",
+    "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n",
+    "# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n",
+    "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
+    "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
+    "# DEALINGS IN THE SOFTWARE."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "jYysdyb-CaWM"
+   },
+   "source": [
+    "# Train your first neural network: basic classification"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "S5Uhzt6vVIB2"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/basic_classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/keras/basic_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/keras/basic_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "FbVhjPpzn6BM"
+   },
+   "source": [
+    "This guide trains a neural network model to classify images of clothing, like sneakers and shirts. It's okay if you don't understand all the details, this is a fast-paced overview of a complete TensorFlow program with the details explained as we go.\n",
+    "\n",
+    "This guide uses [tf.keras](https://www.tensorflow.org/guide/keras), a high-level API to build and train models in TensorFlow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "dzLKpmZICaWN"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.12.0\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "from __future__ import absolute_import, division, print_function, unicode_literals\n",
+    "\n",
+    "# TensorFlow and tf.keras\n",
+    "import tensorflow as tf\n",
+    "from tensorflow import keras\n",
+    "\n",
+    "# Helper libraries\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "print(tf.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "yR0EdgrLCaWR"
+   },
+   "source": [
+    "## Import the Fashion MNIST dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "DLdCchMdCaWQ"
+   },
+   "source": [
+    "This guide uses the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset which contains 70,000 grayscale images in 10 categories. The images show individual articles of clothing at low resolution (28 by 28 pixels), as seen here:\n",
+    "\n",
+    "<table>\n",
+    "  <tr><td>\n",
+    "    <img src=\"https://tensorflow.org/images/fashion-mnist-sprite.png\"\n",
+    "         alt=\"Fashion MNIST sprite\"  width=\"600\">\n",
+    "  </td></tr>\n",
+    "  <tr><td align=\"center\">\n",
+    "    <b>Figure 1.</b> <a href=\"https://github.com/zalandoresearch/fashion-mnist\">Fashion-MNIST samples</a> (by Zalando, MIT License).<br/>&nbsp;\n",
+    "  </td></tr>\n",
+    "</table>\n",
+    "\n",
+    "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. The MNIST dataset contains images of handwritten digits (0, 1, 2, etc) in an identical format to the articles of clothing we'll use here.\n",
+    "\n",
+    "This guide uses Fashion MNIST for variety, and because it's a slightly more challenging problem than regular MNIST. Both datasets are relatively small and are used to verify that an algorithm works as expected. They're good starting points to test and debug code.\n",
+    "\n",
+    "We will use 60,000 images to train the network and 10,000 images to evaluate how accurately the network learned to classify images. You can access the Fashion MNIST directly from TensorFlow, just import and load the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "7MqDQO0KCaWS"
+   },
+   "outputs": [],
+   "source": [
+    "fashion_mnist = keras.datasets.fashion_mnist\n",
+    "\n",
+    "(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "t9FDsUlxCaWW"
+   },
+   "source": [
+    "Loading the dataset returns four NumPy arrays:\n",
+    "\n",
+    "* The `train_images` and `train_labels` arrays are the *training set*—the data the model uses to learn.\n",
+    "* The model is tested against the *test set*, the `test_images`, and `test_labels` arrays.\n",
+    "\n",
+    "The images are 28x28 NumPy arrays, with pixel values ranging between 0 and 255. The *labels* are an array of integers, ranging from 0 to 9. These correspond to the *class* of clothing the image represents:\n",
+    "\n",
+    "<table>\n",
+    "  <tr>\n",
+    "    <th>Label</th>\n",
+    "    <th>Class</th>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td>0</td>\n",
+    "    <td>T-shirt/top</td>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td>1</td>\n",
+    "    <td>Trouser</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>2</td>\n",
+    "    <td>Pullover</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>3</td>\n",
+    "    <td>Dress</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>4</td>\n",
+    "    <td>Coat</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>5</td>\n",
+    "    <td>Sandal</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>6</td>\n",
+    "    <td>Shirt</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>7</td>\n",
+    "    <td>Sneaker</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>8</td>\n",
+    "    <td>Bag</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>9</td>\n",
+    "    <td>Ankle boot</td>\n",
+    "  </tr>\n",
+    "</table>\n",
+    "\n",
+    "Each image is mapped to a single label. Since the *class names* are not included with the dataset, store them here to use later when plotting the images:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "IjnLH5S2CaWx"
+   },
+   "outputs": [],
+   "source": [
+    "class_names = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',\n",
+    "               'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Brm0b_KACaWX"
+   },
+   "source": [
+    "## Explore the data\n",
+    "\n",
+    "Let's explore the format of the dataset before training the model. The following shows there are 60,000 images in the training set, with each image represented as 28 x 28 pixels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "zW5k_xz1CaWX"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(60000, 28, 28)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train_images.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "cIAcvQqMCaWf"
+   },
+   "source": [
+    "Likewise, there are 60,000 labels in the training set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "TRFYHB2mCaWb"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "60000"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(train_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "YSlYxFuRCaWk"
+   },
+   "source": [
+    "Each label is an integer between 0 and 9:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "XKnCTHz4CaWg"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([9, 0, 0, ..., 3, 0, 5], dtype=uint8)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train_labels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "TMPI88iZpO2T"
+   },
+   "source": [
+    "There are 10,000 images in the test set. Again, each image is represented as 28 x 28 pixels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "2KFnYlcwCaWl"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10000, 28, 28)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_images.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "rd0A0Iu0CaWq"
+   },
+   "source": [
+    "And the test set contains 10,000 images labels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "iJmPr5-ACaWn"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10000"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(test_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ES6uQoLKCaWr"
+   },
+   "source": [
+    "## Preprocess the data\n",
+    "\n",
+    "The data must be preprocessed before training the network. If you inspect the first image in the training set, you will see that the pixel values fall in the range of 0 to 255:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "m4VEw8Ud9Quh"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAATEAAAD4CAYAAACE9dGgAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAdAklEQVR4nO3dfZBc5XXn8e+Z0YxeRqM3JIQQsgVY2Mj2IlgZZEg52CTmpVwRxMYFlcVyQkXsLmxMij8gbLbMVootymtgnThmIwxrUQVmiYGgEJV5kbExdngRQkYSWiwBMhISegVJSBpppvvsH30n9Gjmnntnume6r/h9qK7puaefvo96Zg73Pvfc5zF3R0SkqFoa3QERkVooiYlIoSmJiUihKYmJSKEpiYlIoY0ayZ2122gfQ8dI7lLkI6WLAxzxw1bLe1z4xQ7fvaeU67Uvv3r4CXe/qJb91aqmJGZmFwHfA1qBH7r7bdHrx9DBOXZBLbsUkcALvqLm99i9p8SLT3ws12tbZ2yYWvMOazTk00kzawX+HrgYmAtcaWZz69UxEWkMB8o5/8tiZrPM7BkzW29m68zsW8n2W8zsHTNbnTwuqWrzV2a20cxeN7MLs/ZRy5HY2cBGd38z2fGDwELgtRreU0QazHG6Pd/pZA49wA3uvsrMOoGXzeypJHanu3+3+sXJgdAVwKeBE4Gnzew09/QO1TKwPxPYXPX9lmRbH2a22MxWmtnKbg7XsDsRGSn1OhJz923uvip5vh9YzwB5ospC4EF3P+zubwEbqRwwpaoliQ00eNjvHiZ3X+Lu8919fhuja9idiIwExyl5vgcwtfcgJXksTntfM5sNnAm8kGy6zsxeNbN7zWxysi3XwVG1WpLYFmBW1fcnAVtreD8RaRJlPNcD2NV7kJI8lgz0fmY2HngYuN7d9wF3AacC84BtwO29Lx2geXiDdy1J7CVgjpmdbGbtVM5jl9XwfiLSBBwo4bkeeZhZG5UEdr+7PwLg7tvdveTuZeBuPjxlHPTB0ZCTmLv3ANcBT1A5z33I3dcN9f1EpHkM4kgsZGYG3AOsd/c7qrbPqHrZZcDa5Pky4AozG21mJwNzgBejfdRUJ+buy4HltbyHiDQXB7rrN0XXecBVwBozW51su5lKSda8ZHebgGsA3H2dmT1EpcqhB7g2ujIJI1yxLyLNzwdxqpj5Xu7PMfA4V+rBj7vfCtyadx9KYiLSl0OpQHOlKomJSB+Viv3iUBITkaMYpQHPAJuTkpiI9FEZ2FcSE5GCqtSJKYmJSIGVdSQmIkWlIzERKTTHKBVo5nolMRHpR6eTIlJYjnHEWxvdjdyUxESkj0qxq04nRaTANLAvzcMyfhlrnK2g9bgpYfy9C09LjU144Pma9p31b7NRbakx7z5S275rlfVzidRvhomUtzdKriMxESmwso7ERKSoKgP7xUkNxempiIwIDeyLSOGVVCcmIkWlin0RKbyyrk6KSFFVbgBXEpMmYa3x7SPe0xPGW+bNDePrrxkftz+UHms7EK5Oz6hD8STJbU+uDOM11YJl1aBlfK5YnARq6ZuNCv5s4x9nLo7RrduORKSo3FGxq4gUmanYVUSKy9GRmIgUnAb2RaSwHNOkiCJSXJUl24qTGorTUxEZIVo8V5pIWFNEdp3Y5gsnhfE/+fwvw/ivdp6SGvvd6BPCtj42DDPqDz4fxk/7wTupsZ5Nb8dvnjFnV9bnlqV18uT0YKkUti3t25cerMNUY85HqGLfzDYB+4ES0OPu8+vRKRFprI/akdgX3X1XHd5HRJqAu310jsRE5NhTGdj/6Nx25MCTZubAP7j7kqNfYGaLgcUAYxhX4+5EZPgVa479Wnt6nrufBVwMXGtmXzj6Be6+xN3nu/v8NkbXuDsRGW6VgX3L9chiZrPM7BkzW29m68zsW8n2KWb2lJltSL5OTrabmf2tmW00s1fN7KysfdSUxNx9a/J1B/AoEE9LICKFUKIl1yOHHuAGdz8dWEDlYGcucBOwwt3nACuS76FyQDQneSwG7srawZCTmJl1mFln73Pgy8Daob6fiDSH3or9ehyJufs2d1+VPN8PrAdmAguBpcnLlgKXJs8XAvd5xfPAJDObEe2jljGx6cCjVpl3aRTwgLv/tIb3k2FQ7uqqqf2RMz8I41+bGM/pNaalOzX2i5Z4vrB3fjYrjJf+Xdy3393RmRorv3Ju2Pa4tXGt1oRXtoXxXV+YGcZ3/vv0gq7pGctxTn76jdSY7anPtbpBLBQy1cyqfwmWDDQ2DmBms4EzgReA6e6+DSqJzsyOT142E9hc1WxLsi31Ax/yv9jd3wTOGGp7EWlO7tBdzp3EduWpDzWz8cDDwPXuvs/SJ50cKBCW8KrEQkT6qJxO1u/qpJm1UUlg97v7I8nm7WY2IzkKmwHsSLZvAaoPwU8CtkbvX5zrqCIyYkrJ/ZNZjyxWOeS6B1jv7ndUhZYBi5Lni4DHqrZ/I7lKuQDY23vamUZHYiLSR2+JRZ2cB1wFrDGz1cm2m4HbgIfM7GrgbeDyJLYcuATYCBwE/jRrB0piInKU+p1OuvtzDDzOBXDBAK934NrB7ENJTET60Rz7MrKi5cUyppT54OsLwvg35v48jL/RPS2Mn9S+JzV2+Ykvh235D3H8+6//fhg/8ObE1FhLR/y5vLsgPhJ5Z2H87/bueKqeyavS//RaFm0P2+47kj69UWlF7XfFVK5OfnTunRSRY4ympxaRwtPppIgUVp2vTg47JTER6UeTIopIYbkbPUpiIlJkOp0UkcLSmJgMXlTnNcwW3PhiGP/i+Ndqev+ZwQQEB7w9bPt+qSOMf3vuv4TxnaelT8WTtTjsDzfEU/V8ENSgAbT2xD/TBX/2Smrsq1NeCtt+5+HPpsZa/EDYNi8lMREpLNWJiUjhqU5MRArLHXryT4rYcEpiItKPTidFpLA0JiYihedKYiJSZBrYl8HJmPNrOG344PgwvnvC+DD+bs+kMH5ca/qyap0th8K2s9t2hfGdpfQ6MIDWtvQl4Y54PF/Wf//0P4fxrtPbwnibxUu+nTsmfe2Ly1/7Rti2gzfDeK3cNSYmIoVmlHR1UkSKTGNiIlJYundSRIrNGzpMO2hKYiLSj65OikhhuQb2RaTodDophTFtdHodF8AY6w7j7Ravr7i1e3JqbMOhT4Ztf7svrmG7aPq6MN4d1IK1BvOcQXad14lt74XxLo/ryKJP9bzpcR3Y6jBaH0W6Opl5zGhm95rZDjNbW7Vtipk9ZWYbkq/pv6kiUijulSSW59EM8pz4/gi46KhtNwEr3H0OsCL5XkSOEWW3XI9mkJnE3P1Z4Oi16BcCS5PnS4FL69wvEWkg93yPZjDUMbHp7r4NwN23mVnq4IWZLQYWA4xh3BB3JyIjxTHKBbo6Oew9dfcl7j7f3ee3MXq4dycideA5H81gqElsu5nNAEi+7qhfl0SkoY7Bgf2BLAMWJc8XAY/Vpzsi0hQKdCiWOSZmZj8GzgemmtkW4NvAbcBDZnY18DZw+XB28piXse6ktcZzX3lPeq1W6+S4+uX3J60J4ztLE8L4+6V4nHNS68HU2P6eMWHbPYfi9/7U6G1hfNXB2amxae1xnVfUb4BNR6aG8Tmj3w3j39l+QWps1pijr6P11XPBF1Jj/sK/hm3zapajrDwyk5i7X5kSSv8piEhhOVAu1yeJmdm9wFeAHe7+mWTbLcCfAzuTl93s7suT2F8BVwMl4C/c/YmsfRTnEoSIjAwH3PI9sv2I/nWmAHe6+7zk0ZvA5gJXAJ9O2vzAzOLTEJTERGQA9aoTS6kzTbMQeNDdD7v7W8BG4OysRkpiItJf/oH9qWa2suqxOOcerjOzV5PbGnsHbmcCm6tesyXZFtIN4CJylEGVT+xy9/mD3MFdwN9QSYN/A9wO/BkMOIlZ5vGejsREpL9hLLFw9+3uXnL3MnA3H54ybgFmVb30JCB9WaiEjsSaQcbggo2Kf0xRicXmq08P235pXLw02a+74qP5aaP2h/FoOpwZo/eGbTund4XxrPKOKaPSpxnaXxobth3XcjiMZ/27z2qPl5v7y6fPSo11fmZ32HZCW3DsUY+Lig5ep6uTAzGzGb23LQKXAb0z5CwDHjCzO4ATgTnAi1nvpyQmIgOoW4nFQHWm55vZPCrHcpuAawDcfZ2ZPQS8BvQA17p7PLEbSmIiMpA6VeOn1JneE7z+VuDWwexDSUxE+muSW4ryUBITkb56i10LQklMRPpplgkP81ASE5H+hvHqZL0piYlIP6YjMRkMa2sP4+WuuF4qMnXNkTC+qxQvLTapJZ6Spj1jabMjQZ3YuVPeCtvuzKjlWnXo5DDe2XooNTatJa7zmtUW12qt6ZoVxpcf+EQYv/orT6fGfrzkD8O27T/9dWrMPP555dJEc4XloSQmIkfJPUNFU1ASE5H+dCQmIoVWbnQH8lMSE5G+VCcmIkWnq5MiUmwFSmKaT0xECq1YR2LB0mY2Kq53staMfN0Sx8tdwfxS5czZQkLeHddy1eJ7//D9ML65Z1IYf7c7jmctbVYKpnR5/tDEsO2Ylu4wPm3UvjC+rxzXmUX2l+Pl5KJ50iC77zcetyE19sjePwjbjgSdTopIcTm67UhECk5HYiJSZDqdFJFiUxITkUJTEhORojLX6aSIFJ2uTg5NLesrZtVaeVy201CHFp4dxjdfGteh/cmZ6UvzvdvTGbZ95eDsMD4xmJMLoCNjfcYuT6/f23pkcmoMsmutonUlAY4P6shKHtcFvtMd9y1LVv3clp5gTcw/iuc6m3TfkLo0KEU6Esus2Deze81sh5mtrdp2i5m9Y2ark8clw9tNERlRw7gCeL3lue3oR8BFA2y/093nJY/l9e2WiDSMfzgulvVoBplJzN2fBfaMQF9EpFkcY0diaa4zs1eT083UAQQzW2xmK81sZTfx+ImINAcr53s0g6EmsbuAU4F5wDbg9rQXuvsSd5/v7vPbGD3E3YmIDGxISczdt7t7yd3LwN1AfHlNRIrlWD+dNLMZVd9eBqxNe62IFEzBBvYz68TM7MfA+cBUM9sCfBs438zmUcnFm4Br6tGZqA6sVqNmnBDGu0+eHsb3nD4uNXbwhLgwcN4l68P4N6f/nzC+szQhjLdZ+ue2ufu4sO2Z4zaF8Z/tnRvGd40aH8ajOrNzO9Ln1AJ4v5z+mQOcOOq9MH7jxq+lxqaPi2uxfvjx+IJ7t8cDQq93x0Mne8vp85H9xdxnwraPMi2M10WTJKg8MpOYu185wOZ7hqEvItIsjqUkJiIfLUbzXHnMQ0lMRPpqovGuPLRQiIj0V6erkym3LU4xs6fMbEPydXKy3czsb81sY1KDelaeriqJiUh/9Sux+BH9b1u8CVjh7nOAFcn3ABcDc5LHYir1qJmUxESkn3qVWKTctrgQWJo8XwpcWrX9Pq94Hph0VDnXgJpqTOzwxZ8L48f/1zdTY/MmbAnbzh37XBjvKsdLvkXTwrx2aGbY9mC5PYxvOBKXf+ztiUsNWoNR2B1H4ql4bn8rXh5sxdn/O4z/9daB5gb4UMvY9N/03aW4POOr4+Ml2SD+mV3zsWdTY6e07wjbPn4g/tvZmjFVz/S2vWF8dtvO1Ngfd/42bHsMlFhMd/dtAO6+zcyOT7bPBDZXvW5Lsm1b9GZNlcREpAn4oK5OTjWzlVXfL3H3JUPc80AFl5npVElMRPrLfyS2y93nD/Ldt5vZjOQobAbQe1i8BZhV9bqTgK1Zb6YxMRHpZ5hvO1oGLEqeLwIeq9r+jeQq5QJgb+9pZ0RHYiLSX53GxFJuW7wNeMjMrgbeBi5PXr4cuATYCBwE/jTPPpTERKSvOs5QkXLbIsAFA7zWgWsHuw8lMRHpwyhWxb6SmIj0oySWxuJl2c75Hy+FzS/oXJcaO+jx1CdZdWBZdT+RiaPi5bkOd8cf847ueKqdLKeNfjc1dtmE1WHbZ79/Thj/va7/Esbf+FI8jdCKQ+lTzuzsif/dV7z1pTC+6u1ZYXzB7LdSY5/tfCdsm1Wb19naFcaj6ZEADpTTf1+f74rr50aEkpiIFJqSmIgUVsFmsVASE5H+lMREpMg0KaKIFJpOJ0WkuJpoObY8lMREpD8lsYF1H9/B1qvS19m9ZeLfhe0f2LMgNTZrzNHzrvX18fZdYfyMsb8L45HOlrhm6JMT4pqhxw+cFMZ//v6nwviMtvdTY788eGrY9sFb/mcY/+Zf3hDGP7/8P4bxfbPT5xjo6Yj/UiacsTuM//WZ/xLG262UGnu/FNeBTRl9IIxPao1rA7NEdY2dLenL3AG0fvITqTHbFM+bl4cq9kWk8KxcnCymJCYifWlMTESKTqeTIlJsSmIiUmQ6EhORYlMSE5HCGtxqRw03okmspRvGbU//dB7fNy9sf8rY9LX6dnXH6ys+8cFnw/hJY98L4xNb02t3PhHM5wWwumtSGP/pzk+H8RPHxusvbu+emBrb3d0Rtj0YzGsFcM+dd4Tx27fH61ZeNmVVauyM9rgO7P1yvI7Naxnrde4vj0mNdXk8v9zejDqyzuD3AaDb4z+tVk//O5jUEteg7fvscamx0vba/6SLVieWudqRmc0ys2fMbL2ZrTOzbyXbp5jZU2a2Ifk69FkFRaS5uOd7NIE8S7b1ADe4++nAAuBaM5sL3ASscPc5wIrkexE5Bgzzkm11lZnE3H2bu69Knu8H1lNZWnwhsDR52VLg0uHqpIiMIB/EowkM6gTazGYDZwIvANN7F7ZMVvI9PqXNYmAxQHuHzjhFiqBIA/u5VwA3s/HAw8D17h6PNFdx9yXuPt/d548aHQ8yi0hzsHK+RzPIlcTMrI1KArvf3R9JNm83sxlJfAawY3i6KCIjyinUwH7m6aSZGXAPsN7dq6+3LwMWUVmSfBHwWNZ7tR4p07n5cGq87Ba2/9mu9Clppo/ZH7ad17k5jL9+ML5cv+bQiamxVaM+FrYd29odxie2x1P5dIxK/8wApral/9tPHh3/vyWargbgpa743/afpv08jL/dkz6E8M8HTgvbvnYw/TMHmJyxVN6afentD/a0h20Pl+I/ja6euGRn4uj4Z/q5KelTP73OjLDtzjOC6Y1+FTbNrVkG7fPIMyZ2HnAVsMbMehcxvJlK8nrIzK4G3gYuH54uisiIO5aSmLs/R6X+bSAX1Lc7ItJoRSt21W1HItKXuyZFFJGCK04OUxITkf50OikixeWATidFpNCKk8NGOIl9cIiWX7ySGv7HJ88Lm/+3hf+YGvtFxrJmj78b1/XsOxJPSTNtXPoSXhOCOi2AKW3x8l8TM+qdxli85Nt7Pel3QhxuiaecKaVeeK5493D6ND8AvyrPCePd5dbU2OEgBtn1dXuOTA3jJ47dmxrb35M+TQ/Apv1TwviuvePDeNe4+E/ruVL6UnoXnbAubDt2R/rPrCX+VclNp5MiUmj1vDppZpuA/UAJ6HH3+WY2Bfi/wGxgE/B1d48n9UuR+95JEfmIGJ5ZLL7o7vPcfX7yfd2m8lISE5E+KsWunutRg7pN5aUkJiL9lXM+YKqZrax6LB7g3Rx40sxeror3mcoLGHAqrzw0JiYi/QziKGtX1SlimvPcfWsy5+BTZvb/autdXzoSE5G+6jwm5u5bk687gEeBs6njVF5KYiJylMq9k3keWcysw8w6e58DXwbW8uFUXpBzKq80TXU6ecqN/xrGf/Dq19Lb/ufXw7YXn7A2jK/aF8+b9XZQN/SbYK4xgLaWeArMcW1HwviYjHqp9tb0OcFaMv53Wc6oE+tojfuWNdfZlNHpNXKdrfGcWy01Th3aGvzbX9w7O2w7fVxc+/eJCbvCeI/Hxwefn/hGauzet84N207/u1+nxjZ5XJOYW/0mPJwOPFqZlpBRwAPu/lMze4k6TeXVVElMRJpAHRfPdfc3gTMG2L6bOk3lpSQmIv01ydTTeSiJiUh/xclhSmIi0p+Vm2QpoxyUxESkL6e3kLUQlMREpA+j5luKRpSSmIj0pyQWaAnmkCrHayBOvP/51Nju++Pd/uSrF4bxc25+KYx/ZfZvUmOfat8etm3LODYfk3E9u6MlruXqCn7hsqqZnzs0K4yXMt7hZ++dHsbf7x6bGtt+cELYti2of8sjWsf0UE88z9reQ/F8Y60t8R9518/juc7eei19/ruJy+PfxRGhJCYihaUxMREpOl2dFJECc51OikiBOUpiIlJwxTmbVBITkf5UJyYixXYsJTEzmwXcB5xA5SBzibt/z8xuAf4c2Jm89GZ3X565x4xasOHS8fALYXztw3H7tZycGrPP/VHY9tAJ6bVSAKN3x3Ny7f943H7CG+lzSLUcjhciLP9mfRjP9kENbfeF0XgWtdq0Z8Sn1byH39b8Dg3jDqXinE/mORLrAW5w91XJDI0vm9lTSexOd//u8HVPRBriWDoSS1Yi6V2VZL+ZrQdmDnfHRKSBCpTEBjXHvpnNBs4Ees/NrjOzV83sXjObnNJmce9yTt3Ep00i0gQcKHu+RxPIncTMbDzwMHC9u+8D7gJOBeZROVK7faB27r7E3ee7+/w2RtehyyIyvBy8nO/RBHJdnTSzNioJ7H53fwTA3bdXxe8GHh+WHorIyHIKNbCfeSRmlWVK7gHWu/sdVdtnVL3sMirLMInIscA936MJ5DkSOw+4ClhjZquTbTcDV5rZPCp5exNwzbD0sAD8pTVhPJ7UJduE9BW6MhXn/6fSVJokQeWR5+rkczDg4oTZNWEiUkDNc5SVhyr2RaQvBzQVj4gUmo7ERKS4jr3bjkTko8TBm6QGLA8lMRHpr0mq8fNQEhOR/jQmJiKF5a6rkyJScDoSE5HicrzUmMlLh0JJTET66p2KpyCUxESkvwKVWAxqUkQROfY54GXP9cjDzC4ys9fNbKOZ3VTv/iqJiUhfXr9JEc2sFfh74GJgLpXZb+bWs7s6nRSRfuo4sH82sNHd3wQwsweBhcBr9drBiCax/by362n/ye+qNk0Fdo1kHwahWfvWrP0C9W2o6tm3j9f6Bvt574mn/SdTc758jJmtrPp+ibsvqfp+JrC56vstwDm19rHaiCYxd++znJ+ZrXT3+SPZh7yatW/N2i9Q34aq2frm7hfV8e0Gmouwrpc+NSYmIsNpCzCr6vuTgK313IGSmIgMp5eAOWZ2spm1A1cAy+q5g0YP7C/JfknDNGvfmrVfoL4NVTP3rSbu3mNm1wFPAK3Ave6+rp77MC/QPVIiIkfT6aSIFJqSmIgUWkOS2HDfhlALM9tkZmvMbPVR9S+N6Mu9ZrbDzNZWbZtiZk+Z2Ybk6+Qm6tstZvZO8tmtNrNLGtS3WWb2jJmtN7N1ZvatZHtDP7ugX03xuRXViI+JJbch/Bb4QyqXX18CrnT3ulXw1sLMNgHz3b3hhZFm9gXgA+A+d/9Msu07wB53vy35H8Bkd7+xSfp2C/CBu393pPtzVN9mADPcfZWZdQIvA5cC36SBn13Qr6/TBJ9bUTXiSOzfbkNw9yNA720IchR3fxbYc9TmhcDS5PlSKn8EIy6lb03B3be5+6rk+X5gPZXK8YZ+dkG/pAaNSGID3YbQTD9IB540s5fNbHGjOzOA6e6+DSp/FMDxDe7P0a4zs1eT082GnOpWM7PZwJnACzTRZ3dUv6DJPrciaUQSG/bbEGp0nrufReWu+2uT0ybJ5y7gVGAesA24vZGdMbPxwMPA9e6+r5F9qTZAv5rqcyuaRiSxYb8NoRbuvjX5ugN4lMrpbzPZnoyt9I6x7Ghwf/6Nu29395JXFi28mwZ+dmbWRiVR3O/ujySbG/7ZDdSvZvrciqgRSWzYb0MYKjPrSAZcMbMO4MvA2rjViFsGLEqeLwIea2Bf+uhNEInLaNBnZ2YG3AOsd/c7qkIN/ezS+tUsn1tRNaRiP7mE/L/48DaEW0e8EwMws1OoHH1B5ZasBxrZNzP7MXA+lalatgPfBv4JeAj4GPA2cLm7j/gAe0rfzqdySuTAJuCa3jGoEe7b7wG/BNYAvTP33Uxl/Klhn13Qrytpgs+tqHTbkYgUmir2RaTQlMREpNCUxESk0JTERKTQlMREpNCUxESk0JTERKTQ/j/oNQwZhzrgvQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure()\n",
+    "plt.imshow(train_images[0])\n",
+    "plt.colorbar()\n",
+    "plt.grid(False)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Wz7l27Lz9S1P"
+   },
+   "source": [
+    "We scale these values to a range of 0 to 1 before feeding to the neural network model. For this, we divide the values by 255. It's important that the *training set* and the *testing set* are preprocessed in the same way:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "bW5WzIPlCaWv"
+   },
+   "outputs": [],
+   "source": [
+    "train_images = train_images / 255.0\n",
+    "\n",
+    "test_images = test_images / 255.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Ee638AlnCaWz"
+   },
+   "source": [
+    "Display the first 25 images from the *training set* and display the class name below each image. Verify that the data is in the correct format and we're ready to build and train the network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "oZTImqg_CaW1"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAj0AAAI8CAYAAAAazRqkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAgAElEQVR4nOydd5xVxdnHf6MxEUFQqlQRrEEJIMWCil2Mxt5rfNUUjZqiMSb6Rt/EGkuMUROM0cRGVIhixQKCIkoRKaJIVUTAFRBR7Of9Y+8Ov3m4Zzi77N29u+f3/Xz48Jw7c+eee2bm3LNPdUmSQAghhBCisbNBfZ+AEEIIIURdoIceIYQQQuQCPfQIIYQQIhfooUcIIYQQuUAPPUIIIYTIBXroEUIIIUQu+FZ1Ordu3Trp2rVriU5FFGP+/PmoqKhwtT1uuczlZ5995uV33nnHy5tvvnnQb5NNNvGyc66obMdbvny5l7/zne8E/bbYYgsvb7jhhtU97RozadKkiiRJ2tT2uPU1n1999VVwXFFR4eVWrVp5eaONNlrvz/r000+9zPMMhOvFrolS0Rj25ueff+7lVatWBW0rVqzwMu8Rnlcg3Jtp+w8APv74Yy9vsMGav7dbtmwZ9GvTpta3RyZKsTfL5T5bSr788ksv18Y+rw1ic1mth56uXbti4sSJtXNWIhN9+/Ytybi1MZec46mmPzQzZ8708rnnnuvlY489NujXu3dvL3/729/28re+FS7hGTNmeHn48OFe7tatW9Dvoosu8vJmm21W3dOuMc65BaUYt7725tKlS4Pju+66y8unnnqql/khs6ZMmTLFy2+++WbQdtRRR3m5rm685bw3szJv3jwvv/DCC0HbI4884mV+MDnllFOCfn369PEyz8vDDz8c9Hv22We93LRpUy+ffPLJQb+zzz4707nXNqXYm3n4zVy0aJGXO3ToUI9nsobYXMq8JYQQQohcUC1Nj8gfMW1OmnbntddeC46HDh3qZfvXH6vNWb1+ySWXBP2WLVuW8YzXsO2223r59ddfD9quuuoqL7MW4sADDwz6/fKXv/TyTjvtVO1zaIzwPD366KNB27/+9S8vP/DAA162JgvW1rFmxppY2Pzy7rvvevnwww8P+vE6OuaYY+JfIGc8+eSTXr7xxhuDtiZNmnj5iy++CNo23nhjL8+fP9/Lxx9/fNBvyZIlXmZTjtXCtm/f3sstWrTw8kMPPRT0u+mmm7y83377efnmm2+GSGefffbxsjUttm7d2stDhgzxclbTG2tzAGDvvff28urVq73cpUuXoN/TTz/tZdbu1SfS9AghhBAiF+ihRwghhBC5QA89QgghhMgF8ukRUWJRWStXrvQyR+pY/xn2C2rWrFnQxj4FHHZsw8g5NPqjjz7yMofL2vfFzr1///5e5jDbcePGBf1Gjx7t5YEDBwZt99xzT+r4jRmeQ/bNAICrr77ay3/84x+9bKOt2A+E/XZsJN2mm27qZfbvOPjgg4N+1hco78yZM8fL9913n5etXxr7Y3zzzTdBG4eVd+7c2cvNmzdP/Vzec3YP8/vYj8v6/uy6665eXrhwoZfZvw4Arr/++tTzyCM8f5w6AgDee+89L/MasPfjo48+2st8f/v666+DfuzvxXuW0xIA5ePHw0jTI4QQQohcoIceIYQQQuSCRmXeYjMKkG7esCq4F1980cuDBw/OND6r+6x6Niv2fJm6yiq7PhxxxBFe5mzK7dq1C/rxd7Fq0rRsyLYfXyvOCGv7pb0nBpvYWG0LhOc+duzYoI0TK+6www6ZPquxwaYpIFR1n3POOV7+y1/+EvTjDNkx89bOO+/s5R/+8Ide5hBqoP6y+JYrbPqJXRs2idgs17w3+R631VZbBf3YxMlj2HuYXSvFxgbCDL8cUj19+vSg32OPPeblQw45pOjYeYITSHLSSSC8Z3L6j8WLFwf9eJ+ym8LUqVODfuyKwPNls3WXI9L0CCGEECIX6KFHCCGEELmgUZm3bPQBq2dnz57t5TvuuCPox+YN9ja3pg6O+ImZtNisYs+J22JjxMw29cWkSZOCYzZpccZPW4SS4WgRIIwqiEWS8LXia8MRJhbOMGvrMXFUUKdOnYp+jsV+Fq+jvEaS8HUEwqiRLbfc0sv2+vC8f/DBB162GWJ5XfHYdo1lNWXmhdNPP93LnIXZmrrYFG3N/mk1zDibNhDOH2OjvGykZRo8Phc95X0KyKRl6d69u5fHjx8ftPFvoS2+nAbvRWva5xpbfN/mosDlijQ9QgghhMgFeugRQgghRC7QQ48QQgghckGj8umJhUM///zzXn7mmWeCfpxtlMMqrX1y5MiRXj7rrLO8HAvRTgvJBsIsstZfJKv9uy4ZNWpUcMzXikNV7Xdh/xxrT7722mu9zFWYeU6AsMov97O+P+yHwD49NmPv5MmTvczVm63PA4dj2u/FFePz6tMTW98ffvhhahv76nCVe7vn2Pcnlm27IaR4qEvY/5AzHD/yyCNBvwEDBnjZ+knxXHA4tPXp4T3DfpB2LnkvcZj70qVLU75F6C/C2b7F2nDaDHtf5P3Bfqt2Lm1oehXWv5V96HheY9m6ywVpeoQQQgiRC/TQI4QQQohc0KjMW1ZVx0yYMMHLNpsrqwJZPuCAA4J+r732mpcvuugiL/ft2zfoxwXdbKbeV199teg57bbbbkG/KpV0OYWuP/TQQ8Exmxv4utmwb1Zz2wKVbCZk86ENjz/jjDO8/Le//c3LPXr0CPqxmY2vXdu2bYN+P//5z7186623eplVtXY8WzyPi2jOmjXLy9tuuy3yQiwLOq8Pu445FLkmn2XNWbE0CXnnvPPO8/JNN90UtHFaAWva5fXO5vaYCYPnwY7HbTGTCBcU5gz5DcF0Up/EUm/w/mOzP7sKAEDv3r29zNfbpguw5rMq7P29HJGmRwghhBC5QA89QgghhMgFDd68FVN5c5TWxIkTvWzVpJ988omX2UzBMgD069fPy1tvvbWXbWTQuHHjvDxs2LCgjdWOHGExZMiQoF+Vqa6cMlxyATogjLBi9WlaYUEgVF1bDjzwQC83a9YsaOPinn/605+8zEVPAWDEiBFeZnU6q22BMHqL58Reb47YstFb/P1ffvllL+fJvGXXPs89R3xY8xZfS26LZVZOM0MDaxfLzDu89nl9v/TSS0G/3/72t6ljsEmLoyJtVnXOaM9zaftx5GaaecS2HXrooan9RAibqmw2bd5XbHa2/dhdgE2Qdr7YjMV7Pjav5YI0PUIIIYTIBXroEUIIIUQu0EOPEEIIIXJBg/DpqWkF5UsvvdTL77//fmo/9uOIVaN98cUXvcw+QtaXqE+fPl7eZpttgjYe/5ZbbvHy3Llzg35V2X5tFeu6Ztq0aV62IahpIcnWf4Nt+5zZ1TJjxgwv22vP88d+CHZtsI2a29jnxsK2cM78DMSzALMvw5gxY7x82mmnpX5WYyNW7Zxla+uvST/2TbH9yim1QzlgQ5arsCHK3bp18/K8efOCNvbJ4vuQ9W3jfjwv1i+Pq7HH5rJLly5Fz13E4fuzTcuy/fbbe5nny94/bcqOKmI+QrweYmljygVpeoQQQgiRC/TQI4QQQohc0CDMWzUtJrj55pt7mc0jbJYAwpA7Vu/ZcFxWC7LJxp4fm8E4fB0I1YJLlizx8kEHHZTyLeqXa665xss2BJUztsbCvvm6WTUpmwm5QOWyZcuCfjwvfN3sePxZnHnUZgAeOnSol5cvX+5luzb4fbaNz8lmkM4L1jTBYc5scoqZrWJFS9P2vjV/iprB82Dvd2y24HukNbnzPuP9FzN1xObcZk8X2eDCvZa0AqGxEHPee9aMzce8z/k3t1yRpkcIIYQQuUAPPUIIIYTIBXroEUIIIUQuaBA+PTWFfUti/gXsq8F20VatWgX9OAyQ7d027C+Wip3fx3bthQsXFv8S9QxXf2dfGgCYPXu2l7m8hPXp4bB9G+46YMAAL/P1sP34mOfPhlimhTjbkGYuRcJlI7gkif0sO88dOnTw8uGHH448EvMJ4Gtu5zO2H9NgPwLr02PXplgDX187Dx07dvTy1KlTU9/H19uOwSVAuM2WBuH7LPv+VFRUBP1sRe8qrF9JWli+CK9vdWA/HpatDxZfe74v2hJP5Yg0PUIIIYTIBXroEUIIIUQuaBD6QWtWYLUrq91syCVn12X1rA2l5JBL7sch2UBowmHTlzXn8Hg2K+nKlSu9vNNOO3nZmlWqQrnru8r6T3/606IyEIZ6v/32216+7bbbgn6jR4/2ss3IzNdgs8028zJfQ6Bm1XtjmX5Z/cvz2rNnz6DffffdV+3PbezwvFuzIV9zVo/XtPoym0vYvGHV97xP2KxSUzV/XujatauX7VzyHuQ533LLLYN+bOrgtBM2fJn78T3Y3t9ltlp/sqZ5sf3S9q/tx/uZ2+xvZjkiTY8QQgghcoEeeoQQQgiRCxqEHtGq1lgNy+YtzrILhFmYuRibjajiMdjM9M477wT9OPsvZyi16liOKLKfxZEK55xzjpenTJkS9KtS5de02GpdwOrr/v37e9lG1jz//PNetnPJ15GvvY3UsBEjVdjrk1YIjz8HCOeSzSEcrSaKw/Nr57qmavUqYqZsxppiWrRo4WWZtLLDGbRjWZLToieB9Ogta97igqPWFYGxpm1RfbL+bth+fN+NRb/yPLO8dOnSap1nfSBNjxBCCCFygR56hBBCCJEL9NAjhBBCiFzQIHx6rH9HWvXeHXfcMThmfwP2s7H2SbZls03S+gZwuDWfk80KzL4p1q7duXNnL3M49IUXXhj022WXXQCUVwigtf/y9+Y5sf4aXJU5du1j/iBpoZQ1Jc1XhMPmLTG7dm2cU0OBv6u9JnX1udZHS6ST5g8HhH4b7PcIhHs6Vj2b9wy/x/oztmvXzsvs31NO97jGQk19etJC0WO+P+wfyVULyhVpeoQQQgiRC/TQI4QQQohcUGvmLVZ/xYoJcj9Wi2VVwcYYPHhwcMzZkLnYXSwkklW81qzGoZlpJjYgPN9YoUUu8Mcht+WKNeHw/DHdu3cPjrkIXVZTZdZMoVmJZeFmYvNg13IsxLcxEzNpxUKba/M9sbmIFdjMI7HrwRniOesyEN4zOdOyhe+ZnBmbM50D6XvdzqVNFVKFMjVnJ2beihVRThsja9oYmbeEEEIIIcoEPfQIIYQQIhfUWF8Yi8KpbTXkmDFjguOHH37Yyy+++KKXObsoEBYF5WgPq6rj8+Ux7HfkMdjUZceLRSOwWYX7DRs2LOh36KGHpo5RLqQVfmW1OBBG0fF1A0ITGUeDWbVrWiRB1gy+sQKVPEZeTVbVIbb20+bJXleep6wRYDF1Ox/zHlN25riJj01TPXr0CNq6dOniZd4v9pouWbLEy2zCsoVJ+X1sVmvfvn3Q77333ks9X5HOrFmzvGzN91mL/8burWn9+PeTKw6UK9L0CCGEECIX6KFHCCGEELlADz1CCCGEyAU1dr7J6vuwbNmy4HjRokVeZhskvw6EPi7cDwh9RNg+aX1pOMyyQ4cOXrY2afYlYfu0rSDNdm2uxv3xxx8H/caOHetla0/nkGj2Zxk/fjwaGmmh4/Y7xzIXx7J+pvWrDZs0nxP7lMT8H/KUdTlG7BpnTS2QNWNsTd6fNexdhPcqm2qCfXL4nskZ1oHw/rdixQovWx9L9vex93uG78GcIb9t27ZBP6UmCJk5c6aXO3XqFLTxteffMQvfC2N7jPvx7+TixYuDfuPGjfMy/2bWJ1opQgghhMgFeugRQgghRC6osXnr5ZdfDo4vu+wyL3MxOVZ3AunZV22hRzafWXUqq9NYBWdDpVmdNnToUC/369cv6Mfhk6zGjWWX5GzKq1atCtpYtWhNbqxa5MKkDSGTZU1hVbad57Rw5ZjZpCbY97NpkdtsxmixNrVRZDSrWTPNXGbnic9Jc5hu+nn33XeDfm+88YaXu3XrFrRxhmZ2Fdh6662Dfnwfmzt3rpdtkVK+z8bgTPpclPmCCy4I+smkFfLcc8952ZqWeT3EzIJZzdNphUnt2rjtttu8LPOWEEIIIUQdooceIYQQQuSCapu3qtTI559/fvA6mzBiBTfTshVztmMgNFVZsxXDRe0WLFgQtF188cVFx2CVGxBmBGXz1j777BP04+iGt99+28u2GB+bTqyqndWCfJ1sZEJDIGs0UyzSjzOH8lqJmbdiKti0NpuhlE2kMbMJo+itSmKZltPMVrGIqth1rUnUHt8TuNhtnkgz/Tz99NPB8Xe/+10v22zpfO343tqxY8eg35tvvullXg82gohdAtq1a+dle/9ksxhnZ+Z7LgBss802EGvgCGBbFYHva1mjsmLwXuR1YyOeOXqrXJCmRwghhBC5QA89QgghhMgFeugRQgghRC6olk9PRUUF7r77bgBr+89wuCOHMNpsxdZ+W4X1pWC7vLUNs0159erVXmY7MQCcdtppXv7vf//rZVvBfN68eUXPfdKkSUG/UaNGeTktIyUQ+idZXxKG7a62X1Voaez9DYW0DNpA6AMQC6VM87th/ynbj+fI+o1Ym3cVNsWCWBvOYG7nM81fwL6+vv5Rdv54POubItbAfjUA0LNnTy/bueR7j/W5ZNL84GJ7mH0nbRg9+xKl+RUB8umxcNoTmy4gayh67J6ZBq8b/j0GwgzNvIbsb2ZdIk2PEEIIIXKBHnqEEEIIkQuqZd7aaKONfGi1NTmxGYtVV126dEntx2pym62zZcuWXubCd3YMVpPaQqJsOjniiCO8vNNOOwX9WC3I5jerguNswmxWsWG7XNzNmqfSwrKt+r+qyGpMrdxQyFqctiYq2DQzlR0jZl7hubTq2bT35JlY+GtN1ONZic11WoZtEZrvOT0HEJoCORMyEM4z7+HYHomlK0m7l9nCpGwSYVcGzvQvwozZQHh9bAoUvvZpVRGAcM9mTSHCYx9wwAFBv//85z9eZneR+szOLE2PEEIIIXKBHnqEEEIIkQuqbd6qMmtZ1WXnzp29zBFQViXJJqI2bdoUlYFQtWrVotzG6llb+JNV7a1atfIyF9kDQrUum+OsBzx/Fp+vVbuzqt22sWqY1bgtWrQI+k2ZMgVAWKC0oZI1y2dWc0hW80Usmy+3seq+MVzvUhOLKExTj8eyKdcEu1Z4z/H9R4TRUfa+zfdSO698v+P7GLslWNjkYu99aUVht9pqq6AfZ17m93BELwAsW7bMy+wOkRdee+211LbY705sX/Kc83qIZV7nvffWW28F/Xj+Zs6c6WWZt4QQQgghSoweeoQQQgiRC/TQI4QQQohcUC2fnk022QS9evUCEIaAA8A///lPL3fo0MHLXJkcCMPK2QfH2pPZBmltyGwP5vFsZlC2O3JYpA3bZBsn2y7teOyPlBaib/uxDITh7GwL5bBSYE12aZtxuJyoSUhyTX070vx4Yv5CsZD1tGr3Wf2P8gzv1Vim69oOHec5sz4GvE/mzJnj5d69e9fqOTRE+D5m9x/fF60/G993+b5lrz3fP/m+aP1K+D7J1dP79u0b9BszZoyX+V5t78fsP5RHn57HHnssOG7durWX7e8GzxnPl/WD5T3L19v240zZPM/sp2o/d9q0aUW+Rd0jTY8QQgghcoEeeoQQQgiRC6pl3mIuueSS4LjK7AUAf/rTn7xszTYc6s2mH5uVk9WwNmQ9LfQxlnU3FprJprTYeAy32XNnFS+HVQKhapFVgVz4DwBOPvlkAMBNN92Ueg71TdYMyqwaj2VzZWxobZppw6rr7fvSzo/PncfLai7LM4sWLUpt4/lIC18HsmduTitCa/cmq9hZzS/CLPP23sf34+nTpwdtvFc5pYYdg699zGWBXRG48On3v//9oB//LvAYNgNxWqHTvMBmXCD83bFmprT0LbbfiBEjvHzIIYd4uUmTJkE/NoXaTN5p/WbMmJHary6RpkcIIYQQuUAPPUIIIYTIBXroEUIIIUQuqLZPT5WN3droDz744KLy888/H/RjXyCubm5TjLPN3vpZcChlLESWK82y34CtEM+2ZrZPZg1fZp8VIPTxsT4n+++/v5d32GEHL9dnWu66xF4P9qfh+bP9+DjNz8OOwVi/kbTQeYWsrxveLzadBF9nvpZ2XrL6UXHoLfez886+JFxKRoSlgOy6Z/+OFStWBG18vTkNifXV4XI9TZs2Tf2sNKxPCI/H64nHBoD333/fy9ttt12mz2pMsM8NAIwePdrLdr/xfomV2knzz4mVWor143vFTjvtlPq5dYk0PUIIIYTIBXroEUIIIUQuqLZ5Ky0kOI199tknOB4/fnzRfm+++WZwzCpZW+184cKFXt5yyy29bM1MNhu0qF2yhnCzapwrKAOhOpTXll1nrFLnNnsOfJy1MjSjkPV1079/fy/PmjUraGMTCau2Lax+53nKeo3ZtAGEayKPpo4YXHXeptewYeAMV9zme6sNFed7NYfA22r33I9lG3qdlprArg0O0c4jZ511VnB89tlne9mat9iMaTNqM2m/7zYNBO9zXhsrV64M+vHx+eefn/q5dYk0PUIIIYTIBXroEUIIIUQuqHFG5tpm++23jx4zO+64Y6lPR9QirAq1hevY7MSZY62ZiSNBspqqYoVEOYKPM89aVXvaOQDVN/U2FthEcuqppwZto0aN8nJFRYWXramDTSSxoro8bzyfXbt2DfqxGd2acPIOm5S32mqroI1NWBZe7xzxY82WHHl63333edmawfbdd9+iY9t9xfcLnstu3boF/fbee+/Uc88jnOXaZvhnbIFsZunSpUVft5mbed3wHrUmx6efftrL7IpSn+Tzri2EEEKI3KGHHiGEEELkAj30CCGEECIXlI1Pj2h4ZK2y3qdPHy/36NEjaOOKyjFfHbb7c9bQWPX0tHB4IPQjYR8CDse25NWHx8LX2Pp3DB48uOh7li1bFhyzjwBnY7fzucUWWxSVs4bDK80AcOutt3rZZszlfXXccccFbezfxv4Y7777btCP/YT69u2b6ZyOOuqo1LZjjjkm0xgihDMe25D1sWPHennmzJlethUTdt9996Jjn3vuucEx+/7wuuFqDOWK7uJCCCGEyAV66BFCCCFELnBpBRqLdnbuAwALSnc6oghbJknSZt3dqofmst7QfDYeNJeNi1qfT81lvZE6l9V66BFCCCGEaKjIvCWEEEKIXKCHHiGEEELkgrJ46HHOHeGcS5xz6bUnwv7znXOti7y+qlj/yDjV6h8Z53TnXId192zcOOdaOeemFP4tds69R8ffXsd7BznnHktpu8M5992Utgucc5uY137jnDvJOXd42vvEutF85hvn3NeFuZ7hnHvdOfcL51xZ/GbkGe3L9aNcFvAJAF4EcHx9n0gNOR1A7h96kiT5MEmSXkmS9AJwO4Abq46TJPliPcY9M0mSN+zrzrkNAVwAwBZbOgDASACHA2gwm7Hc0HzmntWFue4BYH8ABwP4X9vJOad8b3WI9uX6Ue8PPc65ZgB2B/A/oIeewhPpaOfcQ865N51z9zqTacw518Q595Rz7qwi417onJvgnJvqnLs88vnXO+cmO+eec861KbzWyzk3vvDe4c65zdNed84dDaAvgHsLT9pNauXCNGKcc3vRXyavOec2LTQ1KzbfhXXQtyCvcs5d4Zx7BcBvUfmwOco5N6rQ3hzAtwFsA+AHAK4rfE73yLyOds7d5Jwb55yb7pxLz1Ao1kLz2fhJkmQpgLMBnOsqOd0596BzbgQqf/iK3nOdc02dc48XNEXTnXPHFV6/2jn3RqHvn+rtizVitC9TSJKkXv8BOBnAPwryOAB9CvIgAB8B6ITKh7OXAQwstM0H0BXAswBOpbFWFf4/AMDfAbjCex8DsGeRz04AnFSQLwNwS0GeCmCvgnwFgJvW8fpoAH3r+1qW0z8Avwfwq5S2EQB2L8jNUJkZPDbf/voW5uxYGms+gNZ0fCSAKwryXQCOprbY/A0pyHsCmF7f16/c/mk+8/ev6n5qXlsOoB0qtdsLAbQsvF70ngvgqKq5KPRrAaAlgLewJnp4s/r+rg31n/Zl9f/Vu6YHlaatBwryA4XjKl5NkmRhkiTfAJiCygedKh4B8M8kSf5VZMwDCv9eAzAZwPaofCK1fANgaEG+B8BA51wLVG7CFwqv3w1gz7TXM39LwbwE4Abn3HmovKZfFV6PzXcVXwN4ODL2QQCetC9mmL/7ASBJkjEAmjvnNoPIiuYzP7C2/ZkkSarqi6Tdc6cB2M85d41zbo8kST4CsBLAZwDucM4dCeDTOjv7fKF9WYR6fehxzrUCsA8qF/98ABcCOK5K3Qbgc+r+NcJaYS8BGEx9g6EBXJWssXNunSTJPzKckpIWlQDn3DmkZu2QJMnVAM4E0ATAeLfGgT0231V8liTJ15GP6w/g1Rqcpp17rYUUNJ/5xDnXDZXzWFV46RNuRpF7bpIkswDsjMqHn6ucc5cVfnz7o/JH9XAAT9Xdt2i8aF9mo741PUcD+FeSJFsmSdI1SZLOAOYBGJjhvZcB+BDArUXangZwhqv0F4JzrqNzrm2RfhsUzgEATgTwYuEvkeXOuT0Kr58C4IW01wvyxwCq7KXCkCTJX+lmuMg51z1JkmlJklwDYCIq/yqsKf7aO+d6AHiTNqtvW8f8AUCVr8FAAB8V+osiaD7zh6v0d7wdlS4AxX6oit5zXWVU66dJktwD4E8A+hT6tEiS5AlUOsj2qptv0bjRvsxGfXvdnwDgavPaw6h8ABm6dve1uADAnc65a5MkuajqxSRJRjrndgDwckERtAqVvkNLzfs/AdDDOTcJlXbOqnKxpwG43VWG6M0F8MN1vH5X4fXVAHZNkmR1hnPPMxc45/ZG5V8Zb6BSTbprDcf6O4AnnXPvA3gc4V+NDwAYUlDvHo30+QMqN+o4AM0BnFHDc8krms/GSRPn3BQAGwH4CsC/AdxQrGPknrs1Kp1cvwHwJYCfoPIH8hHn3Mao1BD9vNRfJKdoXxZBZShEo8E59wwqHdvfr+b7RqPSGXBiSU5M1AjNpxDlR0Pfl/Wt6RGi1kiSZP/6PgdRe2g+hSg/Gvq+lKZHCCGEELmgvh2ZhRBCCCHqBD30CCGEECIX6HAiZLQAACAASURBVKFHCCGEELlADz1CCCGEyAXVit5q3bp10rVr1xKdSjpfffVVcLxy5UovV1RUeHnDDTcM+m288cZe3mCDNc93drxPPlmTWLRp06Ze7tixY9CPx6gr5s+fj4qKimJZp9eL+prLvDNp0qSKJEna1Pa45TifH3/8sZe/853vBG3f/va3M43x+edrksd++umaagWbb775ep7d+qO92bgoxd7UXNYPsbms1kNP165dMXFi9ULsbXRY8aoRcZYuDXMKPv/8814eMmSIlzfbLCzjscMOO3iZb7rLly8P+r388ste3mWXXbx85ZVXBv2aNMlWQJ2/c02+L9O3b9/1en8aNZlLsf445xaUYtzamM+0SM6aruEXXliTiLV79+5BW6dOnTKNMW/ePC/z9zvmmGNqdE61ifZm46IUe1NzWT/E5rIkeXqy/uizlubPf/5z0Pbss896+bPPPgvaWBvzxRdfeHnChAlBv2HDhhX93I022ig4Zo3OK6+84uXddtst6NeyZUsv77XXXl7+2c9+FvQrh79ChaguvG9jWs2FCxd6+c477wzarr/+ei+zRrY24HM65ZRTgrZrrrnGy+eff36m8b755pvU8YUQjRPtciGEEELkAj30CCGEECIX6KFHCCGEELmgzmtvzZkzx8uHHHKIl7fYYougHzslWx8cjtJiB2XrWLhq1ap1vgcI/YI++OADL9soL44keeaZZ7z80ksvBf1+9KMfefnII4+EEOVIVp+W3r17B8dvv/22l3lPAMAmm2ziZd7T1i+P/d54r7//fljDcPXq1V7mQAI73q9+9SsvcwDCvvvuG/S77777vGy/L18P+fekYx3e065bzJ8zVv6oJo7z48aNC47ZH/Ott97y8rbbbrven9WYqe1ghqycfPLJXv7FL34RtPXp08fLfL+xv+NZ0c4WQgghRC7QQ48QQgghckFJzFsxVdhvfvMbL7dv397LNsybTUt2vG99a81pszqOzVlAqP5imc1ZQJickE1p/DlAmOyQVbp2vL/+9a9ePuCAA4K2Zs2aQYj6ImtY+q677url6dOnB23t2rXzsl37vFe5ze6lxYsXe5lNWjYXFicxZJMW70V7zPeO+++/P+jHCQ7/+9//Bm18PWoz11aeyHqtanJNR48eHRxPmzbNy2xyBYBLLrnEyzyXI0eODPrV1ERSjmRds7F+fMz9subb+/LLL4Nj/j3l+Tr66KODfrNmzfKy/R3nfVobe1GaHiGEEELkAj30CCGEECIXlDx6y0ZjsFq7efPmXrZqMVaHs0oaCM1RX3/9tZdt7S0+ZtW1jfzg8blfLGqMzVRW1c7n9+ijjwZtJ554IoSoL2Lq4eHDh3t5/PjxXu7cuXPQj027dt/y+GkyEO59Vp3biLI0c5zdwzw+79suXboE/Z5++mkvP/nkk0Hb4MGDU883D2Q1YdjX7X03jX/9619e5nI/Y8eODfrdfPPNXu7QoYOXX3/99aAfR2JxhA8A3HTTTV7u1atXpvNr6KSZpmL9+PfTwnvRRjKzGZr72d/MMWPGePmII47wsq29t/3223uZ3UMsdvyaIE2PEEIIIXKBHnqEEEIIkQv00COEEEKIXFByn57ly5cHx+zTw7Zgm9mV/WyszZhDYdPCTIHQ1sh2TGufZGJ2UfYz4szNrVu3Tj0/rhYPyKdH1D0xvzeGs4fzmv7444+DfrFs6ezjE9tz3JY1+3GsX9p9wIbU87kffPDBQRv7H3I2aXvuNvxerGHmzJletteNQ84nTpzo5WXLlgX9TjvtNC/vtddeXrZ+OzwGy0DoMzJ79mwvb7311tHzbyxk9UmL3Q+4LeZLw3vv3XffDdp4j2266aZetr5E119/vZc7duwYtNV2+ghpeoQQQgiRC/TQI4QQQohcUHI97dSpU4NjVnmyqcuGqvKxDQnnMMbu3bt7uWvXrkE/Ln7IIXZNmzYN+rHqjs1snEESAEaMGFF0vBUrVgT9OKMkh68LUR+kqbAPO+yw4JhNP5ySYf78+an9rMkpTQ0eC42tCfZzWe3N39feV/ieYO8rbH45/vjji47XmMlqOrApRLjYJ5sFW7RoEfQ744wzvHzjjTd62ZozuODk0qVLU8+Pw5wnT54ctHFBaJ7nvJi3shYTtixZssTLbHb88MMPg36TJk0q+h5r0mzZsqWXeW189NFHQT9bLLyUSNMjhBBCiFyghx4hhBBC5IKSm7dYTQwAe+yxh5fvvfdeL9uihlwwjtWYMazadfXq1UVla3Li7K5s+rKRVldddZWX+/Xr52U20wGhCn3u3LmZzl2Iuubll19ObbPRlExMVR7LwszEMsZmIWuhRHuuHF1mszpPmDDBy3zfykt2ZmuC5GvH1yBW2Jnv47ZA6N/+9jcvP/XUU14+8MADU8+pbdu2qW1s+mIzCgC89957Xr7zzju9vPvuuwf9dtxxx9TxGzKxuZwzZ46XL7jggqAfu2pwtNWMGTOCfuxi8sYbb3h50KBBQT82XfI9xRZ6jUVUZyWrCV2aHiGEEELkAj30CCGEECIX6KFHCCGEELmg5D49F110UXDMtsW9997by7179w76rVy50svWp4dt9lytuVWrVkG/tMyx1kbP43EonfUz4nBH9kfi8F57HtZ2mXdqWv03zb+gptlyOaQzazinhf1D+HMbig8Ip10AwuzFsevIcxjLyMxjxOztsRDztPUSCyPnNWHD0tmvwKauuO+++7zMGWLzQiwNAGPXDc/R888/7+WTTz456Hf77bev7ykGcBg1/14AwM477+xlzs5sfdVsKHZjIZZBmdO83HXXXUGb/Q2tLm3atAmO2W+O/aeOO+64oB/7CMXu/dwWq5gQQ5oeIYQQQuQCPfQIIYQQIheU3LxlwxGfe+45Lz/88MNeHjlyZNCPi87deuutQRuboLiYnA2lTDODsAoeCNWfrEqz6lkO4bv66qu9bE1Ym2++uZeHDRsWtHH2UhtmmQeymn6s6jLtfVlVmnYN/eEPf/DyokWLMo1hiamQy5XXX3/dy1w0Fwgz6LJamveHbbPmo7TiptZsxW2xMPe0YoOx4sK8Jmw/LoBs923eC4lm3Zt8HwSAPffcs6hs4bQhvG6ypjaw/bhALN9zgdDtYfDgwUXfAwALFixI/ew8YM1ZvI94L2e917HLChD+xvMcvfDCC0G/X//6117OWgTVktVUKU2PEEIIIXKBHnqEEEIIkQv00COEEEKIXFByI/bFF18cfiDZzTlMbYcddgj6Pfroo16+4oorUsdnW6O10af5DVjbfZq/jy1XwSHwAwYM8DJXjwVCu6at6ptHP54YaTb7rP4VHGYMAFOmTPHygw8+6GXre8KhlSeccIKX77///kyfC4Qh3tdee62Xf/e732Ueo67htW79bBj2j7OhzDxnNmUAt/H41reG/QV4/FjIesyen9bPhr/y/cJ+r4ULF6aOL9LJOpcMt9W0ij37pNm0IWnr0Pp95t2PK+Y7GfPj4X3P1/DUU08N+vE9mD+LfXGB0N/LpkRguOTFOeecE7RxyYsY0vQIIYQQIhfooUcIIYQQuaDkur0jjjgiOOaQ9UmTJnmZwwoB4Ac/+IGXuZouAHTp0sXLrFq1oeisMotlhGX1HFdIt+q9jz/+2Msc6njjjTcG/bjNVhrmzNM2C3VjJRZ2mhau+vbbbwfHrCbl6uA21UG3bt283KlTJy/bMNv58+d7+Yknnkg79SgPPPCAl1955ZUajVHXTJ482ctsngPSQ8JtyDqrn60JOE0lbuc5LcO2NTnxvo1l4k7b3/Z1vifY7LFsIuH5ZFO2WJs085R9nddN7H4cu18wvPbuvvvuoO2QQw7x8oknnuhlawaLmVLyQE2zx6dlsefrDoRh6lzBnVMKAOFzQefOnYM2+wxRBaefAEJXB66YYJGmRwghhBC5QA89QgghhMgFJTdvzZw5Mzhm8xFHPe2yyy5Bv5deesnL06ZNC9pYJReLEEjL9BorepkWiWDPl1WmvXr1CvpttdVWXraquu222y71s8uRWGFONo9YEwgTU6GyyvOSSy7x8tChQ4N+XByyffv2Xu7fv3/Qj02cn376qZdt0dr33nvPy5deemnq+bFp1Z7TL37xCy+/+eabXmazLRAWP6xveO3bfcDmiKwZWO0Y/D7O3GxNHWlmq9jeZOya4kKSnFnaRuuwWcx+Rx7jpptu8nJ1IvrKnayZzktNLMIurZ+FswlbV4GJEyd6+Uc/+pGX58yZE/Tbbbfd1n2yjYys5sPYvSLruuHfP3YPWbZsWdDv0EMPTR2jXbt2XuY9a7M/8+9CDGl6hBBCCJEL9NAjhBBCiFyghx4hhBBC5IKS+/RYGyrbb999910v26zGsdBxDjtkW6PNrpnmnxOr5Mx+IPZz2b+Dz8/6DbC/CPusAMDixYu9zOHV5UTMlsvE/HgYDkfkqrtAGGbI2ap79OgR9OO5/eijj7y8cuXKoB+HoLIfENv4gXC9cXjjddddlzreTjvtFLSxDwj7r9jw+HLChuwyaVWV7Tzzmoj5YzAx37usxMLoeZ/x/rZh+ZxV3Z4Tj8nz2ZioLx+eGFkzMnO2dQD43ve+52XOqg4Ajz32mJeffvppL9v1YH0u80BN1kBaiPq6eP31173cs2dPL9tq95z+w97TL7vsMi/zb+3+++9fo3OSpkcIIYQQuUAPPUIIIYTIBSU3b1nzCBd+ZJOFNQmwmcmq1lgtzep1+1lp4da2X1qRPKsK5bbWrVsjDQ7Hs5ljFy1a5OVyNW+x+jOr6vnmm2/28m233Ra0LVmyxMtWnbzjjjt6mdcDvyd2fjFTJc+rzb5rVahV2BDW4cOHp57HH/7wBy//9a9/9fKWW24Z9LvnnntSx6hrrrzySi9b8y0fs+nOhpdyqHDWEPPagPe6NW/xOuVzt1na2bzH9xggNFn/97//9XK5hHk3JnguY/eYa665xst2Hf74xz/28r///e+gjdfowQcf7GXOxA5kN9HnhbRwdvs7llbM2+4VLgLOv/HVuW/88Y9/9DL/Bh9zzDGZx2Ck6RFCCCFELtBDjxBCCCFyQcnNWzZCIs38wIXJgLAwYMy8FVM1Z83InKbWtyo9/lzOEskmOyBU/dkxOCtlucBFKAHgmWee8fJbb73lZRvRwqY6/l4cIQOEhT858goIr7dtY9j0wNc0Zqpk04ZdQxyVxfNnC4dylk9bXLNjx45e3nbbbb1szSZDhgxBuTB37lwvs+oZCOeCTbvWXMffry7NW0xsD/NatOatWDZ3Nrl07dq16HtE7cD3SGty+v3vf+9l3utt27YN+nEk6DbbbBO08bzzfaohmrN4rfOaje09e7+rafRV2vvT9kTfvn2DY86azFF0MaxbCe9LvhfFXExiSNMjhBBCiFyghx4hhBBC5AI99AghhBAiF5Tcp8fCNlq2C9qMzNYvIo00HyH7WWwLtbZ8Ps5a/Zf9IWKh8rEs0fXJ0qVLccsttwAAhg0bFrSxP1UsCy7bzTn7sb0enEXTzhH76rAvkPWF4rXCvkX2s9gvheeBv5Mdg23IXKEbCNeD9TtjPxIev9z8tjhDOJ+ntYmnZSO3c5aW6RxID3m1YcnWbp8Gj89jxEJj2TfMrln237LzxHv1nXfeyXR+5YK9r2RNNVHbn83zYueY9/rMmTO9fOGFFwb92D+Os/Zff/31Qb+YrxVnb2Y/tl133TX1PaUmlvogVvm8JilEapuYT9CRRx7pZc66DAD//Oc/i77H/gbz+Pbez76UvXv3XvfJrgNpeoQQQgiRC/TQI4QQQohcUHLzVtZwT2s6sCouJi27sjUlpYW2x86Jx7AqY/4sNhPYEG02sVjKpZBhq1atcMoppwAA+vXrF7S99NJLXp4+fbqXFyxYEPRj88Dy5cu9bMOE+ZpatSYXca2oqPByzKTCanP7WWlhnLbQJpvj2ARi1ce8VmxqAj4PVt3bUPDvf//7Xr722muLnl8pGTt2bNHXYyYnNm/Z782Zca35KE0VnzW1RE3ha85za9cRm1rtPYa/Z20USK1LYmaPWGhzbVz7NJcA3hNAaGa94YYbvLzPPvsE/ThtxIMPPlijc+LvFTunuiSWPb4m8/Dmm28Gx3feeaeXrcnQZqSvImZm4t8qew/43e9+5+UPPvjAy9ZVIo2YuSyWoqZ79+6p78uaPkOaHiGEEELkAj30CCGEECIX1Hn0VlZYtWZVt2kZKmMq6Zj6MK3gqDVTrFixwsts3rLZQDlywKr/6yuDbTGqzoWLfgLAgAEDiva3Zrt58+Z5efbs2V62GVY5I6o176XNpVVxcgFBLlzHrwOhqZEjsawJktXcMZU3m3xic8eRUGxeAeo/o68tLFqFXd9p2V553QOhuSBmUk7bV/aYzy92jflz7TVNM8fZ785mWGu+tt+lsVDb6y8WhRQzs3Gm5Q4dOnh56tSpQb+hQ4eu5xmGa4/N5nWdkTlJEm+Cj2WP57XHpiMAuOOOO7xso5wZvh8/8sgjQRtn1k87B3uOvI84ig4IzY5PPPFE6jnx7yRnwY+Z1XiPAuH6GjhwYOpnybwlhBBCCEHooUcIIYQQuUAPPUIIIYTIBSU3YrP/BRCGjMZ8cNgWaO3ybDeOhb6lZby0tr+08PiYPw6fe5cuXYJ+EydO9LL1myiXjMwbbrih93Ox1cPff/99L8fspC1btvTyoEGDvGz9dtJ8SoB0Pw27NnjMtPB1IAxh5/fwugPCMMtYVW4+d7tOOIMxr3PrG2KrlNc1e+21V9HXra9Hmo+BnQu+JjG/IB7fXjs+Zlu/vf5p4dB2PD6nWMZoHr++stuWgpifDftkLVmyJOjHe533cIysPkL/+7//GxzzmmI/nuHDh2caL5bGJJb5nn166hrnXPT+V4zJkycHxzxnsXskV6HnVCAAMGLECC8feuih0fMtxgknnBAcH3TQQV6OhZHz3s7K4sWLg2P2kdxtt92qPZ5Fmh4hhBBC5AI99AghhBAiF5TEvMUmh1gWyubNm6eOwWroWCgpjx9TjWcNhY2ZztLU9V27dg368XnE1Ovlgg2xtsdpsAkyZjZg05INe0+7HtYMmFYUNvY+ni9rZu3YsaOXeW1YFXrse6WtG3v9ODy3Pnj88ceLvm7Nt3zM5r927dql9rP7Km3t22vHZrE0kxgQXuNYP563WGbltDkrdtyQiJmc3njjDS/b0GO+B9sizzXJXsxZl8eNGxe0sbk5LUt4jJg5Nta3PovHrlq1CmPGjCl6HkcffbSXec2yydHCaThsFQM2Jdl70Pnnn+/lmHmLOeyww7w8Y8aMoM2GxNcmXDAYyL4OFbIuhBBCCEHooUcIIYQQuaAk5q1YcU9Wf7OJwRLLvpqm1rTqrbSILfv+tMyx9nPZzMYRPzYjc8y8VU4ZmdcXVqfGvPStGlbULU899VTR163ZmE1OvL5vu+22oN9JJ53kZWue5MKuvPatKY3bYns97T02QpCPWT1uI9e4aK7N0p2GjXiy5r5SUHWfyBopFYveqo2Il6ycddZZXp41a1bQ9thjj63X2LHM/BZeK7YwZ13y+eefY+7cuQCAH/3oR0HbpZde6mXeN2witG0cCWZNlfy+WNHOiy66yMtnnnlm0O/Xv/61l0eNGuXl/fbbL+hnM+HXJta8Z10T0si6V6TpEUIIIUQu0EOPEEIIIXKBHnqEEEIIkQtKnpHZ2tnYthgL5c2aVTUtpLXY+6rIWiU4ZjNmv4EePXoEbbHK743Jp0c0DDhNANvHbYhy2n454ogjguPzzjvPy/fdd1/Qxr5Ay5Yt83L79u1Tz4mxfhu8N9mfwWbY5vcNGDDAyxyqCwAvvPBC0bGLfXYVjz76aHDMfiulorqV0WP9+Z5z8MEHB23sB3LxxRcHbSeeeGKmz77iiiu8zP5jF1xwQdBvp512yjRebcC/C7Zqd13SqlUrnH766QCAv//970EbpxLgc7T7kCur87rnTNsA0Lp1ay9bnzdeA9ddd11RGQDatGnjZfbTvPzyy5EG/8bF0ghkxX6vrL53WT9bmh4hhBBC5AI99AghhBAiF9S5eYvVbLFCjBw+yyo3IFTRx7KophVNjBU65fOzKvi0Apax0Ht7frGieUKUAt6DbH7Kqja2XH311UXlGFbdzufBe87eL/iYw95j2dyzEssmzRlyuVgjUHrz1scff4zRo0cDWDvUn+99XPDXZuDl+yd/F5YBYPbs2V6+/vrrgzYOU+ZiliNHjgz6/fnPf/YyFy3NujZqSsykx/d4WxS3vrCZ+8ePH+9lLlptiyhzygT+XhzKDoS/V7FrwylEYteGzWox02R1TbHA2r+tbEqzGZnTUkTYe4pd22lI0yOEEEKIXKCHHiGEEELkAj30CCGEECIXlMSnJ638gyWWXpptftZ2x6GrH374oZdtWv2s4ecM20yt38Ann3ziZU6VbW2JfO7Wh8faa4UoNf/4xz+8PGzYMC/zegZqP/SUsXskq/29tmG/Cq4kD4Q+TnzP2X333Ut+XswXX3yB+fPnA4D/v4qlS5d6mf2i+J4IhH4bfB/s3Llz0O/kk0/2cs+ePYO2Z5991stcMX3atGlBv4EDB3qZ/YKsPxLfF0vtZ8M+IgceeGBJPysrv/nNb4Lj+++/38tcUsL+VvHvJP8m2WvIvjX2d4f91Xh869/Ka8qmo2DW914R+z22v/dpPj0x39wY0vQIIYQQIhfooUcIIYQQuaAk5i3OhmlVnFlNTkcffbSXV65cGbRxCDt/Vix8nfvFqrGzqs6ay1q0aOHlvn37pn4Wq5rtOfF5CFEXsNmGq4zb6tu8z7Jm440RSxPBx7GQ17Q2q1Ln41gI/EEHHeTlO+64I2jjNBTf//73vcyVp+sCzuKbFTbzA8DChQu9zJmx+XUgvFa8NoDQpMVrw2Z15rVizWdMXYaOs3nrhhtu8DJXNq9rbNg3X3vOZH3ZZZcF/SZMmOBl+1tY2+yxxx5e3nvvvUv2OTGTGK87IL1yQ01C5QFpeoQQQgiRE/TQI4QQQohcUBLz1urVq70cU2vbwmKM9XRvSLDazX7/2HcWotTEMr9y5IY1gzAc9WUzATOswq7taLAYbEK2JupevXqltrF569xzzy3R2ZWGVq1aRY/zBkfpNYS5ZLMry5ZZs2Z5edKkSUHb1KlTvcyFZIHQxMm/T7aawO233170c61LyPru55ip86KLLgqOt9tuu6L9rOtMVqTpEUIIIUQu0EOPEEIIIXKBHnqEEEIIkQtK4tPD1X+33XbboI1DGgcMGJA6RiycvaahanUFh3DOmzcvaNt5553r+nSE8PC+uu6664I23rft27dPHaNcqlanEbs/cLoLDmsGwu9Vlz5IorT83//9X32fQq3Bv6f2t/WEE04o2efW9m9ubLz99tsv0xixFDUxtLOFEEIIkQv00COEEEKIXOCyFuIEAOfcBwAWrLOjqE22TJKkzbq7VQ/NZb2h+Ww8aC4bF7U+n5rLeiN1Lqv10COEEEII0VCReUsIIYQQuUAPPUIIIYTIBWX70OOc+9o5N8U5N90596BzbpN19L/LOXd0QR7tnEsvgy7qHOfcb51zM5xzUwvzmp6voPpjD3LOPVZb44k42puNl1Ls0yxzrnVRGjSfa1O2Dz0AVidJ0itJkh0BfAHgx/V9QlU452qWICCnOOd2BXAIgD5JkvQEsB+Ad+v3rCpxzpUkV1UjR3uzEVLO+1RUH81nccr5oYcZC2Br51xX59z0qhedc79yzv0+9kbn3AnOuWmFv0qvKbz2E+fctdTndOfcXwryyc65VwtPxX+ruok651Y5565wzr0CYNcSfMfGTHsAFUmSfA4ASZJUJEmyyDk33zl3uXNucmGOtgcA51xT59ydzrkJzrnXnHOHFV7v6pwbW+g/2Tm3m/0g51y/wnu6RcY5vaChGAFgZN1dhkaJ9mbjIW2fXlbYQ9Odc393hcxyhb/mrynMySzn3B6F15s45x4oaBeGAvBZIJ1ztznnJha0D5fXx5fMEZrPIpT9Q0/hL/HBAKbV4L0dAFwDYB8AvQD0c84dDuAhAEdS1+MADHXO7VCQd0+SpBeArwGcVOjTFMD0JEkGJEnyYk2/T04ZCaBzYSPd6pzbi9oqkiTpA+A2AL8qvPZbAM8nSdIPwN4ArnPONQWwFMD+hf7HAbiZP6TwEHQ7gMOSJJkbGQeo/HE8LUmSfUrxhfOA9majI22f3pIkSb+CZq8JKrUHVXwrSZL+AC4A8L+F134C4NOCduGPADgN/W+TJOkLoCeAvZxzPUv5hXKO5rMI5fzQ08Q5NwXARADvAPhHDcboB2B0kiQfJEnyFYB7AeyZJMkHAOY653ZxzrUCsB2AlwDsi8oJnVD47H0BdCuM9TWAh9frG+WUJElWofK6ng3gA1T+iJ1eaB5W+H8SgK4F+QAAFxfmYDSAjQF0AbARgCHOuWkAHgTwXfqYHQD8HcChSZK8s45xAOCZJEmW1dqXzBfam42QyD7d2zn3SmHf7QOgB72t2P7dE8A9hTGnAphK/Y91zk0G8FphHN7DohbRfBannP0ZVhf+ovM4575C+KC28TrGiBUMGQrgWABvAhieJElSUPPdnSTJb4r0/yxJkq8znLcoQuHajQYwurDZTis0fV74/2usWY8OwFFJkrzFYxTMJUsAfA+V6+Azan4fleuhN4BF6xhnAIBP1vtL5RftzUZKkX36I1T+Fd83SZJ3C3uQ57bY/gWAtRLAOee2QqU2t1+SJMudc3dh3etErAeaz7UpZ01PMZYAaOuca+Wc+w5CtVwxXkGlyq11wf5/AoAXCm3DABxeeG1o4bXnABztnGsLAM65ls65LWv7S+QN59x2zrlt6KVeiGcpfRrAz8jW3LvwegsA7ydJ8g2AUwCw0+oKAN8HcKVzbtA6xhG1j/ZmAydln1b9wVDhnGsG4OgMQ41BwfTonNsRlT+yANAclX9s9IsQxAAAIABJREFUfOSca4dK06goEZrP4pSzpmctkiT50jl3BSpvmPNQ+ZdgrP/7zrnfABiFyr8sn0iS5JFC23Ln3BsAvpskyauF195wzv0OwEjn3AYAvgRwDpRGfH1pBuAvzrnNAHwFYDYqVa5pP4z/B+AmAFMLDyzzC31vBfCwc+4YVM5poK1JkmSJc+5QAE86586IjCNqGe3NRkHaPl2BSr+t+QAmZBjnNgD/dM5NBTAFQNUcvu6cew3ADABzUWm2FKVD81kElaEQQgghRC5oaOYtIYQQQogaoYceIYQQQuQCPfQIIYQQIhfooUcIIYQQuUAPPUIIIYTIBXroEUIIIUQuqFaentatWyddu3YtyYl88803wfF7773n5U8+CZPntmrVystt2rQpyfkAwPLly4PjiooKLzdv3tzL7dq1K9k5zJ8/HxUVFbHstTWilHNZaj77bE0i5pUrVwZtG264Jl/hBhuseaZv1qxZ0G+jjTYq0dnFmTRpUkWSJLW+aBvyfDZUtDcbF6XYm5rL+iE2l9V66OnatSsmTpxYO2dlsA82l156qZfHjRsXtJ166qle/ulPf1qS8wGABx98MDi+4447vDx48JrkkxdccEHJzqFv374lGbeUc1lq3nprTVWJp556Kmhr2bKllzfeeE1G9N12Cwuyd+zYcb3Pg3NcFZI+rxPnXEmS6TXk+WyoaG82LkqxNzWX9UNsLmXeEkIIIUQuqNcyFD/+8Y+9/MILLwRtbO6y5iPWAt18881e7ty5c9Bvm23WlB1p0aKFl5ctC4trsybpiy++8LI1nbRv397Lt912m5dHjBgR9BsyZIiXu3XrBpGNrJqTn/zkJ15+9dVXg7avvvrKy59//jnSOPPMM738+uuve/nTTz8N+u25555evv7664O2Jk2aePnrr9fUu2QTmxBCiPJBmh4hhBBC5AI99AghhBAiF+ihRwghhBC5oM59ep5//nkvz5s3z8u9e/cO+rE/jQ1n/973vuflDz74wMtz5swJ+nFEGEdaTJ06Nej3rW+tuQytW7dOPaelS5d6eauttvLyihUrgn6//OUvvTx8+HCIbGT16Vm8eLGXN99886CNfbK+/e1ve9nO0T333ONlDoG3oewzZszwMq8TIPQn489lXx8hhBDlgzQ9QgghhMgFeugRQgghRC6oc/PWM88842XOVGnDi9nM8OWXXwZtbIJikwObR4AwjJjNFNb8wNl6N910Uy9zVmgA2GSTTYp+VqdOnYJ+bJp78cUXg7aBAwdCFIfNmJxNGQjNR++8846XmzZtGvTjkHU2b9qMzGwWYzMrm8SAcJ5//vOfp567PV8hhBDlh+7UQgghhMgFeugRQgghRC6oc/PWokWLvMxFO2PmLTZT2b5sjrAmDDaJMDZjLpujOCMvm7Ps+GzOsOfHkUcyb8Vh85GN0mM46o/NVmyOjI1h1wKPwevJmlJ79uxZ9D1AGEW2xRZbpJ6DTF9CCFEe6G4shBBCiFyghx4hhBBC5AI99AghhBAiF5Tcp8f6N7D/DFc+ZxkIs+Ra2O+C/WlWrVoV9OPwZfb9sX4bfI78Hnvu/L6NN9449fzYp2fWrFmp/UR4rWy4ODNhwgQvs//MZpttFvR76623io5t/bM4kzfDfmYAcNhhh3l55MiRQdvOO+9c9Jxs6gQhhBDlgTQ9QgghhMgFeugRQgghRC4ouXmLs90Coclo9erVXrZmBc6Ya81RH3/8sZc5I7MNS2YzA5vLrPmBw+PZvGX7sbmEw5Ct6YSxWZ1FSNYio6NGjSr6ujVv7b///l6eO3du6ths3urVq5eXp0yZEvTjNXXUUUcFbVtuuWXRc7IpEUR25s+fHxwvXLjQy0r3IIRYX6TpEUIIIUQu0EOPEEIIIXJByc1b77//fnD8ne98x8tsIrKmJDYd2IzHnIWX32ejt9hsxZ/FrwOh+YyLkVozBUcXtW/f3ss2Uy+fR6tWrYI2Nqu0adMGeYfnlk2VFjZVcdbs8ePHB/1atmzpZV4bNjpw0KBBXmYTygknnBD0u/LKK1PPKatpTsR58MEHvXzppZcGbQcddJCX2ZS54447lvSc7rnnHi9vu+22QVv//v1L+tlCiNIhTY8QQgghcoEeeoQQQgiRC/TQI4QQQohcUHKfng8//DA4Zl+Yjz76yMtjxowJ+p100kle7tChQ9DGfkJcIZv9cYD0DL/Wd4T7cci67de2bVsvsy+JraK9ww47eJkzUAPAm2++6WX59KSHd48dOzY4Xrp0qZfZn8Our+XLl3uZ0x7YDMycQXn27Nle5rkT1YdTUvC+sKkbzjvvvKJt3bp1C/pNnTrVy2effbaXx40bl+l8rJ/fnXfe6eWKioqgjVNoNGvWzMv2/tNYiaXoiHHzzTd7uU+fPl7m+yUQ3jP53tezZ8+gX8eOHTN9blauuuoqL/fo0SNo+8EPflCrnyXKH2l6hBBCCJEL9NAjhBBCiFxQcvOWNStwNmXOsmv7TZo0yct77rln0MYqbw5jteYsVrVzmLrN3MwmLc7cbEPROYyeszC/8sorQT8eo1OnTkHb66+/7uU99tgDeSdNhc4hw0Coeuf5sikB2MSZlmnb9mOOOeaY4PgXv/iFl2+44YbUc1f4eiVpxVaXLVsWHHNh2K5du3o5ZhLhe4RdH3vvvbeXH3vsMS8PHz486McmLLv/TjvtNC+XOiS+HLGpQdJSSDz77LPB8fHHH+9lNlvZa8/Zzvn+eeuttwb92MTZr18/L3OBXyA0RdtM3s8995yXFyxY4GWef0DmrazYfc1rgOere/fuqe8rl/uiND1CCCGEyAV66BFCCCFELtBDjxBCCCFyQcl9es4888zgmKtgr1ixwssc9giEoaUc5g0AG2+8sZfZj8f66nDILJeasPZJHoNtzex/BACvvvqqlzl1vvX14BDc22+/PWjjMhx5xPoNpIWsjxw5Mjhm3x2+vlySAgjnOS1lAbB2qHsVp5xySur5HXbYYUHbI4884uVysVfXFuwPZ79b7LumzedOO+0UHHO5kBkzZniZ0wwAoR8Hz9nPfvazoB/7zn3ve9/z8i9/+cugH/vqcPoMS5oPGbB2GZuGBM8rEN4jrQ/PzJkzvcz3Oy7bAgBPPPGEl3n+7HXq0qVL0c+yJWL4+N133/XyhAkTgn7sP2TP/dhjj/UypziZNWsWGiu14T/D5X6uuOIKL7PfHQC88MILXj700EO9zD6Q63Meadxyyy1e7tWrV9A2cODATGNI0yOEEEKIXKCHHiGEEELkgpKbtywc9j1s2LDUfqyGttl5WZWdFiJrYbWuVfGyyaV58+ZetiYQ7sfq+T/84Q+ZzkHE1Z2cisCGoG611VZe5izcbOoEgM6dO3uZVbU2y6vNol0Fr08AeOmll7zMWcIbAzFTR9r1qS2uu+46L++7775eZpMhEGZGZvNIu3btgn6s9t5rr73W+/x4nTYEc5a9D/Ixy2nmRwB46qmnguMbb7zRy+eee66XbdbsNJPRkiVLgmO+pmyWbtq0adCP1yWnlrDrldeGTTXB65dNZJyxHVjbVFeOpP3GVcfszGZ/Nic/+uijQT82BTLTpk0LjjnUn6+p/a2uSVoWTlcDAD/96U+Lnsfhhx8e9JN5SwghhBCC0EOPEEIIIXJByc1bVjWXZmayKmSO9mA1JhCq8XgMG2XBHv0xdT2/j8fmSC4gVJPGsBFKTEy9nAdi88ARW3Y9cNQbq2rtnHOBSTaD2aKRnN2XP+udd94J+l166aWp53v66ad7+a677krtV1dU7bWYmpv3Y2wuFi9e7OV///vfQduTTz7p5eeff77a5wkAAwYM8DJH2vDYQLiH08weQBhdFDNv8d7kgsdAuHY4c++iRYuCflURSjZysD6x91meW75unAkbALbbbjsvX3755UEbR9Bydno2NQPAySefXO3z5cjdp59+OmjjzM1sorZmMM7+azP6s2mN58neV+rCvFU1N7GCrrE9W5MIKHsfu+SSS7zM64FNxkAYpcUuHJtuumnQj81iXBXBZuHmagUcgWvngSO07bnvvvvuXma3h+nTp6MmSNMjhBBCiFyghx4hhBBC5AI99AghhBAiF5Tcp8faI9mnJeZTYP14GM60yxXNbVZOtt+n+QHZ8+DxrA05luE3bbzGlqm3JvA8WJ8m9rvhrNw22yb7InDmbTsn1vZcRevWrYPjOXPmFD0/TlkAhL46Npx99OjRXubK3occckjRc6gr7PrOugYvuOACL3P2cXtNOESVw0mBtStmZ+Fvf/ubl++///6gja8x2/NttvS7777by+x7xxnggdCHY+XKlUEb+4fxvcT6H2yzzTYAQh+guiIt6669l/L88XxxaD8A7LPPPl5+/PHHgza+3uy3w/5TlrRraGE/kOOOOy5o42P22/jrX/8a9HvmmWe8zH5+QOiHxfcLm/G7Lqiap6z70O5fXmcVFRVetr4vy5Yt8/Lbb78dtHEqD85Yzv5TQHgv5L1sr9t+++1X9Nzt/Zj3G+9LWz2BfTY50zYQ+mQdfPDBXrYpEdjvLIY0PUIIIYTIBXroEUIIIUQuqPOMzAyr0qwqlNWVto3Vzaz6s2GsbKri91j1IY/PoapWVbftttsW+RZrUxuF3xoTsTB9zmbN6k9WfwOhejbN1AWsbZLMck68HqyZgNcUm+KAMBs0F120ZpMTTzwx0zmtL9VVo1t69Ojh5XvvvdfLVeacKrbeemsv2xDViy++2Ms2HDYN3pusegdCFTtffw5jBYDevXt7mdNd2EKJ/fv3Lzqehe8JNjN727ZtAWRfazWhak1mzbp72223BcdsmuJ5HTRoUNCPTUS27cUXX/QymxVi90E+v1iIdtZ7JJu8beoA/v2w5k7eg3wvsW4TNpVFKbG/O2lh2mymAsLUCmzqsaZ8Ni3aa//d737Xy2PGjPEyh5EDYabzqnUOrH1P46oIjDUx8X7mNAV27/DvuE0FwSkSuBgtm3CB0PQXQ5oeIYQQQuQCPfQIIYQQIhfUq3krxnvvvedlGz3BZivGqtbSCgVaE0aaKS0W5cVe6VbVl7UIamMldt0sHB3Famib/ZojiNh8MXv27KAfR6qwacNG2mQtIsnmTqtO5siXmkQt1SZJknhTn1UPs0o4Zko466yzvMxRVNbscdlll3l5l112Cdo4uy6PZ+dz/PjxXuasu3Zv9+zZ08v9+vXzslWPs6mKo+wmTpwY9OPzYHU7EJpQeQ3brL1Vpp5Smq6rW/DV3oPY3MdmD2uq5MLO9nv26dOnaBtH2liyZpyPXTteQ0OGDPHyQQcdFPTjQqc2OpOz6fP6t+dXavPWsmXLcM899wAITb8AcMYZZ3iZI5ZstCSboPh7WlMdZ6W2EVBsMuPIWLse+H7HRWbtb1pa5ntbjcAWeK1i6dKlwTGbpuy9mT9r8uTJXrZFqbMiTY8QQgghcoEeeoQQQgiRC/TQI4QQQohcUK8+PTG77ssvv+xla+PjMGW2vVtbM9snuc3adbkf+wrYCt7cj22S1p7O59SYq6pnzQ7LjBgxIjhmXwH26eFrDYQhkxyeakOceW0sWLDAy9bWzJ/F5xvLItutW7fg+B//+Edq37rm888/91mmbdVqnqdYpXL2EWDfGhuWzv1sWoezzz7by+xHYDPm8vu233774Hsw7McxYcIEL3fs2BFpcIjvHnvsEbRNnTrVy/vuu2/QxmuR9z5XIgfWrJdySkdhw3fTfClsFltOu2AzjnOIOGcwj8HX7f333w/aeF7YZ9P6YvLnPvzww162KRA4S7D18eLfDF5r1t8ttt9rg+bNm2Pw4MFFP4vnLGvFcPYrtPfIefPmedl+Fu8rfp8dg++TPJc8d/Z9fP+0v9W879lXyc4X31Ni+4p/x+1anjRpUur7GGl6hBBCCJEL9NAjhBBCiFxQr+atmBmEQ5Fj5ig2Z1jzVlooeszkxGp9Dnu043FWYA7tBMpL7V1KavI9OdwZCMPKOXzShjjzvHCoImeNBcJssby+Ro0aFfTj9cBmHmuGSTuHGLFMtKVigw028CpiNhcB4TXhLLA2NJbVxRxOa8NaWY1+/vnnB22HH364l3lfxAoMcnFEa2KZNm2al9kkac1gPD7PoS28yGOMHTs2aGNTKZsBbSbgqky1pTKNrFq1yq/rYcOGBW3t27f3Mn8Xe69ikxGvW2vS5HDgmTNnBm28jjmc/6mnngr6pRUZtWarNDOyNXXw+uX32HvCG2+84WW7b/mYTS42VPp//ud/UEqcc/7zjz/++KDNHq8v/J3tbyvvF74e9l6Vdo+zv5k8Bsv1+dtns3KnIU2PEEIIIXKBHnqEEEIIkQvq3LyVVtzRRkpxdklrtooVtWPSTF9WLc1jpBWiBEI1Hpu3LNXNptoYiBXt5KibKVOmBG2cOZT72YKjXHSOC15alSZn7OSIgIEDBwb9OCMwrxMbjcRrjTO7xqgPFe8GG2zgTRccGQOEUVQcBdeyZcugH0f88LxYswJndOVCiUBo0mLTFEfaAGEUCmfFtaYkVrdzpJE1b/Exr0WbmZajU+x8Ll682Mux4o1VpqRS7fMmTZr4TMl2LvmYC6FyoUggNIPxNbSFIzkTrr2mbPria8BFgoHQRM3RUfaezvB49vryuuE5svPF+yxmluZim/Z6nnrqqanvqw023HBDb0a2156PeV1aUxL/XsX6MfYexHPL+8iOYX/zqrBzlPa7a1/n8Vi2a43XSux78RjWZM4FUmPk79dZCCGEELlEDz1CCCGEyAV66BFCCCFELqhzn540W6C1d3JlWRtmyKG27NNhs0HaLLxVWFsznxO/x9pF+X22ujfDtv76CF+uTdJsskD4PWP+Db/+9a+9zPZkILwe3GZt7xymzv1stly233MINmdnBsLq0hzGbe3J7ONj/VLKCfYdsHPB+yWWwZz9bHj/2Qr1HCps1wTvVQ51t3suzQfH+nJx+DL7JrHPChDOIX8v6zvAfiHWp4l9Xzj7L48NrPEVK1W29Q033NBfh+OOOy7Te+y9jr8Lh47bueRrb+/BvPbZZ8bew7haPY9nK5jzvuX1YLMk83jcL1Z9284Fr3kO57fZ8+0aKCU2RYQ9FnWDND1CCCGEyAV66BFCCCFELigb85YNi2VVayz8jsPWbD9WyaaFvtr3cbZnVvcDYehgmuoXCNWwVv1fjgVI7Zzw9+HvmTVE97rrrguOOTx8r732CtrGjRvnZb42NjyV1dx8fraooTWFVnHHHXeknhOH0VuVM3+WDX8uJ5xzfq7steP0CjyftiglFxXkcP9YGKqFrxebozg0Ggj3MJuo7dg8XiwsmeeN16ldH3yfsVmM2SzG9wQO0bfjlwv2vsJZjlnOGtYrRGOl/HavEEIIIUQJ0EOPEEIIIXJBvRYcZWyERNbMsTEzE5tEYuYtHoMjB2y0AL+Px2OzAAC0bt3ay7GM0eWCNQvarMRV2AgRzsb7l7/8xcs33nhj0G/XXXf1Mme9BYDddtvNy5xN2WZaTjM9xEwNjz76qJcPPfTQoO2JJ54o+h47Hs9fLCMz96vvCL0jjzwyOGaTERfgtHPBpsG5c+d62RaE5LVvs5vzNeL9xxm1gTASjs3I1kzDUVr8nqwmJrtm+Tva/c0mt5ipVQjRcJGmRwghhBC5QA89QgghhMgFeugRQgghRC4oG58eDm8FQvu69RtgHxrOHGvt9+xbwX4NNjssh+eyT48NWecx+LOsbwT79DREHnroIS//8Ic/9LK9buzbwVgfiBkzZnh55513DtqmTp3q5e7du3t5+vTpQb+0zKz22g8fPtzL1o+HScvWbeE1ZDPMMrw2yi0tAfu/cAZrm826MRLzERJC5A9peoQQQgiRC/TQI4QQQohcUDYZmefNmxcc23BShgvNdevWzcu2uCDDJjFbOJJDtHlszs4MhGHTbM6w4dVMQwhZt1lrL7zwQi+zaZHNgDGs6Yjn5eWXXw7adtllFy9zmLT9LA415gKKRxxxRNDv8MMPz3SOaWH51hzCpiFbDJNpCPMshBB5R5oeIYQQQuQCPfQIIYQQIhfooUcIIYQQuaBsQtatLwWXfIj51rDvD1dcB0LfDw6Jtynx7fuqsL4pfI5c8iJWdiBWkbpc4HINQHittthiCy/z9QTC68Ph6/Y7s1+M9X2ZMGGClzt16uTlvn37Bv24RMX8+fO9PGzYMKTBvkS8ZoC1SytUkbYWAKBdu3apbUIIIcofaXqEEEIIkQv00COEEEKIXFA25i0bQsymJGtyaNu2rZfZdGJNGPw+Hs9Wbf/000+9zGYPa4pJM2PZqu1M1mrQ9cmpp54aHP/nP//x8syZM73M4fxAesbrWNh3kyZNgjZ+35w5c7zMIepAmCl71KhRRb7F2thM3kxaSgT7Hs4EHQvZZ1Nf7HOFEELUH+X/iyyEEEIIUQvooUcIIYQQuaBs9PCzZs0KjtmcYU0Ry5cvLypbM9iHH37o5ZUrV3p59uzZQb8lS5Z4ecqUKV7eddddg35s3mHTV1p234aCNTk999xzXl64cKGX77rrrqDf448/7mWOropFQGXFFjN94oknvDxo0KD1Hn+bbbYp+jqvOyDM+N2jR4/U8cqtyKgQQoi1kaZHCCGEELlADz1CCCGEyAV66BFCCCFELqhzn560EG6bgbeiosLLHKIOhKHpbdq08bL1q1i0aFFReeeddw76cebeBQsWeNmGqG+yySZeZt8fzlpsaQgh6zE4S/Lvfve7oM0eV2H9s7h6OvtgAWH6APafSfO5qS24kny/fv28bNcan1+rVq1Sx1OYuhBClD8N+xdZCCGEECIjeugRQgghRC5wNutwtLNzHwBYsM6OojbZMkmSNuvuVj00l/WG5rPxoLlsXNT6fGou643UuazWQ48QQgghRENF5i0hhBBC5AI99AghhBAiF9T7Q49zrpVzbkrh32Ln3Ht0HK3v4Jwb5Jx7LKXtDufcd1PaLnDObWJe+41z7iTn3OFp7xPrxjl3hHMucc5tn7H/fOdc6yKvryrWPzJOtfpHxjndOdehNsbKC8653zrnZjjnphb27YBaGHO0c67v+vYR1UNz2fApxRzS2Km/uQ2Fek8ukiTJhwB6AYBz7vcAViVJ8qdaGPfMYq875zYEcAGAewB8Sk0HADgWwHUAHgPwxvqeQ045AcCLAI4H8Pv6PZUacTqA6QAWraOfAOCc2xXAIQD6JEnyeeEBtmEXo8spmsuGTznPoXPuW0mSfFXf51Hvmp6sOOf2Ig3Qa865TQtNzZxzDznn3nTO3esKGQX5Lwfn3Crn3BXOuVcA/BZABwCjnHOjCu3NUbkwtgHwAwDXFT6nu3Oul3NufOGpebhzbnMa/ybn3Djn3HTnXP+6vSLlh3OuGYDdAfwPKh96ql4fVLhea80T9WninHvKOXdWkXEvdM5NKMzB5ZHPv945N9k595xzrk3htbT5W+t159zRAPoCuLcw/03SPkt42gOoSJLkcwBIkqQiSZJFzrnLCnM23Tn3d7Mvr3HOveqcm+Wc26PwehPn3AOF+RgKwF9759xtzrmJhb9eU+dfrDeay4ZP2hzOd85dXrg/TnMFTbxzrqlz7s7C/L7mnDus8HpX59zYQv/Jzrnd7Ac55/oV3tMtMs7pzrkHnXMjAIysu8sQIUmSsvmHSs3Ar1LaRgDYvSA3Q6WWahCAjwB0QuUD3MsABhb6jAbQtyAnAI6lseYDaE3HRwK4oiDfBeBoapsKYK+CfAWAm2j8IQV5TwDT6/v61fc/ACcD+EdBHofKvzawjnmaD6ArgGcBnEpjrSr8fwCAvwNwhfc+BmDPIp+dADipIF8G4JZ1zF9sXvvW97VsKP8Ke3EKgFkAbqVr2pL6/BvAoXR9ry/IBwN4tiD/AsCdBbkngK9o/7Ys/L9h4f09NVeaS/2r1hzOB/CzgvxTAHcU5CsBnFyQNyu8rymATQBsXHh9GwATC/Kgwj14NwCTAHRZxzinA1jIa6i+/zUYTQ+AlwDc4Jw7D8BmyRo12atJkixMkuQbVE521yLv/RrAw5GxDwLwpH3ROdei8FkvFF66G5UPOFXcDwBJkowB0Nw5t1k1vk9j5AQADxTkBwrHVcTm6REA/0yS5F9Fxjyg8O81AJMBbI/KTWj5BsDQgnwPgIFp85dhXkVGkiRZBWBnAGcD+ADAUOfc6QD2ds694pybBmAfAD3obcMK/0/CmnWwJyrnDUmSTEXlQ2kVxzrnJqNyDfQAIJ+7EqC5bPhE5hAoPlcHALjYOTcFlQ+eGwPoAmAjAEMKc/4gwnnaAZV/iB6aJMk76xgHAJ5JkmRZrX3J9aTefXrScM6dA6DK1HFwkiRXO+ceR+VfFOOdc/sV2j6nt32N4t/psyRJvo58XH8AP6nBadokR7lNeuSca4XKG+KOzrkElX/JJc65iwpdYvP0EoDBzrn7/r+9Mw+XqrrS/rsc4hAVRVARZHRgEjCgBjXOIcZE/Ry6jUkbjd0ZzBejpttEkzbdrSZqmy/RpGObxHRsTIgxse2AIw7ggKCiMomioqCIiiASMZKg7O+Pqrt59+KeTd3LHarueX/Pw8OqOrtOnTr77H3OXe9aa4fqnwq8awCXhxB+1sJDKm1fdDTVsTUVwNTqJPllVP7CHxNCeMUqsXpb00eargV/HWzQZ2Y2AMA/Adg/hLDSzG5w+xJtiPqy8WmmD8+obmqurwzAySGEBbyPaj+/AWAkKh72NbT5NVT6bT+sj30s2s+BAN7d5B/VhtStpyeE8NMQwqjqv6VmNiiEMDeEcCWAmaj8xd9a3gGwPQCY2TAAz9JDUdwWQlgFYGWTVg3gdAAP0H5Ore7jEACrqu3LyikAxocQ+oUQ+ocQ9gDwEoBDavjsdwGsQMUd67kbwFlWiReCmfU2s12aabdZ9RgA4LMAHi7qv430a+x/sXHMbB8zY8/bKABNE9/yar+dsuEnN+BBAJ/R1VpAAAAgAElEQVSr7nM4KjdaANgBlUlzlZntCuCTbXLgYgPUl41PQR/mKkLfDeAcitPar/p+NwCvVT3zp6PyR2wTbwP4FIDvm9nhG9lP3VG3np5mOM/MjkDlKXU+KnLU2Fbu6+cA7jSz1wDcDuAu2nYTKm69r6MywM8AcJ1VUtxfBPAFarvSzB5BZTCf1cpj6SqcBuAK994tqDyA/G7D5htwHoD/MrN/DyE0eYcQQphsZkMATK+Op9WoxA4tc59/F8AwM3sClfihU6vvF/Vf0fs3VN9/D8DYEMJ7NRx7mdkOwE+q0u77AF5AxbX+NoC5qMQSPF7Dfv4TwK/MbA4q8udjABBCmG1mTwF4GpV+mtbWP0BE1JeNT1Effrqg/aUArgYwp/rAsqja9loAt5jZ3wCYAuetCSG8YWbHoXIfPSuzn7qj9MtQmNk9qATQvtbCz01FJeh6ZrscmBBCCCHalEby9LQLIYSPd/YxCCGEEKL9Kb2nRwghhBDloG4DmYUQQggh2hI99AghhBCiFOihRwghhBClQA89QgghhCgFLcre6tGjR+jfv387HYpojkWLFmH58uW28ZYto7P68t130+KcK1asiPYWW6y/HDfffPOkndH6pO+/X7xQ74c+tH5B4T//+c+Fn1m7dm2099lnn40ddpvxxBNPLA8h9Gzr/dbj2ORznuvPRqUrjE1OZPnrX/+abHvvvfUlqj784Q9He8stt9zk7+Xv4u8BgG7dum3y/ltDe4zNehmX69atizafb3/ut91222jzGOX5EkivgW22qb91mXN92aKHnv79+2PmTJWl6UjGjBnTLvvtrL58/PG0ttn48euX29p5552jvf32aVFkfiBavnx5tP3Ns2/fvtGeNWtWtJctS2sZvvnmm9GeMmVKTcfeFphZrjpqq6nHsckPtP5Gxv3ZnvjsVH692Wab5uju7LHJNzL/W3LbGH74ePnll5NtTz/9dLQPPPDAaO+2224bPbaNsXjx+mEwf/78ZNsxxxwT7Vofjvn3Aq3r2/YYm+05Llvym1evXh1t7le2AWDEiBHR3mqrraL92mtpGbtdd9012iNHjiz8Xh5vHfmHTq4vS1+nR3QsU6dOTV7Pmzcv2jwoXnrppaQdD1p+6Nlpp52Sdnxz3XHH9eu/9ujRI2m3aNGi2g9aJPBEdvfddyfbbr755mjzw+Qbb7yRtFuzZv1SPl/5ylei/dRTTyXteGJ/5plnoj14cLoKzfXXXx9tnrj9RMuv/QNRo3mf+HhrvQF++ctfTl7/5S/rl8TjmxyQ9tk111zT7PcCqRdgv/3Wrz7gvQj8oMsPOv4PnLvuWl8g/+2334728ccfn7Q7+eSTo93ah75GJve7FixIlsDCO++8E+3nnnsu2nPmzEna8fzJcyv3A5COXx5Ho0aNStrV45jqmleDEEIIIYRDDz1CCCGEKAV66BFCCCFEKVBMj+hQfPbWgAEDov3WW29Fe4899kjasUbP2VYck+DbcUxP9+7dk3b8OY7vqYdMi3qAA03/9m//NtnGfbhq1apkG8cZ8Dnn7B+/f47z8rFcDAcOc4wCAHzmM5+JNscbfOlLX0raXXjhhdH28QadFXTZWmoNyr7ooouivXLlymTb7rvvHm2fvcVjkPvZB7XyuT/77LOjPXbs2KQdB7/y9/p4O44R4mwijhcD0sDr888/P9lWxuWVFi5cGO0lS5Yk2/r16xdt7j8/f3If8Vzosy856YTjfXzQdnsF+28K8vQIIYQQohTooUcIIYQQpUDyluhQOF0SSOvlcFq6l8H49S677BLtXNFBlkC8u5s/9+CDD0Zb8laFM888M9peEuFUVi9bsczCEpEvLcCyJpcgOOqoo5J2O+ywQ7T/9Kc/RXu77bZL2hVJU3fccUfSbuLEidF+5JFHkm2NIGkxubTsF198MdpcFsLLxixv+N/P++zdu3eznwFSmen3v/99tFmaAlIZi/v1gw8+KPxetlkSA4C5c+cW7oPlGN7mZZquBMtMLFMBaTmCPn36RPvGG29M2t16663RPvbYY6N99NFHJ+2GDBnS7Hf5UiBctqBeihjK0yOEEEKIUqCHHiGEEEKUAslbokNhKQNIJahcVhBnArG72stWvA9213uXPMtbXr4pK7/4xS+izdV4fXYNn/9c1hD3jV+7h9dFY7e3lzW533IyBb/eeuuto92zZ7r8Dktkt9xyS7KNK/w2ArmlPO67775ocx/xeQfSc5Vb047Haa9evZJtLFFPmjQp2r46L8vXLHv4a4jXdWIJz491vqYeeuihZNvhhx9e+LlGhs8HS5hAen55CR4glTVZqnzhhReSdrx2IWfzLV26NGnH0jDLm5xBBqRS2mmnndbs+x2NPD1CCCGEKAV66BFCCCFEKdBDjxBCCCFKQWliejiV8rrrrku2DRs2LNqcMnvCCSe0/4GVDB+rw/EBrO3zKsxAGnfDcQieIv3ep89yO/9dZeXaa6+NNp8fnw7McPyF/xyTq37M+DgV/m6ON/DtOCWXY1P86uMc++PTdRstpicHX9N8rn3MFJ9Tf64YPm++cjOfey4lkGvH8Tg+pofHN88XXGkbSK8pTssH0pieXOxTo8FxPBxLA6Rz3J577pls49XUDzjggGjvtttuSTtOOec4Kf4MADz22GPR5nihI488MmnH1820adOivffeeyft9ttvP3QU8vQIIYQQohTooUcIIYQQpaDr+P02wowZM6LtFyt8/PHHo/2Tn/wk2ueee27S7uqrr27x93p38mWXXRZtTgv+2c9+lrTzskEjw2nHnDIMpNIiu9q9HMLVRl999dVoc5omkFZ6ZXevT7vmKqJ+AUWRSh1epuD+zMmGuXR27t+iKs5AKk3wNp9ezcfL8oivAsvtfPVYTsv11X8bDU4d5nPoSwdw6riXjXk8ch/lqpvzd/l2LHVwOy8/8fXF38vH6vfPafNdGZ4HuTK93+bH0bhx46LNcySXGPDtWFr2shX3Gfc/LxoNpBXb+drzc+5ee+0VbV9tva2Rp0cIIYQQpUAPPUIIIYQoBQ0vb9W6mBxHjnfr1i3ZxnIXR/1fc801SbvTTz892qNHjy78LnYz8v4AYMWKFdHm6qhnnHFG0u6www4r3H+jwS7P7bffPtnGFXPZRe0lFT5X7Lr1Lu+DDz442uwa99cGu/K7UsXWlnDWWWclr/lc8vl+5ZVXknbsHvfZH5yhw32YW8yy1kUgixaR9LAs8/rrryfbuCK4vxYfeOCBaHP12EbAy1YsEbCkzOcGSKVivxgpjxGWBXOVm/24ZVi2qrXPOWPLSyd8vL46cVeCxyWfXy8LspTk50WeW/mc9uvXL2nHfcsZW1zFGQCefvrpaBdV0Pavc1mVS5YsifbgwYPRnsjTI4QQQohSoIceIYQQQpQCPfQIIYQQohQ0fEyPjxVgWAN+6aWXou01Q9aaOV7BV7UcM2ZMtE855ZRo9+3bN2n3wx/+MNoDBgxItnEMBGvtO++8c8GvaHy4mrKPKeDYDo5L8O04hoOrzfrUYq5S2r9//2j71GXu565UHqAlnHPOOcnryZMnR5vPv48P4H7yJRk4zoDjNnLjlLflKjdzP3H8ApDGn3Aava/Uy7/Ff9eDDz4Y7UaL6fEpwByTxWPMl3jgOXKfffZJtvGYy1Xo5v1zrEatVbj9+OOx+uSTT0bb9zlfhxxH2dXgOLSi0gxAGqvTvXv3ZBvf43gM+PN2/fXXN7sPHxvH8FzhY8t4PuBr1M/vXL5FMT1CCCGEEG2AHnqEEEIIUQoaXt7KVX2dMGFCtHfcccdo+3Q5dsFxSrmvNsvu3zvvvDPa3sU/ZMiQaHMKL5AuoMcuaE7ZA4Dhw4ejq8BuV++iZtg16t3wXFGZ3ebcr0Dq8uWKu14+5D7Ppdl2Zfwif3wN8uKbPlV44MCB0faLHvIY4bHpXfFFac/shgfSMcif8dcRS8Xslu/Tp0/Sjredf/75ybb999+/2WNqBFgGAoqvaZ5zgOJqykDxoqB+zs1Jl0XtcinrRZWbvRTDoQJ+fPPYZ5m7EeH5k22/sgDPhb6fuc/4nuTvcX/84x+jzeVW/Dnk+1guFZ2lNJa3Ro0albTLyWdtjTw9QgghhCgFeugRQgghRCnQQ48QQgghSkHDx/Tk+N73vhdtXnrCr/RdtDIw66d+G5dA95o2l7f36b6sV7NmzqvAA8AxxxyDrgKfH586zrAe7JcK4TR1Zqeddkpec/l9XrnXx55w3/rlCARwyy23FG777Gc/G22/ujXH5HAcj48DKVo+xrfjMZeLP+HrimOT7rrrroJf0bXglF8Px3D4+EMu3ZBLN+ax6VPPi9LUc3E7nKbu98fHwcful5rg+DG/j1mzZkW70WN6OH6G5zcf08PbfEq4j5Vrwt+fjj766GjzPc6347HNc2nuezl+yLfjffi+rDVmrFbk6RFCCCFEKdBDjxBCCCFKQUPKW+z+YtcXV10G0jQ4Tm/0shW7cXNuNm7H7nmfHuqrYRbtg13506dPL/xMo8PnMVdigLd5d6xPYW/CV82ePXt2tFne8qmZ7DKudcVnUaFoHACpzJQrVVBUndf3BUsnOYmFjyO3CnjRvoF8Zeh6Z+HChclrlohYivDlB/bee+9o+7FZdB5z540/U9TH/vj8NcQyDW/z7fh7/TEtWLCg8LvrHZ9uzuEYLAv5+x2PMV/Ko+ja9vculvqLxh5QPN78NcSyGFeW9u1YduWyMUBarqQtkKdHCCGEEKVADz1CCCGEKAUNIW/5yHGO6GdX3SWXXJK069mzZ7Q5S8G76nJuc4Zdeuye9dk/vM1nRPBvYTfu1KlTC7+30eE+8lk3LDuxNOKzgoqyvtg9DwDTpk2LNrv1Wd4E0uqg3m0u8vjsxyKKMrSA4sVl/XjJZfkwvP9c1W8mJ7U2GkuXLk1es7SYq9TLc6mXs4okvlrHS63n11etZ8mFszP9tcHztpe//QKsjYQ/73xtswzkx6E/j0XUKkflMm35fPO49PP7c889F23OqvR9yWPWV2eWvCWEEEII0Qr00COEEEKIUqCHHiGEEEKUgrqN6WGdMKctTpo0Kdo33HBDso3TmVn/9LpjUQp8rh3Hi3gtlXXz3ArerFe/8MILyba77757g+PuCni9mvVlPqc+vsCnYDYxdOjQwu/i1EcfD8LxXo2WntzZcNqzH5tF8QI+jq7WdGh+zbENPq6EY39qjW3oSvhUdB8z0UQups7D557Pdy62irf5uY/7j8e6L0/B4zEXn8W/0Vcn9jFOjYTvO+6jomrVQLrSvE/7Lior4Mcbn28e274vebzlSkRwDBLPub7iftFK8u2BPD1CCCGEKAV66BFCCCFEKWgzeYvdmkW2h93fXmLISQ6XX355tC+99NJoDx48OGnHbjd2z+ZSJHPHW7TgoXcRshvXp+oWSWns7gXWVxb2KaaNSM7lXbRYnU+lLFoUdP/9909ec19wf/l+KFoIT2wcrqzKpSCANOWVXeVejipapNJTJH/6ccHHwaUgyoIv68FjrqgqLpD2Ua2VrH1/8XdxP/s5jeF2fqzzHFHrIpV+XmnkMhT+2ubfwufeS5o8p+X6KHfv4te8fy8z8j2Uj9efd/4uTkX3C+SyNCd5SwghhBCiDdBDjxBCCCFKQZvJW229WN/EiROj/c1vfjPZxovJjRw5Mtq56pLs8vZuXG7H7ric5JbLJMlJJ0ULlfosmCbXYiO7aZvIZX5wNsLKlSsL2xVlaRVldQHp9ZBz3St7q0KR9OphF7iXMHghV+4b70YvkpFz7vGcTMqvc7JKrb+xEfBZTwxLBCxpjRo1KmnHfeQlh6LK9zlJhLN6ijLIgHS+82OTf9euu+4abS+x8O/KLQ7Nx8HHV694CZKvbR4fOVk+VwGd50UvGTK5cc5Zxbw/Py5ZtuL7rL+GeP+vvPJK4TG1BfL0CCGEEKIU6KFHCCGEEKVADz1CCCGEKAXtXpHZV4a89957oz1r1qxo33bbbUm7efPmRduvpM1pyqxV+rRN1itzqehMUVq6h/Vlr62znur3wcfE3+X176Z2jR53AOT7iFfQ5ZWR/TndY489mt23T2UvqhSaKyuQ07XFhhTFGABpLAn3RS6lmvfhxwGPH+4z3598vXSl1dNzcAych89pUfwFkI+74ba5c1rr3FqUKu3jQHg8ckVfH8PCK3j7WCXe57Jly6Ldu3fvmo61M/F9wr+Ff7MfA7vttlu0+f4JpDGtuZTwon72cyRXwOaVBWbOnJm048rLHJ/l48f4GvIxTW1NOWYHIYQQQpQePfQIIYQQohS0Wt6aOnVq8vqSSy6JNqecsWsRAHbfffdor169Oto+HfFjH/tYtL3Ew+4+3pZzwfFnfDuu5squRe8+5DTLXEVZTgP17v+iSqR8LgBg7NixAIDf/va36Eq8+eabyesimdC7vHnx2BzsxuX9+ZIA7OItYwXf5qg1nTu3OCCPLZa3/PXN+8+VZSiSm/338jZfqbboexudt99+O9r+fPD8xBVz+/Xrl7TjMeKleN5HTsIqqhjs8WnURZ/hsc9p88OHD0/a8X3Gz+l8TCyRNQI+rb6ozAmng/ttvqpz0Rznzw2fbx6zfuFrPt98v3vppZeSdlxq5IADDoj2XXfdlbTbd999o+2vtWeffTbaftWF1iBPjxBCCCFKgR56hBBCCFEKWiRvrV27NkZdn3322ck2dndxRg7bQOpC5chu757MLXbGsAs2l6GTg2Um/i7vdmUXIctgnHXkj8Mvbspux5z8cuihhwIoXmizkeB+8Fk8S5YsiXYum81n8BXBLl92//vz2NYVxMsESyQsIQNpZVU+r74/eVtRJheQzhe5CsR87dS6cGajk5Psi+aZT3ziE0m7OXPmRNvLKjyP5aqb8/75M74v+XO8Py/N8XHwb9xrr72SdjfffHO0vXxalAHWCPg5kudPPteHHHJI0q7oPgYUS8he0uRxmRtHvH+eZ30fMfws4KU57i8/H7d1Npc8PUIIIYQoBXroEUIIIUQp0EOPEEIIIUpBi2J63nzzTVx77bUANkwp5vicWis+cqq4111Zx/TbWPNjTdJXk+Q4Gd5fLr2Tq37638gpkq+//nq0uRImAPTq1SvaXrvk2BI+JtZFgfWaaVevLlukt/u0xe7du9e0vz59+kT7mWeeibZfJZj16kZYebkjKIrh8H3B8SI+JoDPZS4VvSgF2o85HiPcZz5eLxdzUusxNFpsV65iPP82budjDDnWyo+xWmN6OL6D2/kYLN+3Tfg5kvfBc66PYeFUaR8zxvGXPt263vHxWfxbeB7LxWDl4Psf37f9d3NsEd+rAeDVV19t9nsHDhxY2K5nz57R9jFYfG346vu5mN7W0LXvqEIIIYQQVfTQI4QQQohS0CJ5y8yiq9TLEiwLsdvNS0nsumSJKOdq9tIEu2h5f969V5QW6SUjdsOyO867RQ8//PBoX3rppdG+++67k3b8W3LVNdnF196LrNULvo9YKuFryp83XtQuxy677BJtruTp5UN+3QiLEHYmXqbi69uPpVplptxisEzRNi/t8LXTFco81EJOZuQ5k+e3nLzF8zGQjjmWOnzFax5zvM3LNNwvvBD1yy+/nLRj2YrnSC8/8vFyRV8g/f0+Bbze8fdCHissM/kqyzwGvPzL46hoUWb/OrfAL7fj/vKSJlfgZwmLqzMD6bXsy7e09XiWp0cIIYQQpUAPPUIIIYQoBS2St3r16oWLL74YwIYLR95///3RZrejjw5nNxm757x7luWo3EJ4bPt2RdIXu1Z9u2984xvRPu+881ALN954Y/Kas7e8W5Ddy+xaLsps6Grk3K7s4vTZAt5VXgRngvBn/LXB5zuXBSPy2Y5eLinKtvIUVe71Ega34/35721NBd5Gz97ia9hLTqtWrYp2bmFj/s25yshFi14C6b2AJeWPfvSjSbsiGczLp1zlm4/dZ8nya78Q5fPPP194vPWOnyP5/LB85Fc7mDlzZk3757Hjzz2PIx4fPtSD5UN/TTF8j2cZc5999knaPfjgg80eH7BhaMKmIk+PEEIIIUqBHnqEEEIIUQr00COEEEKIUtDqYIYf//jHyWuOT7n66qujPX78+KQdp4SvXLky2r7qIqep+XgOTmnj7/Xpcvxd/Jl//ud/Ttp9+9vfxqbAKxUDqXbp9VmOW+EKlU2r1zfRpEMXVa5tJDhWwKdZ8u/j1NLdd9+9Vd/Vv3//aLOW78seMIrpqVB0rbVkleqiFdN9vExRantulXUmF4vAY6wrw7EUubgKPr+PPvposo3jQpYsWZJs43PK+/d9wn3B+/NjnffBn/EVmefNmxdtTpu/5557knY83/uYJo4L8XNrI+PTuRme43Kp6Nx//v5UFJPnS4jwXM3jzcfwcmwm36s5zR3IV2/3MT6bijw9QgghhCgFeugRQgghRClotV/fp2Kz++uCCy5o1vZwmvuTTz6ZbGMX5+LFi5NtnMLG7j7vBvva174W7QsvvLDwOIrIVXhmrrjiiuQ1V6fOLR7HLr7Ro0c3u+9GS6NtDnZrencqS1Dsrvbuz1rhtFg+d/488vf6YxIpnP4M1J5izraXzooWefVueXbF8/fm3OF+8cmuyrJly6K95557Jtt4juQUcJ/2zdKznz9ZwuD+8n1ZJF/nxjpv8+UpWE5lycannvN3LViwINnG102jz6E8L/bt2zfaPo18/vz50fYVqotkZz/eeBv3uQ8PYMmwaIUEvw/+HbmQgtwqBm2BPD1CCCGEKAV66BFCCCFEKdBDjxBCCCFKQatjeoriW1rCkUce2axdL9T6G88444x2PpLGhmMsimI5gFR35rioXDuv17P2nNOaOY4gl85eJmpNWc+d/6Ixk1tJPafZcxxH7joqiiXqyhTFwwHptb98+fJo+/7imEifYs7jIlc6g+OHBgwYUNiuaHz7/uJSHnw9+ePLxQ/x72+0khQcgwUAr7zySrRHjRoVbR/rumjRomiPHDky2cZjjM+HP/d8HrlsiF+6idtxX/o4I97GMWj+OuRj8ktctXXMpTw9QgghhCgFeugRQgghRCloLL+faHi4wqqHXaG5yqPskvWuT67uyi5TL7uwe1XyVh4vb9WaEs7lGnISFqfN+r7gvs71E/cvu+UbfSX1HFzF3ksiXJmcSw546YCrJHtJmdvy+fXV81lmYpmNU949fLy+HX8X9xdXugdSidPLnTzP5CS3emT48OHJaz5+rnjsJacTTjgh2r4qOY8Dnhf9+GBZkMevL1vBKybw/ODnY57HWWb15QdOOumkaPtrORcS0Rrk6RFCCCFEKdBDjxBCCCFKgeQt0e6wm5wj+IF0gUKu7JqTMnLyVlEFUC9rsESTW6yxTBRJP/78sEucXdYAsHTp0mizK95nifA+WN7yMiTLYnzt+P2xBMDV3DmzCMjLq43GsGHDou2lKV4E+Xvf+160fSYTSyQ8FoFUdnr++eejPXHixKQdS2ncf88991zSjs899/m4ceOSdty33H/++FhymTlzZrKNK7offPDBaCR8hWr/ugm/igGTW6Qzt4Aw9x/LTH6e5X3wvO0pWmTWS5VcUZyls/ZAnh4hhBBClAI99AghhBCiFOihRwghhBClQDE9ot3hFX+PO+64ZBtr+927d4/2EUccUbi/XKVsXkWadWIf28FVXzk2oswUVa495phjktd33313tLkKLJDG+LDW7+OCOF6A01d933LsFccI+dXCOW164MCB0c7F8DR6+jqnNn/rW99Ktj388MPRPv7446PNacit5eKLL97kfbQFHNNz7rnnJtsOOeSQaDdaReYcPF/6uB2Og/RxNkUlQHw6OI833p8/hxynyXOpjxfieCQ+hqI4JWDDeL22WP0h2V+b7k0IIYQQok7RQ48QQgghSoHlFpLboLHZmwAWb7ShaEv6hRB6brxZy1Bfdhrqz66D+rJr0eb9qb7sNAr7skUPPUIIIYQQjYrkLSGEEEKUAj30CCGEEKIU1MVDj5mdaGbBzAbX2H6RmfVo5v0WrSfQ0vaZ/ZxpZrtvvGV5MbOdzWxW9d/rZvYqvd70PFrR5mxKn5nZ4WZ2W8G2681saMG288xsW/feRWb2OTP7P0WfE+2LmX3HzJ42sznV/j8wMw8fb2YXFuzncDM7qP2PWBRhZruZ2U1mttDM5pvZHWa2dwv3saOZfbW9jrE9qYuHHgCnAXgYwGc6+0BayZkA9NCTIYSwIoQwKoQwCsB1AH7U9DqE8FcAsAoddk2aWdcp4NEO1NJnrdzvP4QQ5vv3zWxzAOcB2NZtGgdgMoD/A0APPR2MmY0F8GkAHwkhjABwNIBXitqHECaGEK5oZj9bADgcgB56OgmrFKe6FcDUEMKgEMJQAN8GsGsLd7UjAD30tAYz2w7AwQD+HvTQU/2LYKqZ/cHMnjWz35irJmZm25jZXWb2xWb2e4GZPV79y+TfMt///8zsSTO7z8x6Vt8bZWYzqp+91cx2KnrfzE4BMAbAb6p/ATVfBUo0i5ntaWbzzOw6AE8C6GVmf2dmc6vvf7/abgsze5s+9xkzu57seWY228ymUPsfmtlj1f76h+r7R5vZvWZ2E4CnOvwHd0HM7DDyAD1lZk0rBm7X3PitjusxVXu1mV1iZo8C+A4qfzxMoX7cAcCHAOwF4HgAV1W/Z1BmnE41s6vN7JHqdXFAx56RLkcvAMtDCH8BgBDC8hBC08qy51Tnz7lW9dRbxfP9H1X7huo4nALgdwC+AuD8ah9+rBN+S9k5AsDaEMJ1TW+EEGYBeNjMrqqOl7lmdipQuT9X741NfXxC9WNXABhU7cerOv5nbAIhhE79B+DvAPyyaj+Cyl8TQOUvglUA+qDycDYdwCHVbYsA9AdwL4DP075WV/8fB+DnAKz62dsAHNrMdwcAn6va3wXwH1V7DoDDqvYlAK7eyPtTAYzp7HPZKP8A/CuAf+9OaXsAACAASURBVKraewJYB2D/6us+1f7tAWBLAA+g8lfmFgDepn18BsD1VfsZALtW7R2r/38VwIVVeytUHnD6ovJX6moAfTv7PDTSP+6zZrZNAnBw1d6u2le58RvHS3UM/i3taxGAHvT6JACXVO0bAJxC23Lj8RdV+1AA8zr7/DXyv2qfzgLwHIBr6ZwvAnBO1f4qjcczaS69oTr/br6x60j/OqQvv46Kx9a/fzKAewBsjorX52VUHna3ALBDtU0PAC+gcl/t36jjqtM9PahIWzdV7Zuqr5t4LISwJISwDpVB15+2/RHAr0II45vZ57jqv6dQ8R4MRuUvRc86VP76AIBfAzjEzLqhcuN8oPr+fwM4tOj9mn+lyLEwhPB41T4QwP2h8tfkWgATsPHzPA3A+Ko3p+maHgfgC2Y2C8CjqLhjm66B6SGEl9v0F5SbaQB+aGZfR2WMNNXKz43fJj4AcEtm38cAuNO/WcN4/C0AhBAeBLCDme3Ygt8jiBDCagCjAXwJwJsAfmdmZ1Y3/0/1/yfQfP8CwO9DCB+05zGKTeYQAL8NIXwQQngDlT8290flAef7ZjYHFSdDb7RcCqsrOjWmwcx2BnAkgOFmFlB5ygxm9s1qk79Q8w+QHu80AJ80swmh+hjKuwZweQjhZy08JBUt6hx4wZaiBZHWuW1bk/1FVB6WPg1gtpmNqLb9agjhPt6JmR3tvk+0EDP7v6iccwA4NoRwhZndDuBYADOq5xjIj98m1mzkhngAgLNbcZh+LGtsbwLVPpoKYKqZzQVwRnVTUx8X9S+g8VZPPA3glGbeL5p3PwegJ4DRIYS1ZrYI6dzbcHS2p+cUAONDCP1CCP1DCHsAeAmVp86N8V0AK1Bxt3ruBnBWNV4IZtbbzHZppt1mWH8BfBbAwyGEVQBWkt58OoAHit6v2u8AaIpjEJvGDABHWCVzaAtUZKwHqt6ClWa2l1WCnU+kzwwMIcwAcDGAlaj8NXI3gK9W9wEz20fxVm1DCOGnYX1A81IzGxRCmBtCuBLATFQ8q60ljiUzGwbgWXooits2Mh4BoCkm4RAAq6rtRSuojh32lI9C66sMa67sXO4HsJVRHKyZ7Y/KvHmqmW1uldjWQwE8BqAbgGXVB54jAPSrfqxh+7Gzs1dOQyUgirkFlQeQ323YfAPOA/BfZvbvIYQm7xBCCJPNbAiA6dXYydWoxA4tc59/F8AwM3sClfiDU6vvnwHgOqukzr4I4Asbef+G6vvvARgbQnivhmMXzRBCWGJm30Xlr0oDMCmEcHt187cA3IWK3jwflVgdAPiRmQ2otp8cQphnZs+gEsMzq3oNLANwAkR7cF51QvwAlX65E8DYVu7r5wDuNLPXANyOSn83cROAX1RltFNQPB6BygPRIwB2AHBWK49FVNgOwE+qEuH7qMR1fAkVz2pLmQTgD9WA2HNCCA+13WGKjRFCCGZ2IoCrrVJWYA0qsVnnodLPs1Hxin4zhPC6mf0GwCQzm4mKRP1sdT8rzGyamc0DcGcI4YJO+DmtQstQCCHqEjO7B5VEhdda+LmpqATLzmyXAxNCNCyd7ekRQohmCSF8vLOPQQjRtZCnRwghhBCloLMDmYUQQgghOgQ99AghhBCiFOihRwghhBClQA89QgghhCgFLcre6tGjR+jfv387HUox77zzTvL6L39ZX+i1R48e7fa9b775ZvJ6m23W17bbbrvt2u17mUWLFmH58uVF1TJbTUf25bp166K92Wb18ZzNAfxmbX56C3niiSeWhxB6tvV+O2ts1sratWuT12+/HdeOxQcfrC/I7BMrtt9+ff2zjhpztdIVxqZYT3uMzXrpy7feeivaf/rTn6L9/vvvJ+14/PG43GKL9FGBx+Juu+3WZsfZVuT6skUPPf3798fMmZtW+qI1N5spU6Ykr1988cVo//3f//0mHU+Oa69Niz2PGDEi2occUkvR6E1nzJgx7bLftujLWnnvvfW1GvnBsTPhwe4HdHtiZq2tZJulPfuzJRmeRWP61VdfTV7fdttt0V65cmW0/cPREUccEe3cmCuaV/yxt+UDblcYm2I97TE266UvJ0yYEO377lu/Ms/y5cuTdjz++OHIOxcOPvjgaF9wQf3VJcz1ZX382S2EEEII0c7UTXFC/msPAE4++eTCbVtuuWW058yZE212xwGplMISC7v6PK+//nq0ly1LV63g/W299fo11x577LHC/YnUu/PXv/412cbnu3fv3tHOeRfYc7RmzZrCbStWrIh29+7dk3b9+vWD2HRynhP25vz85z9PtnF/9Oy53gvN4xRIva3PPfdctM86K11ZolYPTmfJmkK0BbWGCuy0007J61Wr1i89161bt2h7aerdd9evDfvhD3842gsXLkzaTZ48OdoXX3xxtP18zNTL2JOnRwghhBClQA89QgghhCgFeugRQgghRCno8JieIi3v/PPPT14/++yz0d5rr72SbZtvvnm0H3/88WjvscceSTtOdf/kJz8Z7enTpyftOOZk9erV0eZ0Wf+9zz//fLRvuOGGpN2ZZ54J0Txf/vKXk9d33XVXtHfcccdo+5ierbbaKtqcYeBjQPj64v737ZYuXdqSwy41fszyufTbbr311miPHz8+2j4ri+MROI5g5513TtoNGjQo2vfff3+0R48enbQbOXJks8dXLyUShGgLctfzCy+8EG0/3/F44XIRu+66a+H+OUaWY1iBNCZy0aJF0b7ooouSdpdffnm0ea7wx9eR41QzghBCCCFKgR56hBBCCFEKOjVlnV1cCxYsSLax+8xXRuYUV3bBcUorkKbcTZ06tbBdUXE673LjdOtevXpFm114gOStHPPmzUteF1Xz5KrbAPDaa69FmyVIn3q+ww47RJtdsvVSFLER8VJjzhXNaepcMoD7DwAGDBgQbU5zfeCBB5J2XMaAJckf//jHSbv//M//jPaHPvShaHemG31TaDrnHZnamyvkmEs35jmYz69v15oCkvWS5tyR1FpQ86WXXkpec+o4z4NAWhyUC7NyiQ8gvcf9+c9/jrYPHeF9cHr8nXfembTj9PgLL7ww2n4cdqQk3RgzgBBCCCHEJqKHHiGEEEKUgk6Vt771rW9F28sZ7KLmzB0gzaJi2cK76njtEJZEvPuQX2+77bbR9hWe2Q3Px8AyGgDccsst0ebK0iKtwAyklXn5PHrZi92zAwcOjLaXrfi6YXvatGmtPGLREllh8ODB0ebK6X4cFFU357W2gNTdzpXZvUzKFWdzFZ4bRd4qOudz586NNp9fnt+A1q0Lluvn3DaeC1uz/9Z+b1cl95u5Evk999yTbOP1sfxaWW+88Ua0OZzDLzjKcjKvcemvL74X8rztFwXmSuwzZsyI9v/+7/8m7YpWT/Db2oLGmAGEEEIIITYRPfQIIYQQohTooUcIIYQQpaDDY3pYr+PKyKzJA6ku72N6GI7H8bE1Pn6kuWMAgN13373Z/fkYIf4ca5q+3U9/+tNoK6Ynxa+yzvEAHNfF8ThAWjmUP+M16aJYEa+TL168ONpacb3teOaZZ6L91ltvRXvPPfdM2j399NPR5jggH9vHabM85ny1dI7fy8X0NEIK9Lp16+Lvvvnmm5NtEydOjPaIESOi7eMeHnzwwWj37ds32lyNF0jPm698z6VC+Jx6eJ88V/tj4hhJ3jdXYgfSPsvN/dx/fl7heYGvKV/+hGNk6pUpU6ZE++GHH4627y8+bxzvBaT3Rp5b/RjgKvYHH3xws+8DwJIlS6LNMUJ+XPK8zXPDpZdemrTjdHulrAshhBBCtAF66BFCCCFEKehweYtdV+yq+/znP5+044VEc+5Pdpn6ysqcDs3prlxN2X+OFz/0bjZ2r/P+fJqtd0mXHT5vy5YtS7ax651lK79AJbtnOU3du799amUTfiFLru4reasCSz9s59zNv/zlL5PXffr0ifawYcOi7WUmHoPsOvdyJbv2hw4dWnhMnAL7j//4j9H2MmlusdR6YdWqVZg0aRIAYNasWcm2yy67LNoPPfRQtHnhXiCVdkeNGhVtX8WXZRC/EDOnPXPK8/Lly5N2XOaDZTBeNBpIxyC34zR8IB3fPPf7sc4SHlf/BtLfzPIpz+9AunB0vXLjjTdGm+9VXtJj/LXN547nWX9O+X7K14YvS/CFL3wh2q+88kq0/WoHLE9z5WaWujoaeXqEEEIIUQr00COEEEKIUtCpFZmZ8ePHJ6856+m+++5LtrHrkjOncouYsWvVu/5YEmEpxstlnOlw0UUXRfsb3/gGRDGcxePPKbs8fYYAU5TFwW58IO0j/i5f4dlnC4p0XBQtIgkA999/f7SfeOKJZBtLE3z+/T54QUTuC5akAeC4445rdhtnj/jX5557brSvueaapB0fR60LO3Y0W265Zcwo9bLCzJkzo/3YY49Fmxd29K9ZBjrssMOSdlzp3M/BxxxzTLQXLVoUbX9Mp556arRZvmZpA0jnAd7mpY6DDjoo2jxve+mEQwz8vMLXF2dssSQIpDJNvcJSP49LP4cNGjQo2rm5lPFyMr/m7/Jjg6VL/gzLoEAalsByGUtiHY08PUIIIYQoBXroEUIIIUQp0EOPEEIIIUpBp8b0cMyN1/x5pXLWkwFg//33jzbrmL6aK2v2rE/mqrQy8+fPT16zTsppmiIPa/l+VXSfmt6EX+GeyVXV5W38Xb5at0+7FSm5lbMfeeSRaPtyEhx7xfEiw4cPT9otWLCg2W2+5ADHAXAKtU+95hR4juviaw9I44L8PFDrauHtzZo1a+L54XMIpLEQfN4WLlyYtOM5c86cOdH25TW4ar2vms1p4Lx6NpeZ8HCJgD322CPZxvMp/y5f0Z7hir5NafzNbfPX1wsvvBBtLn/iY11y310v8FzF90kfP8MrC/gYSI674evc3/uK7pO+9ANfh7zNV2Tmyuv77LNPtP1559IBvtJ0WyNPjxBCCCFKgR56hBBCCFEKOlzeKqr06uUMdsGxWxtIXeBFVWSB4uqr3q3N38378O0kabU9XCLAL5LHsHTJrlrfJ9x/uYVJc9VMy0qti3GyfMS2hyURliIA4OWXX442py/772XXPqcoezmcj4P71lc0PvLII6Ndr/LWFltsEWU4X8GcSy+wpOV/C3+u6DNAWsl6zJgxyTaWMEaOHBltLlkApFLjvvvuG22WlYA0FX3q1KnR9hLpk08+GW3uE3+PYAnPLyTK8gnv398jiuT1eqIo/dzPYSxV+nsmS1C50AEOCShKX/f7Y9vLVjy/89jm94FU7pS8JYQQQgjRBuihRwghhBClQA89QgghhCgFHR7TUxQrkIshKFqCAEg1WZ+yzksUFKWv5/bnS5sXUa/l7OsF1p59LAafY44B8Zov6/Kc+sil+IG0/Dz3g//eeonfqCc4LoTPj4+X4Bic/v37J9tYmx8wYEC0fXwH981rr70WbY4JAdK4El6SwMdocWosx7D4Fbw5pqdex+kHH3wQVwPncwgAH/vYx6LNK6v7WIohQ4ZEm8eET3M+77zzou1jdTieipcCOvjggwuPifv/2GOPTdrNnj072rz0xGmnnZa0K1r+guOKAGDGjBnR9qUJmKFDh0abV1wHNow1q0e4vAOvTu/vd4y/J3Fbvsf5McDzZC7ukcdfURyl339RaRggHaeHH354Ybu2QJ4eIYQQQpQCPfQIIYQQohTUzSrrOVezT2XmFDl2s+VSntlV591sLLGwi18p6m0DlxjwlT2ZXIo5S5zcR34lZ5bB+Hrw8lZO4iwrRe7niRMnJq/Zxc5SI5COJXaps8QApCnVfH14mYLHIMvVPo23SQ4CUjmH03g9tcrXHc37778fZSiW9IA0BZ/T9P3cxytw8zlgiQkAjjrqqMJ9sKzygx/8INp+XrzxxhujzfKWX8GcZYspU6ZE219DLNX94Q9/iPbbb7+dtOMK0l4OX7p0abP789dhrauRdyR+DPD44KrLXt7iOY3HA5CeHx4f/rzxPnjO9PMxw3KZl8R4H3yP9/f7J554onD/bY08PUIIIYQoBXroEUIIIUQp6FT/bq0VYD3sDmU3rne7skuOJZFc9Wfe1q1bt5qPSRTDLlQvKbD7MydvcYVRdvF6iiqs+u/1spgoHoM+e4vHLVfWBdL+7NevX7S9NMGSCy9S6LOtWK7k4/MSAI9VXlzWL2DKkkAuK7Qz2XbbbTF69GgAacVkIJV0eJHVBx54IGnH8iFnaPnsrSuvvDLa/nxcddVV0eaMuGuuuSZpx1leLF9Pnz49aXfcccdF++tf/3q0/TXE1wZnbHkZjBcg5Sw/IF2AlCUXL+999KMfRb3B1cqB4pUFPDz3eamS59acrMvjN7c6QdFnPPxduewt/5vbE3l6hBBCCFEK9NAjhBBCiFKghx4hhBBClIJOXWW9tRVROc2QtUqvGbK+zNo+xxAAxat2e62SV3neaaedCr+3Xiu9dha1rmjOOnSuL/nc86rA7XFMZaKoSvW8efOS1x/5yEei7eNAnnvuuWhzn/Xp0ydpx2OE4za4Krdnjz32iPaSJUuSbRw3xr/Dj+Hnn38+2hz3UU9sttlmMS7pzjvvTLYNGzYs2lzJeMWKFUk7fs3nbcKECUk7TntfvHhxso3jXQYNGhTt008/PWn3P//zP9Hm2A++ToB0NXaOreJ5FUivDf4d++23X9KOt/l9fPKTn4z2r371q2j7FO1cnEln4eOueF7MVTjOpYTzOOC4VR/fWnQ+/P74PPLx8dwMpPFZXDrA7y9XyqStkadHCCGEEKVADz1CCCGEKAV1s+CoT4ljd9wvf/nLZBu75Dil1S+6x/tg26fscaofy1u+mutFF10U7euuu67ZfYsN4f7KLZLH14aXn9iFypKKT23n72KZw6ey545DpHKBl5zY/e5TzFmq4jTnF198MWnHbnQuH+AXgOR0eZZHfCo69/uzzz4bbT82eeHTepW31qxZE6she4mIf8/8+fOjzYt+Aun1Pm3atGiPGDEiacfVeXkRUADo27dvtH/9619Hmys1A2kqOvfLww8/nLTjMTxq1Khoe4maK37zfHz77bcn7fbee+9on3/++ck2lln52vD3Hy+T1gO+RESuGjJTJIMBxfOiHx+1hmbwPZT37cvGsAyWC23h0jPtje7WQgghhCgFeugRQgghRCmomxX3cm61++67L3ldVEHZw641jg73UgdLa2xzZVegYxdF60pwH3kZk12e7Gr18hNnBbBskpPBcpkZRZWbRQU+r5zhAwDjxo2LNlf+BdJ+44wtlqGBVCJ74YUXou2za7jaL1d49lI2zx+8qKTPasotQFovbL311thrr70AbPg7+drnCsW86CeQnoMhQ4ZE+7LLLkvajR07Ntr+3Nxxxx3RZsnFVz9mSYsXhf3Nb36TtDvhhBOa/S5fjZclt9deey3axx9/fNKOr7Vbb7012XbggQdGu6m6NbBhhWuWyOoFn4nGfc74TCluV2uWmp+P+d6auyfzNt6Hn7cPOOCAaHMVdT9v+4rt7Yk8PUIIIYQoBXroEUIIIUQp0EOPEEIIIUpBQ8T0+AqV3JbjRXwqOuuYrCH6KrK8v5ym6VeuLYI1TqWzp/hzyOeYz5VPSe7du3e0eaVprw3zPt59993C46g1DbSs3HLLLdH2Ket8zv05fvTRR6PN1YR9O44L4VIQv/vd75J2nM7MMXU+xfXoo4+ONldsf/XVV5N2HBdUr4QQYsyZT0XnWI0pU6ZEe+bMmUm73XffPdocZzNw4MCknU8/Z3hsHnnkkdH2MV4c78Nz67777pu04/gOjlXycSAcx8XzO1eWBtLq2j6mh4/pxBNPjLaPC/Lp4fWAj+Pi88N90q1bt6Qdp/r7fuVUcr4/+VifohjLXIVnvmf6Y2+KTQPS68bHHHXkfKw7shBCCCFKgR56hBBCCFEKOlXeqnXxUU5bBFIZi91kPsW8qBKnl5z4OIoqVwKpe04SVu0UuWeBtC+5rIB3d7K7fpdddom2l01YPuP+87KaUtbzcJVkL2/xAqS9evVKtj311FPR5r72lVpZcuHUW99P7C7nsend8pz2zlWdvcTCkki9snbt2jjncfo2kM41XAbA/07+3Pjx46PtQwW6d+8ebV8ZmSs581jidHAgTfvm/jrnnHOSdixP5hYSZclp0aJF0b7//vuTdryoqK9czSnQPFd7iaweFxzlsQGk1z3Pi4MHD07a7bzzztH24QEsheUqVBfd1/w9rkj68vMqzw9cDd2Xmsnto9awklrR3VoIIYQQpUAPPUIIIYQoBQ0hb3kJo8hV57O3ir7Lw9+dOw52+XP2iK+MKVJY3splC3Bf+uyc7bffPtosb3lXaNE15eUy7kuxIXx+fIYcS8q8uCeQyiC5McdjldvlKnbnxiZn/LCE4TONvNu/Htl8882jPOUXxORKxmPGjIk2y78AsHDhwma39e/fP2nH8pHPaj3iiCOizdeAl1W40i7LZV5K432wFLN48eKkHe+DpUpftZflN65ODQDHHntstHnxUb5OAOBTn/oU6g1/nfMcx9t8lfOiKslAOt5yoRm5FQ6YogW8/b2a+5mvL86wBFJJb+nSpcm2ts64lKdHCCGEEKVADz1CCCGEKAV66BFCCCFEKaibisw5uBovkOqBrCd6LZTjAdj28R38uVwMAWurrGMrpicPn1Mfg1NUidPHXvhYhCZ8Si/HmxRVIQVq167LCuvqBx10ULKNU0jnzp2bbOP+zY1NpmicAmm/se3LSfD3cjo0p0kDacyBjz/wJS86k6aYCV+tePr06dHm9Ht/fXP8C1ck9uPokUceibZPe+fXfBy/+MUvknZ8PfTo0SPafgwfc8wx0eZ4pCuvvDJp9/TTT0f7i1/8YrRHjhyZtLv88suj7cua8D2C46K4QjCwYcxXPeBjU7lved7y5SJ4Ls2VBuGx4sdR0ffmUtbZ9hWZ+d44ZMiQaHO1diAtl+BXmVdMjxBCCCFEK9BDjxBCCCFKQd2krHvYjeddZkWpyN6ll0tZruV7veuPj5fdqYMGDapp32JDWYn7hV3o3sXrF0psgtNbgdSl7lM6RR4uE8Dn0Y9TTof2KcCtISdvMexu91VaWabg+YIXIgWAyZMnR9vLL/Uib2255ZYxVdtXSWaJgMeLT+fmlO3DDjss2lwxGwDGjh0bbT/GuGwBf5eXyDg1nc+pl+a40jJX9R42bFjSjtOced8vvfRS0o7nXS/v8fXA9wFfXZy/q17gyvRAevx8Tn3YB8udfh9FFZS9bFX0XbnFt3kfuUrLfN34MAfehy9X0tbI0yOEEEKIUqCHHiGEEEKUgk6Vt3IZHZyFk6viy27NWhePy7Xjbd71x9/lJTdRDLtCvcxYVKXTy1tF0oOXsNi9zq7WnDtVVGD5gV3nCxYsSNpxH/oMEq7QzJXTPUVV0GvNEvGZV1ypmI+hZ8+eSTt22c+fPz/ZxtV/O5M1a9bEc37TTTcl27i6Mlcp56wpAJgwYUK0WY70GVosGfnqz+PGjYs2y2KcHQdsKBk14bNweFFYlpU4WwtIxzq3mzVrVtJuzpw50fZZnHx98FziF5ydMWNGs8femfi5j8cHV7X2i6fy+fGyKN+7cvfd3HEwPLfy/O6/11debu54PG0hmefQzC+EEEKIUqCHHiGEEEKUAj30CCGEEKIU1G1F5lw116K08lzsD5OryJzTPjmmgFeFFXm4MrLvE06L5fPN8QpAceXQXEwJ6/r+e3N6dVnhWI1XXnkl2j6Vmava3nrrrck2jtHicZqLI+B2Xuvnz3Fati8TwcfE146PMeD4g1pjADuazTbbLP4GjqsB0lhHTvv2K6QfeOCBzW7j8Qakqd2+DABXs+bYudxK9XzufSo6z7u+gjLDaeq8CrxPh+7bt2+0fZwRp2xzqrRPt/ers9cDPtWf4XPg+5y35eY3nkv9vZDHBLfLrXbA+PFWtL9cbGfu+moL5OkRQgghRCnQQ48QQgghSkHd+vjZ3eVddezirTX9jqn1Mzn3t0+RrPVzZWfAgAHJa04l5zIARRWYPb4qKae/cj/7a0jy5IZwyjrLGSw3AGk/eXd2rpIzk0tZZdglzp8588wzk3af/vSno/3xj3882iyBeGqt0t7RrFu3LspOPuWex8u9994b7f322y9pd8ABB0Sb09kfeuihpB2XFfDSF6ec86KlfhHXl19+OdocAsDp9UAqfbF86mUa/o18Hfr0Z5amfHkEXtDyqKOOijanfAOpfFYv+HIMLDvyNi7TANReUbzWCuhFZSVy+/ASKV9DPJZ9n7Mcyff39kCeHiGEEEKUAj30CCGEEKIU6KFHCCGEEKWgbmN6GK//8SqsrVlOwOuYrDVy2p9PkeTv8mXfmdbEGXVluNS9Ty3lVdI5Jfmggw6qad8+ZoP7jLVhHw9Qj1p+Z8NxEXxevcbO/eTPa63LS+yyyy7RXrp0abRzy4rwmPvRj36UtPvOd74T7ZEjR0Z7zz33TNpxHEx7r+bcWrbeemsMHToUwIbxHRyb9jd/8zfR9nMVL7HBZR18iQc+V7fddluyjeOJOK7LxzMOHz482rxshF/6ha8jjsXzx8TfxXOzvzY4LoivJyBdjZ6X1/ArtZ966qmoN/z9iWOhOH7K9znH9PilQXj8FZX/ANK4uaKV2Zt73YTvBy6JwH1S60ry7YE8PUIIIYQoBXroEUIIIUQpaAh5i93fnly13yJqTdPzLnl2LfP3tmT/ZYRTS33K+m677RbtF198MdqjRo2qad8jRoxIXu+0007RZrnGu4I/8YlP1LT/MsGp6OyW9qtlsyzk5UV2v7MM5s8/pw6/9dZb0fbyJ383jz/vHi9KX/YrxHNqe60pvh3NNttsE1dD96uityef//znO+y7RO2wvMXyk69KPnny5Gh76ZZDRLhUgx+XTK1hGrlKyzynH3bYYdH2JUT4c76sQFsjT48QQgghSoEeeoQQE/bk1wAABy5JREFUQghRCjpV3qrVfcYZAcCGlSib8AuV8WuOCPfR4UWLs/lqszlXIKPsrRSWFNhuC9hlCgBTp06Ndi5LQWwIu8C56i5n2AFAnz59oj1hwoTC/c2ePTvaXqJmGYsXpjzuuOOSdjzmcotZcpYWf+akk05K2vFxjB49uvDYhegsfFXjxYsXR5vlLR8qwJK9r7zN9zLeh6+MXrRAaC5Lmrd5WY2zcHlRYJ8RyhL38uXLC7+rLZCnRwghhBClQA89QgghhCgFeugRQgghRCloiJgev5I2V4Hl1HEfe8BprVzZ1GumrGOyPskpt0CqQ+ZWWRcpnILoU41rhc89x2D5eKyiOB4fj8Upkr7id1nh+Kirr7462n68XHXVVTXtj6v9sp3DrxbeGvga8HMHzxG8GrsQ9YKPe+Qq4hyD46sfn3322c3a9cjxxx+fvOb5+eSTT27X75anRwghhBClQA89QgghhCgF1pLqwWb2JoDFG20o2pJ+IYSeG2/WMtSXnYb6s+ugvuxatHl/qi87jcK+bNFDjxBCCCFEoyJ5SwghhBClQA89QgghhCgFDffQY2YfmNksM3vazGab2TfMrOF+R9kws52r/TbLzF43s1fpdevy2EVdY2a7mdlNZrbQzOab2R1mtncL97GjmX21vY5R1A7NvbPN7EkzO2jjnxL1RtnHZcPF9JjZ6hDCdlV7FwATAEwLIfyLa7dFCOH95vYhOhcz+1cAq0MIP3DvGyrX5LpmP9j2x6FrpJ2o9uUjAP47hHBd9b1RALYPITyU/XC6n/4AbgshDG+P4xS14+beTwD4dgjhsI18TNQRGpcN6OlhQgjLAHwJwNeswplm9nszmwRgMgCY2QVm9riZzTGzf6u+92Ezu736F8s8Mzu1+v4V1SffOWb2g8IvFm2Gme1Z7YPrADwJoJeZ/Z2Zza2+//1quy3M7G363GfM7Hqy51X7cwq1/6GZPVbtz3+ovn+0md1rZjcBeKrDf3B5OALA2qaJFQBCCLMAPGxmV1X7ay6Nve3M7L6qB2GumZ1Q/dgVAAZVPQy1VUUUHcEOAFYC2b6DmV1sZs+a2T1m9lsz+6dOO2IBaFx2bkXmtiCE8GJV3moqTzkWwIgQwltmNg7AXgAOAGAAJprZoQB6AlgaQvgUAJhZNzPrDuBEAINDCMHMduzwH1NehgL4QgjhK2bWB8BlAMYAWAXgXjP7NIC7Mp//FwCHhxDeoH77EoBlIYQDzGwrADPMbHJ120cBDA0hvNwuv0YAwHAATzTz/kkARgEYCaAHgMfN7EEAbwI4MYTwJzPrgUp/TQRwIYDhIYRRHXTcophtzGwWgK0B9AJwZPX9NWi+70YDOBnAfqjca55E89eE6DhKPy4b2tND8HoW94QQmtapH1f99xQqA24wKg9BcwEcbWZXmtnHQgirAPwJlcF7vZmdBODPHXb0YmEI4fGqfSCA+0MIy0MIa1GRLw/dyOenARhf9eY0XdPjAHyhOkk/CmBHVPoeAKbrgafTOATAb0MIH4QQ3gDwAID9URnD3zezOQDuBdAbwK6dd5iiGd4LIYwKIQwGcAwqY85Q3HeHAPhjCOG9EMI7ACZ11oGLjVKacdnwnh4zGwjgAwDLqm+9y5sBXB5C+FkznxsN4FgAl5vZ5BDCJWZ2AICjAHwGwNew/i8Z0b74PmuOdW7b1mR/EZWHpU8DmG1mI6ptvxpCuI93YmZHu+8T7cPTAE5p5v2i/v0cKh7Y0SGEtWa2CGkfizoihDC9+pd/T1Tm0eb6rrbFFUVHUvpx2dCeHjPrCeA6AP8Rmo/IvhvAWWbWFHzX28x2MbPdAfw5hPBrAD8A8JFqm24hhDsAnIeKq090PDMAHGGVbK8tUHkAfaAa3LzSzPaqypkn0mcGhhBmALgYlTiD3qj0/Ver+4CZ7WNm23ToLyk39wPYysy+2PSGme2PSv+camabV8fvoQAeA9ANFTlyrZkdAaBf9WPvANi+Yw9dbAwzGwxgcwArUNx3DwM4zsy2rs6vn+qcoxVE6cdlI3p6mnTlLQG8D+BGAD9srmEIYbKZDQEwveKFxWoAfwdgTwBXmdk6AGsBnI1KB/7RzJr+Qjm/vX+I2JAQwhIz+y6Aqaj0w6QQwu3Vzd9CJbbnZQDzATQtj/4jMxtQbT85hDDPzJ4B0BfArGrfLwMQAyxF+1KNizsRwNVmdiEq0vEiVP6g2A7AbAABwDdDCK+b2W8ATDKzmQBmAXi2up8VZjbNzOYBuDOEcEEn/BxRoWnuBSpj7YwQwgeZvnu8Gv8xG5WlGGaiEqcnOgmNywZMWRdCCNEYmNl2IYTVZrYtgAcBfCmE8GRnH5coL43o6RFCCNEY/NzMhqISB/LfeuARnY08PUIIIYQoBQ0dyCyEEEIIUSt66BFCCCFEKdBDjxBCCCFKgR56hBBCCFEK9NAjhBBCiFKghx4hhBBClIL/D3r/yQ21AObSAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 720x720 with 25 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(10,10))\n",
+    "for i in range(25):\n",
+    "    plt.subplot(5,5,i+1)\n",
+    "    plt.xticks([])\n",
+    "    plt.yticks([])\n",
+    "    plt.grid(False)\n",
+    "    plt.imshow(train_images[i], cmap=plt.cm.binary)\n",
+    "    plt.xlabel(class_names[train_labels[i]])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "59veuiEZCaW4"
+   },
+   "source": [
+    "## Build the model\n",
+    "\n",
+    "Building the neural network requires configuring the layers of the model, then compiling the model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Gxg1XGm0eOBy"
+   },
+   "source": [
+    "### Setup the layers\n",
+    "\n",
+    "The basic building block of a neural network is the *layer*. Layers extract representations from the data fed into them. And, hopefully, these representations are more meaningful for the problem at hand.\n",
+    "\n",
+    "Most of deep learning consists of chaining together simple layers. Most layers, like `tf.keras.layers.Dense`, have parameters that are learned during training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "9ODch-OFCaW4"
+   },
+   "outputs": [],
+   "source": [
+    "model = keras.Sequential([\n",
+    "    keras.layers.Flatten(input_shape=(28, 28)),\n",
+    "    keras.layers.Dense(128, activation=tf.nn.relu),\n",
+    "    keras.layers.Dense(10, activation=tf.nn.softmax)\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "gut8A_7rCaW6"
+   },
+   "source": [
+    "The first layer in this network, `tf.keras.layers.Flatten`, transforms the format of the images from a 2d-array (of 28 by 28 pixels), to a 1d-array of 28 * 28 = 784 pixels. Think of this layer as unstacking rows of pixels in the image and lining them up. This layer has no parameters to learn; it only reformats the data.\n",
+    "\n",
+    "After the pixels are flattened, the network consists of a sequence of two `tf.keras.layers.Dense` layers. These are densely-connected, or fully-connected, neural layers. The first `Dense` layer has 128 nodes (or neurons). The second (and last) layer is a 10-node *softmax* layer—this returns an array of 10 probability scores that sum to 1. Each node contains a score that indicates the probability that the current image belongs to one of the 10 classes.\n",
+    "\n",
+    "### Compile the model\n",
+    "\n",
+    "Before the model is ready for training, it needs a few more settings. These are added during the model's *compile* step:\n",
+    "\n",
+    "* *Loss function* —This measures how accurate the model is during training. We want to minimize this function to \"steer\" the model in the right direction.\n",
+    "* *Optimizer* —This is how the model is updated based on the data it sees and its loss function.\n",
+    "* *Metrics* —Used to monitor the training and testing steps. The following example uses *accuracy*, the fraction of the images that are correctly classified."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Lhan11blCaW7"
+   },
+   "outputs": [],
+   "source": [
+    "model.compile(optimizer='adam',\n",
+    "              loss='sparse_categorical_crossentropy',\n",
+    "              metrics=['accuracy'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "qKF6uW-BCaW-"
+   },
+   "source": [
+    "## Train the model\n",
+    "\n",
+    "Training the neural network model requires the following steps:\n",
+    "\n",
+    "1. Feed the training data to the model—in this example, the `train_images` and `train_labels` arrays.\n",
+    "2. The model learns to associate images and labels.\n",
+    "3. We ask the model to make predictions about a test set—in this example, the `test_images` array. We verify that the predictions match the labels from the `test_labels` array.\n",
+    "\n",
+    "To start training,  call the `model.fit` method—the model is \"fit\" to the training data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "xvwvpA64CaW_"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/5\n",
+      "60000/60000 [==============================] - 10s 160us/step - loss: 0.4965 - acc: 0.8247\n",
+      "Epoch 2/5\n",
+      "60000/60000 [==============================] - 8s 138us/step - loss: 0.3745 - acc: 0.8648\n",
+      "Epoch 3/5\n",
+      "60000/60000 [==============================] - 8s 142us/step - loss: 0.3358 - acc: 0.8757\n",
+      "Epoch 4/5\n",
+      "60000/60000 [==============================] - 8s 141us/step - loss: 0.3140 - acc: 0.8853\n",
+      "Epoch 5/5\n",
+      "60000/60000 [==============================] - 8s 135us/step - loss: 0.2963 - acc: 0.8906\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<tensorflow.python.keras.callbacks.History at 0x178c8d44a58>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(train_images, train_labels, epochs=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "W3ZVOhugCaXA"
+   },
+   "source": [
+    "As the model trains, the loss and accuracy metrics are displayed. This model reaches an accuracy of about 0.88 (or 88%) on the training data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "oEw4bZgGCaXB"
+   },
+   "source": [
+    "## Evaluate accuracy\n",
+    "\n",
+    "Next, compare how the model performs on the test dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "VflXLEeECaXC"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10000/10000 [==============================] - 1s 71us/step\n",
+      "Test accuracy: 0.8727\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_loss, test_acc = model.evaluate(test_images, test_labels)\n",
+    "\n",
+    "print('Test accuracy:', test_acc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "yWfgsmVXCaXG"
+   },
+   "source": [
+    "It turns out, the accuracy on the test dataset is a little less than the accuracy on the training dataset. This gap between training accuracy and test accuracy is an example of *overfitting*. Overfitting is when a machine learning model performs worse on new data than on their training data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "xsoS7CPDCaXH"
+   },
+   "source": [
+    "## Make predictions\n",
+    "\n",
+    "With the model trained, we can use it to make predictions about some images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Gl91RPhdCaXI"
+   },
+   "outputs": [],
+   "source": [
+    "predictions = model.predict(test_images)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "x9Kk1voUCaXJ"
+   },
+   "source": [
+    "Here, the model has predicted the label for each image in the testing set. Let's take a look at the first prediction:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "3DmJEUinCaXK"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([9.4569641e-09, 9.1678389e-09, 8.5358849e-09, 2.8125953e-11,\n",
+       "       4.8381317e-08, 1.5418796e-03, 7.6329192e-09, 2.6696799e-03,\n",
+       "       5.2743690e-08, 9.9578828e-01], dtype=float32)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "-hw1hgeSCaXN"
+   },
+   "source": [
+    "A prediction is an array of 10 numbers. These describe the \"confidence\" of the model that the image corresponds to each of the 10 different articles of clothing. We can see which label has the highest confidence value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "qsqenuPnCaXO"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.argmax(predictions[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "E51yS7iCCaXO"
+   },
+   "source": [
+    "So the model is most confident that this image is an ankle boot, or `class_names[9]`. And we can check the test label to see this is correct:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Sd7Pgsu6CaXP"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_labels[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ygh2yYC972ne"
+   },
+   "source": [
+    "We can graph this to look at the full set of 10 class predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "DvYmmrpIy6Y1"
+   },
+   "outputs": [],
+   "source": [
+    "def plot_image(i, predictions_array, true_label, img):\n",
+    "  predictions_array, true_label, img = predictions_array, true_label[i], img[i]\n",
+    "  plt.grid(False)\n",
+    "  plt.xticks([])\n",
+    "  plt.yticks([])\n",
+    "  \n",
+    "  plt.imshow(img, cmap=plt.cm.binary)\n",
+    "  \n",
+    "  predicted_label = np.argmax(predictions_array)\n",
+    "  if predicted_label == true_label:\n",
+    "    color = 'blue'\n",
+    "  else:\n",
+    "    color = 'red'\n",
+    "  \n",
+    "  plt.xlabel(\"{} {:2.0f}% ({})\".format(class_names[predicted_label],\n",
+    "                                100*np.max(predictions_array),\n",
+    "                                class_names[true_label]),\n",
+    "                                color=color)\n",
+    "\n",
+    "def plot_value_array(i, predictions_array, true_label):\n",
+    "  predictions_array, true_label = predictions_array, true_label[i]\n",
+    "  plt.grid(False)\n",
+    "  plt.xticks([])\n",
+    "  plt.yticks([])\n",
+    "  thisplot = plt.bar(range(10), predictions_array, color=\"#777777\")\n",
+    "  plt.ylim([0, 1])\n",
+    "  predicted_label = np.argmax(predictions_array)\n",
+    "  \n",
+    "  thisplot[predicted_label].set_color('red')\n",
+    "  thisplot[true_label].set_color('blue')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "d4Ov9OFDMmOD"
+   },
+   "source": [
+    "Let's look at the 0th image, predictions, and prediction array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "HV5jw-5HwSmO"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAC6CAYAAACQs5exAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAOvUlEQVR4nO3de9BV1XnH8e8jqMhFuYh4o762xTFGKSghbdN0kmpMtK1Km6TSpNM0M512TMbazhjTm71O0kmnt2nT2kYdk9ZLUkMS0jRB/UcBkQAmKmi9JIBVFAWVFxBRYfWPvaGHs9d+OQeBpe/7/cw4857nrLP32kf9nXX22mufSCkhSTr8jijdAUkaqQxgSSrEAJakQgxgSSrEAJakQgxgSSpkdOkOSKUdf/zxaWBgoHQ3NEytWrVqU0ppau45A1gj3sDAACtXrizdDb3JnHgibNzYe/tp0+DZZ5v1iFjf9hpPQUhSRj/heyDtwQCWpGIMYEkqxACWpEL6moRztliH0rp169i0aVOU7od0uPQVwM4W61CaM2dO6S5Ih5WnICSpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpEANYkgoxgCWpkNGlO6CDZ9euXY3aEUfkP2Mjouft7ty5s1E7+uijs20ff/zxRm3GjBk970saSRwBS1IhBrAkFWIAS1IhBrAkFWIAS1IhXgVxkKSUeqpB/sqEp59+Ott22bJljdpFF12UbTtu3LihunjA2q54yFmwYEGjds011xzM7kjDhiNgSSrEAJakQgxgSSrEAJakQpyEO4TalgHnLF68OFtfvnx5o7Zhw4Zs2yuvvLLn/fXjueeea9QWLVqUbTthwoRD0gdpOHIELEmFGMCSVIgBLEmFGMCSVIgBLEmFeBXEQZK7Gfro0fm3d8WKFY3aI488km07bdq0Ri1303OAefPmNWqTJk3Ktn3llVcatdNOOy3bdvPmzY3a4OBgtu0pp5ySrUtqcgQsSYUYwJJUiAEsSYUYwJJUiJNwB2D37t2NWm7Cbfv27dnX33777Y1a2z13c5NlW7duzbbt557EufqaNWuybU899dRGrW1yLzcZKSnPEbAkFWIAS1IhBrAkFWIAS1IhBrAkFfKWuwoiN3sfEdm2uasV2trm6m0z+qNGjRqqi3tdd9112XpuefGYMWOybdevX9+o5a6MaNvu66+/nm2bO962X1XOXaGxZcuWbNudO3c2am1XgxyqX3GW3iocAUtSIQawJBViAEtSIQawJBXyppiE62dira2e08+vEucm3HqdbAO49dZbG7Vnn30223b27NmNWttk2UsvvdSoTZ48Odt2ypQpjdqmTZuybbdt29ZzH3Lalji//PLLjVrb/YtnzZrV8/6k4cgRsCQVYgBLUiEGsCQVYgBLUiFvikm4fibWcqvbcjXIT6K17aufCbcbb7yxUXvssccatenTp2dfn/uRy7ZJrR07djRqbT98mbtPcNvxjh07tlFrW2HXzyRpzqJFi7J1J+E00jkClqRCDGBJKsQAlqRCDGBJKsQAlqRCDtlVEG1XJuTkZtTbrgrILS/uZ8lxmw0bNjRqCxYsyLbNXZkwY8aMRi233Bfy98zNXRkBcOSRRzZqbVcg5JYBt8m9Z22/zJxr23Yv31zfli5d2nO/pJHEEbAkFWIAS1IhBrAkFWIAS1IhfU/Cdd83t20J7xudGOtnqevzzz+fra9bt65Re/TRR7Ntn3nmmUbtqKOOyrY99thjG7XcfXsHBwezr3/ttdcatdzEHOTf39xxQf5+vhMnTsy2zR1b24+Q5iZEjznmmGzb3DbGjx+fbbt69ep9HucmN6XhzBGwJBViAEtSIQawJBViAEtSIQawJBXS91UQvd64fOPGjY3a+vXrs223b9/eUw3yM+Vr167Nts0tzR09On/IEyZMaNTallNv2bKlp3617SvXr7arCnLLg1999dVs25NOOqlRa7sSI9eHSZMmZdvmllS/8MIL2ba5Kx7afh26exttV2FIw5UjYEkqxACWpEIMYEkqxACWpELe8P2A77rrrmw9d3/dtkmp3FLitgmZ3CRgPxNrbffozU0Utd2TOLdsODeB1TaJl+tD2/Hm7rvbtrQ3t+y4bZl2P3LH1rbUPDcZ2TZp2PbvTRopHAFLUiEGsCQVYgBLUiEGsCQVYgBLUiF9TUMPDg5yxx137FO74YYbsm3PPPPMRi23VBb6Wwb8Rm8kntsX5Gfq22b6t27d2tO+2m4wnrvZfNsx5K7OyC3zBnj44YcbtbYrEPpZ9pu76qJtqfiYMWN6ej3ACSecsM/j3C9AS8OZI2BJKsQAlqRCDGBJKsQAlqRC+pqEGzduHHPnzt2ndt9992XbPvTQQ43akiVLet5X24RMbhJt8uTJ2ba5+nHHHZdtm5usaluKvHnz5kYt92vLuXvuQv4evW2/Av3AAw80ajNnzsy2HRgYaNTuvPPObNvccup+fsm6bRnxySef3KjlfkUampOZ3g9YI40jYEkqxACWpEIMYEkqxACWpEIMYEkqpK+rIEaNGtW46fe1117b8+vbboa+fPnyRi13VQHAvffe26itW7cu2/bBBx9s1NqW0OaueGi7MiF3tUDuiotzzjkn+/oLLrigUbv44ouzbXNLe/txySWXZOtPPvlkozZlypRs29xVDG1LunNXR+R+2RngjDPO2OfxGz1W6a3GEbAkFWIAS1IhBrAkFWIAS1Ihh/VnadvuC3v++ef3VAO44oorDmqfhruFCxeW7kLP+lkKLQ0H/hcvSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUiAEsSYUYwJJUyOh+Gq9atWpTRKw/VJ3RiHda6Q5Ih1NfAZxSmnqoOiJJI42nICSpEANYkgo54ACOYF4EKYIze2y/LoLjM/Vtfe63r/ZDbOdjEZzc8tyHIlgTwe4I5nQ99/sRPBHBoxG8v6P+gbr2RASf7qjfHMGDEXymo/bHEVw6RN9mR3B9V+0bESzr8djeE8F/tRzzP/WyjQNpP8R2JkZwRcfjqRF8541uV3qr6+sccJf5wBLgcuBPD0pvDq+PAauBDZnnVgO/BPxrZzGCs6iO9+3AycBdEZxRP/154H3AU8CKCBZSv78pMTOCxREcB4wF5qbEXwzRtz8A/rJjvxOBc4FtEZyeEmv7PNbSJgJXAP8MkBLPR/BMBO9KiaVlu+bksg6eiGy5dXL5gAI4gvHAu4D3AgupAziC99R/bwLOBlYBH02J1PHaY4CvAV9NiS90bfdq4MPA0cDXUuJPWvb/N/W+XwQur/+HngVcRxVwPwA+nhIv5urA+cAc4OYIdgA/lRI79mw/JR6p99PtUuC2lNgJrI3gCWBu/dwTKfHD+nW31W2/DhwTwRHAUcAu4M+Ba/PvLEQwAZiZEg90lH8Z+CawkeoD4LN125uAwfpYTgQ+lRK3d23vHcC/1dvorE+t35cfqUtXtYTh9Hq0ejpwS0r8Wf3636N6LwGuT4m/H6L+V8CPRfB94M6UuLp+bz4C5QPYyWWVcqCnIC4DvpMSjwEvRHBux3OzgauAs4AfpQrqPcZTBcktmfC9EJhBFWizgPMi+NnMvscB96fEucDdsDekvwRckxIzgYeGqtchtRL4SErM6gzf/TgF+N+Ox0/VtWy9DvIngfuBrwA/DkRKfG+IfcyhGoF3mg/cWv8zv+u5k4CfAX6BKuj2iuCnqUL20j0fDh3+Afi7lHgHVThfT95cqqCcBXwogjkRnAf8BvBO4CeB36xPm2TrwKeBH9Tv9dX1dlcC7x7ifZCGvQM9BTEfqhEPcFv9+P768XdT4imAesQzQHWqAuAbwOdS4ubMNi+s/9kTTuOpAvmerna7gS/Xf/8HsKD+aj8xJe6u618E/rOt3t+h7iP3BSOR/yBLAClx1d4XB98EfiuCPwR+gmo0+IWu150EPN/xmmlUwb0kJVIEr0dwdkp7Q/rrKbEbeLhuu8fbqEa+F6aUPc1yAXBWxyj/2AgmpMTWrnZ3psTmui8LqMI+UX1D2d5RfzfV+5OrL8zs/znIn4OXRoq+AziCKcDPAWdHkIBRQIrgU3WTnR3Nd3XtYylwUQS3dJ6W2LNp4LMp7XvetQfd2zmUngKmdzw+lf8/h9xWB6CedFtJNYI/OyU+HME9EdycEi93NN0BjOl4/CvAJKpTHgDHUp2G+KP6+c73u/MD4pl6O7O7+1I7gq5TLy26399E/oOoe//7MwZ6/uYhDUsHcgrig8CXUuK0lBhIienAWqqR0f5cC2ymnozpsgj4eH1+mQhOieCElj5/sP77V6lGhluAFyP2fqX9NeDutnr991ZgQg997rQQuDyCoyM4nWqE/l1gBTAjgtMjOIoqIPeO+iI4Evgd4K+pzkXvCbU954Y7PUI14t1jPvCB+r0eAM6rt78/LwE/D3ymPjff7Q7gkx19nNWynfdFMLk+d38Z1YfoPcBlEYyNYBwwD1g8RD33Xp9B81SLNKIcyCmI+XSdawS+ShWGX242b7gKuDGCz6W0d9RMStwRwduAZfVIbxvwUaqvqp22A2+PYBWwhWqECPDrwHURjAV+SHUucqj6TXW9MQkXwTzgH4GpwLci+H5KvD8l1kTwFeBh4HXgEymxq37NJ6k+REYBN6bEmo4+fwL4Ykq8HMGDQETwEPDfKfFS58GlxP9EcFw9GTeFapLsvo7n10YwGME7h3yXq7YbI/hF4NsReyfG9rgS+Hzdn9FU4fnbmc0sAf6d6kPhlpRYWR/vTVQfPlBNtn1vP/WlEawGvl2fB34v8K39HYM0nEVKh/MbvHoRwe8CW1NqnRh7y4vgHqrJwRdL90UqxZVwb07/wr7ndoeV+hK4vzV8NdI5ApakQhwBS1IhBrAkFWIAS1IhBrAkFWIAS1IhBrAkFfJ/mETmJvftLlgAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x216 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "i = 0\n",
+    "plt.figure(figsize=(6,3))\n",
+    "plt.subplot(1,2,1)\n",
+    "plot_image(i, predictions[i], test_labels, test_images)\n",
+    "plt.subplot(1,2,2)\n",
+    "plot_value_array(i, predictions[i],  test_labels)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Ko-uzOufSCSe"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAC6CAYAAACQs5exAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAMA0lEQVR4nO3df2xV9RnH8c+X8rNQBNZq2RQaiCDBOV06HDMEdHY4N8OMcdkmU1kylywYl2xZSJZFyYDokpEJC39MN90Ws5nFsAnTuT82N7LJIiUOWILAEmRYqDSKIJQK7bM/7uksPc9peyntQ9v3K2m897nPPffbg348nO/53pPMTACAwTcqegAAMFIRwAAQhAAGgCAEMAAEIYABIAgBDABBRkcPAIhWXV1tdXV10cPAMNXY2NhiZjXeawQwRry6ujrt2LEjehgYplJKbxS9xikIAAhCAANAEAIYAIIQwAAQpKxJOGaLMZAOHjyolpaWFD0OYLCUFcDMFmMg1dfXRw8BGFScggCAIAQwAAQhgAEgCAEMAEEIYAAIQgADQBACGACCEMAAEIQABoAgBDAABCGAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEEIYABDQm2tlFLffmpro0fbNwQwgCGhuXlgeiMRwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEEIYAAIQgADQBACGACCjI4ewKVs06ZNbn3Pnj197u0rM3PrKaV+bRfApYsjYAAIQgADQBACGACCEMAAEIQABoAg/b4KorW11a1PmDChX9sYO3bsBY+pU0VFRZ97t27dmqs1NTW5vZdffnmudu+99+Zqa9eudd9/1VVX5WrlXO3Q3t7e595y9gGAwcURMAAEIYABIAgBDABBCGAACNLvSThv8kmSVq5cmastXrzY7S1nwm6geEuJFyxY4PZ6E4RXXnllrvbss8+67/cm8e688063t6qqKlcrmljzJueKljj3F0ukgf7jCBgAghDAABCEAAaAIAQwAAQhgAEgSFlXQXR0dOjUqVPn1Q4fPuz2Pv/887na6dOn3d5rr702V5s2bZrbW1lZ6Y7Lc+jQoVztqaeecntra2tzterqard3y5YtudqyZctytePHj7vvf+GFF3K1vXv3ur2zZs3K1RoaGtzemTNnuvX+8q6uKNrno0bl/5/OcmjAxxEwAAQhgAEgCAEMAEEIYAAIUtYkXGtrq3tHYE/3yTpJeuaZZ9ze6667Llcr+j5gr37gwAG3d/fu3bna+++/7/YuWrQoV9u5c6fbu3Tp0lzNmxws+h1uu+22XO2tt95ye/ft25ervfLKK27vvHnzcrX58+e7vfX19blaTU2N2+tNojGxBvQfR8AAEIQABoAgBDAABCGAASBIWZNw7e3tudVdb7/9tr/h0flNv/vuu27v5s2bc7WpU6e6vWfPns3VvO/MlaSFCxfmanPmzHF7vRVc3go9SWppacnVvFV+Rav5vH3mTeJJ0owZM/pUk6QTJ07katu2bXN7X3311T6PYcqUKbla0ao777uOr7nmGrd33Lhxbh0YKTgCBoAgBDAABCGAASAIAQwAQQhgAAhS1lUQo0aN0sSJE8+reUtlJWnFihW5Wl1dndvrXRVw5swZt9ebkR8/frzb621j165dbq9n0qRJbt27WsBb4nz06FH3/d4S5cmTJ7u93na9qx0k//uLi67E8BTtc2+ZdFNTk9vr7Zs1a9a4vcuXLz/vedH3JwPDFUfAABCEAAaAIAQwAAQhgAEgSFmTcMePH8/dbHP69OlurzdJUzR55N14smi57blz5/r0WZLU1taWq3k3mCxSNCnkLakeM2ZMruYty5XKm4TzFC0ZvuKKK3K1ot/Xm9wrmsz06kV/lt6fRUrJ7V2/fv15z5ubm90+YLjiCBgAghDAABCEAAaAIAQwAAQhgAEgSFlXQbS1teXuQDx79my31/sy86I7Kh8+fDhXK2epa0dHh9vrKer1rgoouoOyN6vvfbn4sWPH3Pd7vRMmTHB7vasrinhfFF/0+548eTJXK7rqw+stWqbtLWfev3+/29v984r2NzBccQQMAEEIYAAIQgADQBACGACClP19wN0nwbZv3+72lrPU1ev17jIs+Ut2ve/BlaT33nsvVytnKXJFRYVb9+747NW8Oy1L/lLkIt4kXNEEmPe9vUX70VtKXPR9wN6dqL3fV/KXihdtd/Xq1ec9f/jhh90+YLjiCBgAghDAABCEAAaAIAQwAAQhgAEgSFlXQcyYMUMbN27M1Tze3Xi9pbKSfxVE0ZUC3qy+d1dlSaqqqsrVvFl6yb9ioWim31ve29ramqsVfRG597sVLcMtZ1zl9Hp/Pt4dpyX/6pWiuy3PnTs3V2toaHB7u9uwYUOf+oDhgiNgAAhCAANAEAIYAIIQwAAQpKxJuIqKCk2dOvW82rp16y7qgABgpOAIGACCEMAAEIQABoAgBDAABCGAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIEhZ34YGAJ1WrVrV595HH310AEcydHEEDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEEIYAAIQgADQBACGACCEMAAEIQABoAgBDAABCGAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABBkdDnNjY2NLSmlNwZqMBjxZkYPABhMZQWwmdUM1EAAYKThFAQABCGAASBISACnpO+lpH+npF0p6bWUdONF3v6SlLT1Im1rbjbGzp8TKelb2WvXp6TtWX1HSlqQ1e/Kfr9tKelDWW12SvpND5+TUtKfU9Lk7PklvY9SUk1K+uPFHBMw0pR1DvhiSEkLJX1e0sfN1JaSqiWNHexxFElJo810rvO5mV6XdH32WoWkNyVtzl7+oaTVZnoxJd2ePV8i6duSPinpS5K+ImmjpDWSvt/DR98u6V9mOjFE9tGxlHQkJd1kpr9Hj6k/mFweeI899tigf2ZKg/6RRQonlwc9gCVNl9RipjZJMlNL5wsp6aCkX0i6Q9IYSXebaW9KmqhSiH1UpTE/Yqbfp6Q6Sb+SNDHbxEoz/aPrh6WkT0j6qaS7JDUXbOd+SZ+TND7b1i0FY/+0pP+YqfM/VpNKR6ySLpPUlD3ukDROUqWktpS0SNIRM+3vYb/ck41zKO2j32XjHtIBzOQywpjZoP5INkmy1yTbJ9kmyRZ3ee2gZA9mj78p2ZPZ43WSLc8eT8neO1GySsnGZ/WrJduRPV4i2VbJPiVZo2QzetnO/ZIdlmxaL2P/uWQruzyfJ9khyf4r2ZuSzczqDdnnbpHsMslekmxqL9t+Q7KqobSPJPuIZLsH+98hfvgZLj/JzAYl6LvK/iq/SNLNkr4haZWZns6O7m4y05vZOc+1Zro1Je1Q6cir89TANElLVTri/IlKpwjaJc0xU2VKWiLpZ5JaJX3GrHRk2sN2bpS02Ewrehjz2Ozz5pupOattkPRXMz2Xkr4o6QEz3drtffdJmiLpn5K+I+kdSQ+Z6XS3vpNmqhpK+ygljZF01Kx0nhtAeSJOQchM7ZJelvRyStot6T5JT2cvt2X/bNcH40uS7rLS+dj/S0mPqPRX5o+pNKF4psvLR1QKkhv0wamBou3cKOlUL8P+rKSdneGbuU/SQ9nj30p6stt2K7OepZL+JGmZSueE75H0RLftn0tJo8zUIQ2ZfTRepQAHcAEG/SqI7KqCq7uUrpfU2wTIS5IeTEkp28YNWf0ylc6tdkj6qqSKLu85rtI5y3XZ0V5P2+mLL0v6dbdak6TF2eNbpNw53u9KetxMZyVNUOmccYdK54a7e13SrGxcQ2UfzZG0p5dxASgQcQQ8SdLGlDRFpb/mHpD0QC/v+YGkH0valQXDQZWuEtgk6bmUdLekv6jbEZqZmlPSHZJeTElf62E7PcqOZBtUOhXQ1dclPZ6SRqt0ZPlAl/d8WFK9mR7JSj+StF2l0PuC8zF/UOkKigMaOvvo5mzcAC5AyDlg5KWk6ZJ+aaaG6LH0VUr6m6RlZnoneizAUMRKuEuEmY5IeqJzIcalLiXVSFpP+AIXjiNgAAjCETAABCGAASAIAQwAQQhgAAhCAANAEAIYAIL8DzJzprb/MWsRAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x216 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "i = 12\n",
+    "plt.figure(figsize=(6,3))\n",
+    "plt.subplot(1,2,1)\n",
+    "plot_image(i, predictions[i], test_labels, test_images)\n",
+    "plt.subplot(1,2,2)\n",
+    "plot_value_array(i, predictions[i],  test_labels)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "kgdvGD52CaXR"
+   },
+   "source": [
+    "Let's plot several images with their predictions. Correct prediction labels are blue and incorrect prediction labels are red. The number gives the percent (out of 100) for the predicted label. Note that it can be wrong even when very confident."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "hQlnbqaw2Qu_"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsYAAAI8CAYAAADyYW3KAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAgAElEQVR4nOzdebwcVZn/8c8h+77vQEI2QiAkIWFX9jUiiOMQ8CeCjsi4zaCjg+MCjoPK4Iwrg8ggoo6AssiiILtAIAGSkBsCJBCyQMi+7yvn90fVPXnOSVen781N7pLv+/XixVNdp6ur03266tZ56jnOe4+IiIiIyP7ugPreARERERGRhkAnxiIiIiIi6MRYRERERATQibGIiIiICKATYxERERERQCfGIiIiIiIANK/vHbC6d+/uBwwYUN+7sV+ZN28ey5cvd3W5TX2O9WfKlCnLvfc96mp7DeWzfP/990O8YcOGEHfo0KFW29u4cWOIDzhg5/WB1q1b12p7da2xfI5VVbB9e+l1zZvDyJF1/pKNUmP5PGtq3bp1IV6yZEmI27ZtG7Xbtm1biFu1ahVi268BduzYUfJ1tm7dGi0PGjSo5jtbBxrC56g+VzfKfZYN6sR4wIABTJ48ub53Y78yduzYOt+mPse61bs3mGNOpFcvWLx457Jzbn5dvnZD+SztAfill14K8emnn16r7U2dOjXE7du3D/HQoUNrtb261lg+R1fmT+rt26EBfHUahMbyeZZi5zpwyQf+5JNPhvhnP/tZiEeNGhW1W2x+pAYPHhzi9evXR+1WrVoV4ubNd56ezJ07N2r3pz/9qaJ9r2sN4XNUn6sb5T5LpVKINHBFJ8W7WyciIiI106CuGIvI/mPz5s3R8k9+8pMQ33nnndE6eyVp2bJlIW7Tpk1hu3JsyoSN7VUqgJNOOinEV1xxRYjPOeecil5HpLErd8X42muvDfHzzz8f4gcffLBwex07dgyxTWkC2G5yBGzf3rRpU9Tuz3/+c4jPO++8wtcSqQ1dMRYRERERQSfGIiIiIiKAToxFRERERADlGIvIPnT11VeH+JZbbonWrV27NsRpuSebb9ilS5cQp7mH7dq1C7Et/WRLRKXbszmUW7Zsidr95S9/CbHNmzz++OOjds8++ywiTZEtZ5iqqqoKse2XPXrEVbBsiUXbL7t27Rq1a9GiRYhtv5w9e3bUbubMmSFWjrHUNV0xFhERERFBJ8YiIiIiIoBSKURkL7MpEzfccEOIe/fuHbWzaRBpWSg7rGpn0UpnqrPLdhvpcPD2gqmj0u3ZyT+aNWsWYluaCuDDH/5wiB966KGS2xZpauwEHd27dw+xTYuCeIa7cjPf2e2l6U/Wu+++W/OdFamQrhiLiIiIiKATYxERERERQKkUIrKXffvb3w6xnfUqTZewd6svXry4cHudO3cOcZr6YGeus8Oy6Sx73bp1K/m66cx3tkqFTefo1atX1M5WpVi+fHm0zg4xizRmS8rMQW/7Ttq3LZvGZKtQQJyuZLdhfzcAli5duvudFaklXTEWEREREUEnxiIiIiIigE6MRUREREQA5RiLyF62Zs2aENsSTDZnF+K84s997nPRuiuvvDLERx11VIhtiTeABQsWhLhDhw4h7t+/f9TO5krafbLPB+jXr1/JduvWrYva2Rn45syZE61TjrE0FTNmzChc17JlyxCnM1La3GGbi5yWa7O/CUUl3mDXPH6RuqQrxiIiIiIi6MRYRERERARQKoWI7GW25Jktr5amUlg/+MEPouVOnTqF2A6xbty4MWp3yimnhPjpp58u3P5hhx0W4pkzZ4Y4nbHrpz/9aYht2bkePXpE7WzJtwkTJkTrjjnmmML9EGlMqqqqomWbPmH7dtovbblEm1plyyZCXKLN/j7Y3xDYNYVKpC7pirGIiIiICDoxFhEREREBlErRoNjh2AMO2Pk3S7lZhNIhJnv37ltvvRXiIUOG1MUuiuzW1q1bC9fZ73L63bU++clPRssPPPBAyXarVq2Klm36xDXXXBPidOasu+66K8QrV64M8fz586N248ePD7FNpbB9FeI77adNm1ZyX0Uau5dffjlatscpmz6RziBp0ydsVZm0r3Tp0iXE9liWpmYcdNBBNdltkRrRFWMREREREXRiLCIiIiIC6MRYRERERARQjvEeseVkbGzzrgDee++9EE+cODHE5557btSuNiVo0hmBrPvuuy/EV199dY23LVIbCxcuLFxn+0Y6O5aVzkBX5O677y5cd+mll4a4TZs20TqbIzxy5MgQL1q0KGrXvn37ivbDsrn9Ik3JG2+8ES23aNEixLZvr1+/PmrXp0+fEE+aNCnE6f0zthSjjbdv3x6169q1a012W6RGdMVYRERERASdGIuIiIiIAEqlqDNp+oT13HPPhfjFF18McTrk/E//9E81ft2lS5dGy48++miIO3ToUOPtieypZcuWVdQuHR61w7Jp37DDqtbJJ59cuP2zzz47xHPnzo3W2aHYRx55JMR25jyI0yxsWkW6P82aNQvx4sWLC/dJpDGzZdcg/t6XS6X46Ec/WtH27W9C27ZtC9uVKwkpsqd0xVhEREREBJ0Yi4iIiIgAOjEWEREREQGUY7xHbMknOwVmOm2mLXHTq1evEKdlnS688MIQ26kxN2/eHLXr379/iFesWBGtW7t2bYj79etX/g2I7AW2PGHKljVM2ZzCNE/X5i/abcyaNStqZ8sSzpkzp/C1DjvssBDPnDkzxO+8807U7qabbgqxLTNl+yfEZRPLvX+RxmzJkiXRcqUlRi+55JKSj6flRu307N27dy/cXjpFtEhd0hVjERERERF0YiwiIiIiAiiVokbSEk02fWLDhg0hvueee6J2drjIpkWsW7cualc0k146/Pzaa6+F+MADD4zW2SFem+ohsq+UK9dmyzul5drscjrj3De+8Y2S7R577LGoXVVVVYhtP7EpRhCnT9j0i/Hjx0ftpk2bVuJd7PpbYGfw2rZtW8nniDR26WyVtiRouePNqaeeWvLx448/Plq2M8Omvw9Wt27dyu6nyJ7QFWMREREREXRiLCIiIiICNPFUCpuCYIc6IR4KTdfZZTs8ZIeBUzfffHOIbeUJgNatW4d4/vz5IU6rTdjn2WGkdP/sncDpXb12ZqItW7aE2KZ6pNsQqUuLFi0qXFdUXQLi73ynTp2idT/4wQ9Kbi9tZ/vQ66+/XrgfvXv3DvHy5ctDbPtqOemwsU2rKte23G+ISGNmU4jS/pAep6oNGDAgWp4wYUKIy1WwSfu9SF3SFWMREREREXRiLCIiIiIC6MRYRERERARoAjnGaR6SzcdNc3Mtm+uYqjQn8M477wyxnalr9OjRUTubO7l69eoQd+3aNWpnS9DYvMf169cXbi9l/z3s7EDpLHujRo0q3IbInihXrs1q2bJltHzaaaeF+LnnnovW2bKEtk/aPHqI+25a8s2yfcjmJafbs9vo3LlziNMybmlftubNmxfiQYMGFbYTaWzsMXbr1q0hrvR7npYbtf233PFbZG/SFWMREREREXRiLCIiIiICNIFUinLDLbYkWzpTlR2OTbdRlD5x2223RctvvvlmiA866KAQr1ixImpn0xvszEH9+vWL2tmZ8Ow+tW3bNmpny7yVSyWxHn300WhZqRSyt9h0oZT9jqff/8svvzzEjzzySLQu7QPV0n6dLhex/cSmVaSpFLbs1Ec/+tEQF82IV4pNi1IqhTQlRbO/Hn744RU9f9y4cdHyDTfcEOJK+7JIXdMVYxERERERdGIsIiIiIgI0olSKomGVNHXAphbYyhPlqlCkFi5cGOL77rsvxDYNAmDIkCEhtpUj0uFYm1rRokWLwn23VSSsdN/tLELpOjujnd3+888/X3LbInUtTSWybB/q2bNntK5Lly6Fz7P9ptyskJX286LZLdPt2b587LHHFm7Pvm46e56GhKWpsn3HHnsHDhxY0fNHjhwZLdvKFuWqL2nmVtmbdMVYRERERASdGIuIiIiIADoxFhEREREBGmCOcXXOUloyrTa5g1Y6G5edjWrWrFnRukWLFoXYzs7VsWPHqJ0tS7V27doQb9u2LWpn8xTt+7L7AHFOlZ1lK50hrCivC6BNmzYl26WzgM2YMQPYNW9aZE+l5dpszq0tNZjmCb7xxhuF27RlodL+ZVU6W5btN+Vmy7TvpdLSkGmftOXaRBqzdKY6W6LNHqP79u1b0fZsv04px1jqi64Yi4iIiIigE2MREREREaABplIUzTq3ZMmSEM+fPz/EdignXbZpAnPnzo3a2dJo6XBOhw4dQmyHSNesWRO1s9u320jLrtn0BltqzZamAejTp0+IbWpGuj1b1sqWiQNYuXJliG36xOLFi0u2s+kWInWh0vJkhx56aLT89ttvF7a1aQx2++XKNZZTNPOd7Z/p9tLycla5VIo0jUuksUr7wJw5c0Js+5GdFbacNE3QKpdmUVTaVKQu6IqxiIiIiAg6MRYRERERARpgKkW1J554Ilq2s9HZIZZ0mNKmBti0jHLpEmk6gk07sMOi6Yx2NqXBDqWm27P7ZO+mTStF2EoUlQ6/prOF2TuDbapHmrZRbphKZE+kVSOKvmtpKsUzzzxTuM2iO9TTtAXbD8tVsrHPs3FRKhfEd+Snd+eXqzyR/h6INFbHHHNMtGwrydg0pGnTpu3xa6XHWytNeRKpS7piLCIiIiKCToxFRERERACdGIuIiIiIAA0sx3jt2rU89thjAPzqV7+K1g0bNizEtqyZzRWGOMfQloJJy5LZvMJ0GzYf1+Yprlu3rnAbNp83LSFlX9vmL9sSdACvv/56yX0oV1ItzVO25ersjGNpu+qyOy1atCjctkht2PKEUJy3m+YAz5w5M8Tp93JPywqmzy+a7a5c7v3s2bND3Lt372id7dfpvqu0lDQVJ510UrT861//OsT2ePvKK6/Uavv2N6HczHeVzoQrUhv6domIiIiIoBNjERERERGggaVStGvXLpSDmTRpUrTu1VdfDfGECRMKt2GHMW2KRNeuXaN2drlTp07ROpvGYNMlVqxYEbWbNWtWiO1wqZ21DuKh2qqqqhAfeeSRUbsBAwaE+PHHHw9xWram3DCSHQru27dviDt27Bi1q04L0cx3UtfSdISi71ha1s3O2ti2bdtoXaWz6VlpSlMRm+pRbvj2gQceCLHtqwBTp04Ncdo/V61aVdF+iDR0J5xwQrRs0/VsPyo3S2Q59jhVbhbL2vweiFRKV4xFRERERNCJsYiIiIgI0MBSKZo1axZmf7vmmmsK29mZpF588cVonU1veOGFF0I8b968qN306dNDbCs5QDyEY4dj0yFSm44xYsSIEJ9xxhlRu3HjxoXYDj2Vc/7554f4nXfeidZ169YtxGmKhE0fsUPa6UxBQ4cOrdH+iFQq7SebN28u2c5WoYA4ZSj9vtq0CztkW264tWh2OyhOsyg3RGt/Q9I0qHvuuadw22nKiEhj1b9//2jZHn9s/037/Jw5c0I8cODAwu3bVMhy/UYpgLI36YqxiIiIiAg6MRYRERERAXRiLCIiIiICNLAc40rZWdxOP/30aJ1d/vznP7/P9qmuPfjgg/vkdTSDkNS1ND+4KG83LWNm8xLTbVQ6e55dLprdLl0ul4tsSzlOnDgxxNU5+qWkr2VnxRRpSmxesS11aEueQuU5xnZWW5vT36VLl6idcoxlb9JZkYiIiIgIOjEWEREREQEaaSqFiDRctuQSxLPY2VKLX/nKV6J2TzzxRIjT9INKU36K0icqnUUrfZ01a9aE+JRTTgnxeeedF7X793//9xCnaR/pzJUijUlR+VKACy+8MMR33HFHiNP0KTtbbVrO1EpnvCy1D7BraoVIXdIVYxERERERdGIsIiIiIgLoxFhEREREBFCOsYjUsXSKdZtzW27K1x49eoT4rbfeitbZEk/lpm2uVFHeZJofbUvK9ezZM8Tdu3cv3Haapzx//vxa76dIfSuXY3zBBReE+De/+U2IW7ZsGbW79957Q/yd73yn8LVsGbZy5RbTco4idUlXjEVERERE0ImxiIiIiAigVAoRqWMnnnhitGxnjGvdunWI09nj3nzzzb27Y3XIzuQF0KFDhxCn5dmOOeaYfbJPIntDuXKG5557bohtCbW0D1RabvGII44I8auvvhpi+7sBsGjRooq2J1IbumIsIiIiIoJOjEVEREREAKVSiEgdS1MH7Cx29m71SodXG6K0ooYdOt66dWu0rl27dvtkn0T2hnQmxyL9+/cP8aRJk6J1GzduDPELL7wQ4hNOOCFqZ6tSbN68OcRpn1q+fHlF+yRSG433yCQiIiIiUod0YiwiIiIigk6MRUREREQA5RiLSB3r169ftDx69OgQ27JL5XJvt2/fHi3bPEc7E9feZl/L7sPgwYOjdh/60IdCvHr16mjd8ccfv5f2TmTvS2edK3LFFVeEeNiwYdG6iy++OMRpXrF16aWXhnjNmjUhbt++fdTugx/8YEX7JFIbumIsIiIiIoJOjEVEREREAHD7clhyd5xzy4D59b0f+5n+3vsedblBfY71qk4/T32W9UafY9Oiz7Np0OfYdBR+lg3qxFhEREREpL4olUJEREREBJ0Yi4iIiIgAFZ4YO8eFzuGdY9juW4NzzHOO7iUeX1+Tnatp+zLbudw5+has+3vneM053neOscm6f3OO2c4xyznONo+fkz822zm+bh7/vXNMd47vm8e+7RwXlNm30c5xa/LYA84xscL3dopz/LngPd9YyTZq077Mdjo7x+fNcg/n+Oueblf2nHPscI5pzjHDOe52jra7aX+7c3wsj/+W9o+9qSH1y7xvLMv/7V53jiuKnmeevz7//wDnmFGzd18z6mONn3N0y79f05xjsXO8Z5Zb7n4L+4ZzXO8cC5xjdfJ4a+e4J+97E53jYLPuW/njM53jjPyxXs7xfP5b9GHT9iHn6F3m9b/qHB93jptNf9xk/q0u3Bvvuyac40bnKK5JJw1epVeMLwEmABfvrmEDdTmUPjEGZgAfBZ61DzrHcLL3ezhwDnCTczRzjmbA/wDnAsOBS5xjuHMcCeA9RwIfdI5OztEHOMZ7Hiizb98Afm5etzNwFNDZOQ6p8Tutf51h54mx9ywDFjnHifW3S5Lb5D2jvOcIYCvwj/W9Q9XyfmU1qH4J/MF7RgGnAN93jl61fKt1yjmaq481ft6zIu+bo4CbgR9XL3vPVgDncM7tu1Fe50rOc/AAcFyJxz8LLPaewWT98Af5No4k68fDgQ8Bv8jfw/8DbgVOBP41b3shMMl7FhfsTwvgUrK++I/5v9X5wCzzb/WnCt7DXpP/Dv0c+Ld9+bpSt3bbyZyjPdmX9x8wJ8b5lcq/5X8lzsyvyrjkuW2c46+lrrA4x9ec4+X8Ss6/l3n9/3aOqc7xpHP0yB8b5RyT8uf+yTm6FD3usiteY4Hf539RtrHb9543vGdWiZe+ALjLe7Z4z1xgNnBM/t9s75mT/2DdlbfdBrTJO31LYAfwXeCaMu+tA3Ck91SZh/8OeCjfrv33vt05fuYcLzjHnPx9pds72jlecY6ByeM9nOPe/N/75TIH0IPyz2uWc1xrnv+V/C/7Gc5x1W4evx4YlP9b/zB/7H6yH0JpOJ4DBjsXX9HMr8h8p9wTneMS53g1/9z/M3/sc85xg2lzuXPZiaVzfMI5Xsq/E7+sPgl2jvXO8V3neBGIZsFogP2yer+WAm8D/Z3jO87xVfO8Gc4xoMx2WzvHr/N/u1ec49T88Red43DT7m/OMcY52jnHbXmffcXlV7jzf9u7neMh4LH8aepjTZBzDM6/VzcDU4E+eX+q7n/fz9s1d+YqrnNc7HaOeFyct61yjqdN+x/l/XK6c3wmf/wM53jCOe4CXkn3x3smQskT1wuA3+TxHyGM5FwA3Ok9W73nbeAdYAx5vwRaATtcdtL7ReBHZf45zgRe9p4du/k3m+Qc1znHs8DnnGNQ3qemO8djLh89do67nOM887zqUZ6DXHY1e1r+73xs/vh5+bZfcY47q88lXHaF/1vO8QJwfv67NcA5upbbT2m4Kvnr8yPAX73nTWClcxxl1o0GriL7a3AgRCdc7clO8O7wnv+1G3SOs4AhZAezUcAY5zipxGu3A6Z6z1HAMxBO1n4LXJ1fBXq13OPecw8wGfh/+V+Umyp4zwD9gHfN8oL8sZKPe88bZJ1+KtkPw2DAeb/rj4sxFnYZZr0EuDP/75JkXR/gA8B5ZCeggcuGbm4GLvCeOcnzfkp2BeJoshPvWyntGLKD6yjg751jrHOMAT4FHEt2peAKlw0zl3wc+Drwdv5v/bV8u5MBTVXUQLjsKsq5ZH2kps/tC/wncBrZ9+Ro5/gIcA/ZlaFq44E/OMdheXxifoVnBztP4NoBM7znWO+ZUOEu1Fe/BCD/o3Mg2Ql5TX0BwHtGkPXt3zhHa7KT+Ivy7fcB+nrPFOCbwFN5vz0V+KFzVE8XeDxwmfecli+rjzVdw4Ffec9owAHXkX0fRgMn2pO7AtcCp3vPSAipBp8FlnrPMcDRwBfczvSH44B/zb+nlQr9L//DdIPLRj+L+uv/kR3HHga+A3wJuG03x+cTgSkV7k877znJe35Odlz8RX5ecD/lT74BPgncl/9ejQJec1l6x1eBU/PPYWa+z9XWes8J5or1NJI/9qXxqGSY4RLgJ3l8V748NV9+yXsWADjHNGAAhAPcA8AN3vP7Ets8K/+v+uDUnuxE+dmk3fvAH/L4/4D7nKMT0Nl7nskf/w1wd9HjFby/IqXmwfSU/mPCA3gfXU19CLjSOb4JjAQeT/9AIDvRXWae04vswD3Be7xzbHeOI7wPB+n7ved94HUXD+UeBtwCnOU9C0vs3xnAcLfzHXV0jg7esy5p97j3rMj35T6yk3AP/Ml7NpjHP0j271Pq8QdLvP5SilNZZN9pk/dTyK4Y/4qafy5HA3/Lh+9xjt8DJ3nP/S4byTgOeAs4FHie7GRwDPBy/v1rQ/Z9gOwk+d4avv4+75e58c7xAWALcKX3rHSVzZRrfYA8PcN7ZjrHfGAo2Qn742QnMBex83frLOB8c1W6NYSTl8e9Z6XZtvpY0/W297ycx8eS/bG0HMA57gBOgrI55s8Dv3WOu4H78sfOAg5zLoxKdiI7BgNM9J53ariPRf2y5OPeswoYB1l+NVnqwcfyq9ydyc4dXkqe14cSV7EL3GXisWTvF7Lzgm/t5rkvkaVotSM75k53jnPI/kCZmPf7lsDfzHP+kGxD/bERK3tinH9hTwOOcA4PNAO8c1lOENlBotqOZHvPA+c6xx3ekxZLdsAPvOeXNdzffVl0eQFwkFk+EMJJZ9HjAORDnpPJrogd4T0XOcezzvF779lomm4iO9hVGw90Aebmna8jWTpFdUe2/972B2dRvp3R6b7kDgCOr+BqefrvW/TDlr7+7rSGiq/Uy96zKb8KEjjHduKTytaUV+5z/wPZid1Msj+avMvSq37jfcmcu827GxYtoT76JWR5jV9MHquTfzvvec85VrgsH3M8cKVp/3dpSkk+tLsh2Yz6WNNlP+ui/vd+ss5+F68gO6E+D6jKv2cO+Lz3PGk34rKb49LvViWq++Vil90s2M571jhXtr9Wuxb4D+ATwCSyP5bvJrugY5Xql0WqL9gUnbCD6b95KscBAN7zuMvSnD4E3OWyVM/3gb94z6fKvZ6h/tiI7S6V4mPAb72nv/cM8J6DgLlkVz525xpgBXBTiXWPAp92Wf4yztHPOXoW7F91Lu3Hya6krgFWOReGDS8Fnil6PI/XAR0q2GfrQeBi52jlspvghpD9JfkyMMQ5Dsl/AC7GXCXNO9g/Az8E2rKzE1bnOFpvkF0hrnYJcE7+bz2A7EpbJTc8ribrxN93jlNKrH8Mdh7UnYtPjowznaNrnjv1EbI/bp4FPuIcbfO/oC8ku9pY9Hipf+uhFAxNS71bAvR02V3xrWC3w7IvAic7R3eX5Qpfws5+dh/Z9+YSdl5BeZLsSlBPgPz71X8P9rc++mWReWQ3ypKnmO3uZtlnydNInGMo2dXf6pPeu8huQurkfUhxeRT4UvXBPU9VKqI+tn+YBJya99fmZN/zZ/KRxFXOMcRl+fS2OsNA75kEfBtYRZbK8Cjw+XwbOMehLrn/poYeBC7L44vYmfv+INmNsC2dYxDQH5MO4bJKV93zVKq2ZCeg70PJfam0Xwb5RbmX2XkecSk7R6bnkR1jIUsxrO5nA4BF+YW735JdcJoAnJ6vwznaO1d2X9QfG7HdpVJcQpLLSvbX3MfZdeiglKuA25zjBu/DVWa857E897B6WGI92V+LS5PnbwAOd44pwBqyqymQdcCbXVZuag6Ev+KKHr89f3wTyZVTl90J+3OgB/AX55jmPWd7z2vO8UfgdbK/LL9QfXXLOb5I9sPSjCwv6jWzz18gu0K20TmmA845XgUe9j4ucZMPp3Zy2c0+3cgOlJPM+rnOsTa/QlSW9yxxWdmbR5zj08nqfwL+J9+f5mQ/DKUqEkwAfkf243OH90zO3+/tEIa1bq3Ozyzz+PMuu6HrkTzP+FTgL7t7D7Lvec825/gu2QnvXLKrveXaL3KOfwOeJjuQPOzz6g7es8o5XgeGVw+Des/rzvEt4LH8gL2NrI+UnQa1ofTLEulG1r3AJ12WnvIy8Ga590R2keDm/HW3A5d7H0aB7iG7F+A/TPv/IEtjm56fHM+j+A8X9bH9gPcscI5ryIbxHfCQ9+Fzv5ospeIdsv7RKn/8x/kfkQ54zHtmOMcbZMebafkxeCkUly+s5hw/Ijvx7ZhfDb7Ze64jS+X7P+eYDSwnv6DjPVXOcT/ZSe12sqvU75tNfg/CvSh3kP1x/S9kVWFSD5Olf9XU58jOQ75NduPg5fnjvwDud45zgUcgjF6dCfyzc2wD1gKfyH/3rgDuyf/w9mT/3rvca+Cy+wb6AdNrsa/SAGhK6HrmHF8G1nlfeENco+eyu4MvyPPKRBq8xtYv1cdkf+AcDwJXlbjBvMFwjkvIrtJ/r773RWpHM9/Vv18Q5w43KS4rsfcjHbClkWk0/VJ9TPYjV9Pwb2rzZKM/0kjpirGIiIiICOBU7WAAACAASURBVLpiLCIiIiIC6MRYRERERATQibGIiIiICKATYxERERERoLIpofeZ7t27+wEDBuzz192+fXu0vGzZztlgmzVrFuIDDij+O8K2K8fe7Ni8efzP36HDznkxnKv5fLO1MW/ePJYvX16nL1abz7GqCpKPIWjeHEaO3PP92h9MmTJlufe+R11tr776ZDkbNuycZOr999+P1qXLRWy7Fi1ahLh9+/Z7uHd1Y3/4HPcnTfXznDVr56SM9piVHr/sca9ly5YlHwfYtm1biMsdb+3zhgwZUtiurjWEz1HHyrpR7rNsUCfGAwYMYPLkyfv8de2JMMAvf7lzpurOnTuHuE2b4omBOnXqFOL0R2HHjp2z3m7dujXEPXvGk/2dcsopIbY/HnvT2LFj63ybtfkcy/0dsH071MPXolFyzpWdOKOmKv0s7YlmekArqnxT2z/+Jk6cGOKNGzdG62z/sv0utWXLzkpsPXrs/G086aSTarVPda2+PkfZO5rq52mPWfbiUKtWraJ2mzdvDrE9EbSPAyxZsiTE9kJR2pft8sMPP1yznd4DDeFz1LGybpT7LBvUiXF9ufvuu6Pl6667LsRdunQJcZ8+faJ2c+fODXG/fv1CPHTo0KjdG2+8EeLWrXdO9X7GGfFU8PZH4dJLL61o30UaAnuSW64EZLmT4XXrdk4y99RTT0Xrpk6dGuJHHnkkxIceemjh9tevXx/iFStWRO26desWYntw/t734pr8H/7wh0N8/vnnh/jggw8ueBciTdfatWuj5dde2zm5pP0DM7VpU5hslrfffjvE9ngI8R/Vbdu2DbH9g3d3ryWyp5RjLCIiIiKCToxFRERERACdGIuIiIiIAMoxBna9+c7eHFDuztjevXuH2N4MkOYzrlmzJsQdO3YM8XvvvRe1GzZsWGU7LNLAlMsxLsorvuWWW6Jle4d7Wl3C9o3x48eHeNq0aVE7e9OPrTaT5iLbG3vatWsX4vS3YP78nfdnfPnLXy75HIDrr78+xH379kWkKUpvlrN92x4D05vH7bK9bye9qc7mMNtjb1q5odyN8CJ7SleMRURERETQibGIiIiICKBUCmDX1AdbCsaWlunatWvUzpaXskOzq1evjtrZoeWioSKAESNG1GS3RRoM+x0vV5LtpptuCvHKlSujdYccckiI7aQbEA+52vrfJ598ctTuvvvuC7FNdUqHdm3fs/3OloKDePIAW6vcplgAfOtb3wrxbbfdhtSP3r3BVL2M9OoFixfv2/1pau69995o2R47DzzwwBCnKRI2NcqmO6UpU7asm02FsumIAAsXLgzxlClTQjxmzJjyb0CkArpiLCIiTULRSfHu1omIVNOJsYiIiIgISqUAoH///tFyVVVViO00lzaG+M50O1SbDiPZId1Vq1aFuNyd9yKNSblUinfffbdkPHDgwKidnakuZfuanSFy0KBBUTu7/NZbb4U4TYM69thjQ/zss8+GOK0oYe/Ct9NPp3fFLzZj9L/73e+idXYWy0pTTkQaoltvvTVatrPB2hSnJcnl+ebNd55q2N8AO7sdxMdYOyuefT7A0qVLQ/zSSy+FWKkUUhd0xVhEREREBJ0Yi4iIiIgAOjEWEREREQGUYwzsmutnyzfZ3MZ0Ri9byq1c7vDQoUNLvm6aH5nmUYk0FuVmiJw9e3aIbQ6hLccE0L59+xBv2bIlWmfz9m27tDTiueeeG+IJEyaEOM0Jtq9tY3s/AMCGDRtCbMszbt26NWpnS1C98sor0TqbY6y8YmnM7OyUAGPHjg2xLbW2bdu2qJ09Jtr+m/Yj2xdteUQbQ/x7Y0u3idQFXTEWEREREUEnxiIiIiIigFIpgF2HgQ866KAQDx8+PMTpMOjdd98dYjuL12uvvRa1O+mkk0Jsy8n069cvameHldIyNiKNle0PtgRTmi5hU5XS778dirXpGHYmSYjLR5111lkln5MuDx48uOQ+QFyGzQ7z2jJuKVs+SqSxW7RoUYjTUqS2RJstoZYeU205U1uuzf4eQJxmYdMx0rQr+zybxiRSF3TFWEREREQEnRiLiIiIiABKpQDgsMMOi5affPLJkuvSIZvDDz88xMccc0yIP/vZz0btDj744BAfeOCBIe7SpUvULr1zXqQpWLBgQYg7duwY4jSVwurVq1e0bGeds8OqLVq0iNrZtA1bXcZWjYF4hjt7V3ta5cLO4GUrVqTpUoccckiIu3XrFq2zKVJ2SFmkMbDpROVS/GwaUnosW758eYhtJYsZM2ZE7ezslzatIk3hKJohT6Qu6IqxiIiIiAg6MRYRERERAXRiLCIiIiICKMcYiPMXIZ7tzuZXpTnBls17THMnbakpmw+VznRnS0CpBI00VjYvN2VzCNN83iOPPDLEae5wmmNYLS3DZvuN3X46w5bNh7RloWxpqnR7dhvpvlvpzJfTp08Psc2vFGkM3nzzzRCn/dIeK620tKntV3bG2NGjR0ft7Mx6/fv3D3Gam2+PnTpWSl3TFWMREREREXRiLCIiIiICKJUC2HU4yKZW2Bl8bFkniNMnRo0aFeJ0GGnTpk0htsOx6fBwOkwl0hjNmTMnWrZll2y60IYNG6J2tt/YmSQhTncoN+tc0Qx5aZ+0s3TZdem27eva3wX7niBOn0pTpObOnRtipVJIYzNz5swQp+XabB+2/S1NNerRo0fJbR933HHR8rRp00Js+2WanmjXqQSi1DVdMRYRERERQSfGIiIiIiKAToxFRERERADlGAO7Tl9p84rTXELLrkvLzlg2N9G+VlpmRjnG0hS8++670bItUZiWMrPmz58f4gEDBkTrbB6hzc23ef4AHTp0CLHtT3bb6X7YnOB0eln7WrZ0Y3pfgn2ttB/bElQijc3s2bND3KlTp2idvWfGfu/T+3Euv/zyktv+9Kc/HS3ffPPNIS73W2HzmdOSjSJ7SleMRURERETQibGIiIiICKBUCmDXoRg7JGTLwqQln4rSLNLUDFvyyQ7Bpq+rISFpCtJhVJua1LFjxxCnJZjWrVtX8jkQp0zYfpKmUtjn2e2nw7I25WLVqlUhTlMpbKlFu+/Lli2L2tkh5vS1qqqqEGms1q5dG+L02GaPifY4Z2OAq666quS2jz766MLtFZVehDgNUcdNqWu6YiwiIiIigk6MRUREREQApVIA0L1792i5aDjH3oELuw67VrPDtADe+5LP6devX9QuHT4WaYzWr18fLduKEl26dAlxWiniggsuKNyG7ZM21SlNx7DLdjg3nY2uaCa9NF3K9tdhw4aF+IEHHoja2b6bVqWw6RgijY3tO2n6oO0v9nveu3fvqN3AgQMrei17LLbH3q5du0btVqxYUfJ1ReqCzsRERERERNCJsYiIiIgIoBNjERERERFAOcYA9OnTJ1q2ucQ2P9jOYAe7lqSplpaQsiXabMmncjP7iDRWNmcX4hJPaa6vNXz48BA/99xz0bqi0ohpXv7q1atDbPOZ03Y2D9juk+3vqaFDh4Y4zWu0z0tntFyzZk3hNkUaum7duoU4PbZZ9r6Ac845p1avZXOTbRm29D6glStXhljHUalrumIsIiIiIoJOjEVEREREAKVSANC2bdvCZTuEmw7Z2OEcy6ZOQFxCyg6z2iEqkcbMDrGmKUY7duwIsU05SMua9e3bt2S7lE1pSlMzNmzYEGLbv9IybHbZlpNL2X0fPHhwyX1I26Xv3w4x27goPUSkIbHfUztLJMT9fvbs2SH+7//+78Lt2eNomuJ0yCGHhHjBggUh7tGjR9TO9jfbTqQu6IqxiIiIiAg6MRYRERERAZRKAcR3v0KcCmGHfdI7ctPhnWpDhgyJlu0d7EUzbok0ZsuXLw9xmgZh0xbsEGiaSmH7V9rXbMqErRqTpiPYNCjb19IqEj179gyx7f/pvtt1NtWj3CyVtgoHxO9/8eLFIbapGSINlU3/S49ZNjXI9h1bYSZlfwPSfnT44YeHeO7cuSFOZ5NdtmxZiG31GZG6oCvGIiIiIiLoxFhEREREBNCJsYiIiIgIoBzjkmx+oy3JluY9FuU2pflV7777bojXrl0b4jQXUaSxsjPOpf2kdevWJdsdfPDBUTubR2jLrgH06tWr5PbTEoo2J9jmQ6Y5xradzV9OS62tW7cuxDaf0u5Puj2bQwlx7uXSpUtDrBxjaQxGjBgR4hdffDFaZ/uYvbfGzmCXKpefP27cuBD/7Gc/C3FaHtHm6nft2rVweyK1oSvGIiIiIiLoxFhEREREBFAqRUkrVqwIsR0eeuSRR6J2V155ZcnnH3XUUdHySy+9FOJ+/fqFOB0GFmmsbEmytISaLfc0a9asEA8bNixqZ5+XzmhnlZtlzu6Hfd00bckOAdvtpTPk2VQqW8bRDi9DnHKRpljZbdp0DJHGYPz48SH+9a9/Ha2z/dSmCT711FNRu7POOivE5Wa1tL8JBx10UIjT9Au7Ddv3ROqCrhiLiIiIiKATYxERERERQKkUJT3zzDMhnj17dojTVIrf/e53JZ9/xBFHRMt2OPbGG28M8ciRI6N2Y8aMqfnOijQANv0oTYOwFSHWrFkT4vT7b2ezssOyEKcj2PSJLVu2RO3szHd2P9KhWLtPNqUpnY3PVpt45513Qjxo0KCo3QsvvFBy2xAPD6fvS6Shs30g7R82Nci2S4+NNpWiXJpU9+7dQ2wrT8yfP7/wdW3VG5G6oCvGIiIiIiLoxFhEREREBNCJsYiIiIgIoBxjYNfyMbZ8k80xtqXboDi3Kc2hsnmVtnRbOkOYSGM1derUEKc5tnZ5yZIlIU7Lmk2ePDnENlcY4hxhG6ezzLVs2TLEtn+l7eyyLetmY4j7clVVVYg7duwYtbPl4NL3b2ftsu/xYx/7GCKNSVpu0H7X7fHQHudqy5ZUnDJlSrTO3meQ9jeRPaUrxiIiIiIi6MRYRERERARQKgWw62xXW7duDbEdpkmHWYvY50M87GPTKtJZu0QaKzsrnB0CBXjvvfdCbGepSsu12VSFzp07R+tsOoKVpkHZ8m02XcKWkoJ4lj2bfpG2s78N8+bNC/H5558ftfuHf/iHEF900UXROpsW0qdPn13fhEgjceKJJ0bLd9xxR4i7du0aYtunamvAgAEhXrVqVbSuqJ+L1AVdMRYRERERQSfGIiIiIiKAUilKssNAdqYqO1xcTjo7kL2z3aZP9O7du7a7KNKgfOpTnypcZ+9knzNnTojT2ePuu+++EKcVK+w27Ex1acrF8uXLQ2xTmtL0DluxwsbpDHk9e/YM8aRJk0J85ZVXRu3srH02TQM0M5c0HV/84hej5XvuuSfEtu+sXr06amf7/cCBAyt6rQ4dOoTYpmBB/BuQ/laI7CldMRYRERERQSfGIiIiIiKAToxFRERERADlGJdkZ7GyuYmV5gqmpWpsSSmbG1UXJW1EGjqbc3vkkUeGOM0bXLFiRYht6Scozs1Py7jZbdh+l/Y1mw9pSz+V65P2taZNmxatGzduXOHzRJqKfv36Rcs2x9/eB5CWLLUz4VWaY1w0iyXEfTZ9LZE9pSvGIiIiIiLoxFhEREREBFAqRUmLFy8OsZ1Vx6ZBlJOWa7LDtnZ7NmVDpKlIZ6Oz/cbOLDdhwoSonS1rmLKzx9ntzZ49O2pXNExr+3S6DZsulZZktH3UDiM/++yzUTubSpG+/3RmTZHGxH6f0+/ymWeeGeJ77703xGlK0gMPPBDiiy++uKLXtcfRhQsXFu5TpcdlkUrpirGIiIiICDoxFhEREREBdGIsIiIiIgIox7ikXr16hXjp0qUhtvmR5aRTVBaVhrLTzYo0FWkeYlG/mTVrVrRsSz/ZfgJx/rF93iGHHBK1sznC7733XuH2bF7ipk2bQpzmB9tcSRunOctW+v7L5WiKNHRF9whAnFtvp4dO759ZsGBBjV+3U6dOIU5Lstlj7MqVK2u8bZFydMVYRERERASdGIuIiIiIAEqlKOncc88N8eTJk0NcaSpFhw4domU7JGRLQ/Xv37+2uyjSaNgShbYPzZ8/P2pn0x2GDh0arbPPGzZsWIjTGfJef/31ENu0BTtzHsSpGba/2r4K8RCu3b90xj27rlWrVtE6pVJIY2ZTAVMf+MAHQmzLGa5evTpqZ1OPqqqqQjxy5MjCbXfs2DHEaX9r0aJFiG0Klkhd0BVjERERERF0YiwiIiIiAiiVoqTWrVuH2KY+VJpKkbJ3vdshoQMPPLBW2xNpTIrSB77//e9Hyz/84Q9D/Mgjj0Tr7NCsrUSRzpZn+5qt+rJq1aqo3dq1a0uuS6tN2GHa7t27h/iLX/xi1C5Nn7DKDUXXl69//etl119//fX7aE+koas0/efggw8O8bRp06J1NvXh8ccfD3G5VIp169aF2Pbr1JIlSyraP5FKNbxfbBERERGReqATYxERERERdGIsIiIiIgIox7ikT37ykyGeMGFCiG0Zt5o4//zzSz4+YsSIWm1PpDEpyrFNZ8e65pprCrfxzjvvhNiWZEvzC23usJ2xK2VzHm1s8yQBTjzxxBC3b9++cHsi+7tvfvObIe7du3e0zvaxk08+uaLtjR8/PsR2NlqIc/9PP/30Gu2nyO7oxFhERGql3E18uoFPRBojpVKIiIiIiADOzspU35xzy4D5u20odam/975HXW5Qn2O9qtPPU59lvdHn2LTo82wa9Dk2HYWfZYM6MRYRERERqS9KpRARERERQSfGIiIiIiKAToxFRERERIC9eGLsHN2cY1r+32LneM8st9xbr1tTznG9cyxwjtXJ462d4x7nmO0cE53jYLPuW/njM53jjPyxXs7xvHPMcI4Pm7YPOUdc1DF+na86x8ed4+b83+Z159hk/q0u3Bvvuyac40bnOKG+90MaFuf4pnO85hzT8+/qsfnj85yje4n25ztHyfpeznFK0XfMObo4x5/y13nJOY4w685xjll5f/y6efz3efvvm8e+7RwXlHk/o53j1jzu5Rx/do6qvE8+bPbzzwXPv9U5hhesu8o52prlJ5yjS9G+yP5Fx8vQVsdLqX/e+73+H/jvgP9qiccd+AP2xT7kr9e8xGPHgz8Q/Ork8X8Cf2MefwL87/P4SPBTwbcEPwj8W+APAP8V8J8C3wn8c3nbC8F/s8z+tABfBb6ZeWww+Gk1eQ97+d+sGfhDwT+0L19X/zXs//J+MxF8q3y5O/i+eTwPfPcabKt50W9Evv6H4K/N42Hgn8zjZuDfBj8w749V4IfnfbS6vz6X98k+u/sOg78b/Mg8/iX4fzbrjsz/fwr4P9fw36pZ+m8C/rJyvw36b//9T8fLwv3R8VL/7ZP/9nkqhXMMzv9KvBmYCvRxjk84x6v549/P2zW3f5U6x8Xmas7Fedsq53jatP9RfkVpunN8Jn/8jPzqzF3AK+n+eM9EYHGJXb0A+E0e/xE42zx+p/ds9Z63gXeAMcA2oA3QCtjhHC2ALwI/KvPPcSbwsvfs2M2/2STnuM45ngU+5xyDnONv+ft8zDn65u3uco7zzPPW5/8/KP/rfFr+71x9Ze+8fNuvOMedztEmf3xx/lf+C8D53jMLGOAcXcvtp+xX+gDLvWcLgPcs956FZv2XnGNq/n0bBuAclzvHjXl8e95fnwb+APwj8OX8O/rB5LWGA0/mrzOT7LvYCzgGmO09c7xnK3AXWf/cBrRxjgOAlsAO4LtA4dR6ztEBONJ7qsz7W1C93numm+bt86tjM/Mr0y7fxt+cY2wer3eO7zrHi8A3gb7A09W/V8CDwCVl/n1FdLyM6Xgp+0R95RgPB37lPaMBB1wHnAqMBk60X9YC1wKne89ICEMnnwWWes8xwNHAF9zO4ZzjgH/1nprMwdwPeBcgP+hucI7O9vHcgvyx/wPOAx4GvgN8CbjNezaVeY0TgSkV7k877znJe34O3Az8wnuOBO6n/I8JwCeB+7xnFDAKeM1lw1VfBU7NP4eZ+T5XW+s9J3jPn/LlacDxFe6rNH2PAQc5x5vOcZNzpPO8Lveeo4BfkH3PShkKnOE9f0f2nf6x94zynueSdlXARwGc4xigP3AgBX3Re94gOwBPJTtIDwac97se6I2xwAyz/D/Ar5zjaZeljPQ160YDV5H9jg0k68epdsAM7znWe74LLCTra6cCeM8qoJVzdCuzTyKg42U1HS9ln6ivE+O3veflPD4WeCq/4rQNuAM4aTfPfx74bf5XbvV7OAv4lHNMA14EOgND8nUTveedGu6jK/GYL3rce1Z5zzjvGQu8SvYX84Muyzu8Jz+gp/oAyyrcn7tMPJbsgA/ZX+m7+/d6CfhH57gGONx71gMfIPvBnZj/m40HBpjn/CHZxlKITg5kP5Z/h8aQHWCXAX9wjstNk/vy/08h/l5Zd+/u6k/ueqBL/j39EtmVrO0U91G856r8JPu/gf8ArslPcP/oHFeUeF7UF73nUbKT3v8FhgGvOEd1MfiXvGeB97xPdgAs9f52APfu5n2pT0kldLzM6Hgp+0TzenrdDSYu1XEA3k/WtTbxFWQ/EOcBVc5xZN72895nQ65h41myv329Si0ADgIWu+zmh3bes8a58Hi1AyEaQobsL/T/AD4BTCI7QN4N2Y0HxqbkfZWzAaB62DZRPUvLdvIfvnxo6gAA73ncOU4FPgTc5Rz/Tvbv+xfv+VS51zNa5/srAkB+Uvs34G/O8SpwGXB7vnpL/v8dFP/OVNQvvWctZN/T/Ps/N/+vLbvpiy672W4y2RXcI7znIud41jl+7z0bTdNd+qL3rCQ78bjDZTfcnQSsMO+t3PvbXMFJv/qUVELHy4yOl7JPNIRybZOAU112V25z4GLgmfxqzCrnGJLnCtq7TQd6zyTg28AqsqGZR4HP59vAOQ6tzgGqpQfJDvQAF5ENHVc/folztHSOQWTDumF4x2X5lN29ZwLZgfv9/L9S+/IG2TBvxbzHAy8DH8sfuhR4No/nkV3FA/g7CLmPA4BF3vNL4LdkQ3ATgNPzdThHe+fK7stQ4qFm2Y/l/WuIeWgUeza16TqgQ8FrdXY778z/DPBsfrL8MjDEOQ7J119M1j+rn9cC+Gfgh2R9sfqAWJ17bEV90TlOc3kVCZflHw+CGl9FK3x/+QG7N1mfFamUjpc1oOOl1EZ9XTEOvGdBPmTxN7Iv5kPe85d89dXAX8kOSK+TJeoD/Ng5DsnbP+Y9M5zjDeBgYJrL/kZcCsWlmao5x4/IOnLH/K/bm73nOuAW4P+cYzawnOwHCO+pco77yTrpdrK/ut83m/we8LU8voNsSPlfgG+UePmHgV/tbh9L+Bxwm3N8m+xGiMvzx38B3O8c5wKPQLhidSbwz86xDVgLfMJ7FuVDyvfkJxWe7N97dvpiztGa7Md0erpO9lvtgZ/neYTbyb43n92D7T1E9l28APhSkmd8GNlQ8A6y34F/APCe7c7xRbKDfDOyHMXXzPO+APzGezY6x3TA5Ve2H/Y+LjflPTOdo5NzdPCedWQHzBudC1eVbvWel53jlFq+v1uAR5xjUZ5nPAaY5D3ba7k92Q/peKnjpex9LisxIvXFOR4ErvKeOfW9L0Wc4xKyqw7fq+99EdlbnOPLwDrvs7v59/Jr/RR4MB3KFpFiOl7KvtAQUin2d1fT8JP0PfDT+t4Jkb3sF8T5w3vTDJ0Ui9SYjpey1+mKsYiIiIgIumIsIiIiIgLoxFhEREREBNCJsYiIiIgI0ADKtVndu3f3AwYMqO/diOzYsbNGf7NmzaJ1W7bsvE9n+/adVZeci2uK2+U2bfakVGTdmzdvHsuXLy8qGl8rDfFz3F9MmTJlufe+x+5bVqahf5YrVqyIljds2Fln394/kfbd1q13zhPQvXv3vbR3tbe/fY5NnT7PpkGfY6yqCraXKTjZvDmMHLnv9qcmyn2WDerEeMCAAUyePHmfvJY9aKYnstaqVatC3KVLl2jd22+/HeLly5eHOD0It2rVKsQjRtRk+vm9b+zYsXW+zX35OdZU796wZEnpdb16weLF+3Z/6ppzbk8m2djFvvws339/Z3nT9KbgtE9V++1vfxstT5w4McT2j9W07w4bNizEn/70pwv3qdLfiaLn1OR5yXMa7edYnxpq/9bn2TToc4zt7qdt+3ZoqG+v3GepVArZrxQdNHe3TkQaPvVvEdlTDeqK8d5kUyIgvgKVXuGxV3i3bdsW4jQNYtOmnVOhd+7cueRzAFq0aBHiK664IsQ33HBDRfsusj844IDK/k6fPn3nhFKXXXZZtO74448vuT3bBwF+/OMfl9xGemXaXu2t9Opxba4Qi4hIw6ArxiIiIiIi6MRYRERERATQibGIiIiICLAf5RgX3dUO8Ic//CFavuaaa0Js8xnvvvvuqN3Xvva1EL/yyishfuKJJ6J2Z5xxRog///nPh3h7UuekefOdH0dt7oYXaSpmzpwZLS8xd0717NkzxC+++GLU7tprrw3xmjVrQpzeH3DrrbeG+Nlnnw3xhAkTonZXX311iFu2bFnRvouISOOlK8YiIiIiIujEWEREREQE2I9SKcqxKQwAffv2DfG3vvWtEI8bNy5q99e//jXEc+fOLdz+TTfdFOJKZ7lR+oQ0dVOmTImW77///hAvXLgwWnfiiSeGePXq1SHu2rVr1O7QQw8N8dKlS0OcplKMNNMxbd26NcQdO3aM2tmSiieffHKIDzvssKhdQ5w9T0REak5XjEVERERE0ImxiIiIiAjQBFIp0lnrbAqCHSKdOnVq1M4Ox27evDlaN3v27BDPmDEjxA8//HDUzs5216dPnxC/+eabhfs7a9asEG/ZsiVaZ1M47Ox5vXr1itpVOkOYSENjqzycfvrp0TqbjmBTIgCOOOKIEM+bNy/Ev/vd76J2Y8aMCfHQoUNDnPa1Bx98MMRnn312iNMUiUmTJoXYVpuxjwN85CMfCfGQIUMQEZHGSWdYIiIiIiLoxFhEREREBNCJsYiIiIgI0ARyjMuVNXv9GP+dbwAAIABJREFU9ddD/PLLL0frbA6jzUUEGDVqVIjfe++9EK9fvz5qZ8tLjR49OsTLly+P2m3atCnE7dq1C/GKFSuidm+99VaI7SxbLVq0iNqpNJQ0Jq+++mqIbW7vf/7nf0btbCnDtITiwIEDS7ZbtWpV1O5Tn/pUiOfMmRPijRs3Ru2mTZsW4mOPPbawnc3779evX8nnA/zoRz8K8S9+8QtERKRx0hVjERERERF0YiwiIiIiAjSBVIpy7DDr4MGDo3U2LaJHjx7RurVr14a4W7duIU5TGCZPnhzil156KcS2tBTAsmXLQrxu3boQd+nSJWpnX8uWZLOpGCKNjZ3hzs4Wedttt0XtHnjggRDbvgBxGbWZM2eG+KGHHora2b5ry7otWbIkamfTlmw5RFtOEeJ0DDvL3vDhw6N2H/rQhxARkcZPV4xFRERERNCJsYiIiIgI0ARTKWyKhE1bsDPTQXx3/IgRI6J16Ux41dq3bx8t25n1bLpDWkVix44dIbZVNNq2bRu1s8v27vj0TnmRxuSpp54K8SGHHBJiW/0FoFOnTiFO+5pNT5o/f36I03592mmnhfjtt98OsZ1JEuJKGTZFKk25sGkW6TasBQsWhDitSqMqMiIijYeuGIuIiIiIoBNjERERERFAJ8YiIiIiIkATzDFevXp1iLds2RLi3r17R+1sLqEtpwbx7HTNmjULcevWraN2HTt2DLHNK/beR+1s6SmbR/n+++9H7eyyzV9Ocxvt+2rVqhUiDZktofbuu++GeOzYsVE7my+c5vl37tw5xLYMY5rPP2TIkBCvWbMmxGk+vy3LZu9FsK8DcZ8/+eSTQ3zvvfdG7Wz5t3RGS+UYi4g0HrpiLCIiIiKCToxFRERERIAmnkrRsmXLEKdDpHbWOZuakK6zaRF2NjqIh3vbtGkT4jTlwrazZd3S4V2b3rF9+/bCfbdD0+msfSINTVEaxMMPPxy1s9/ldLZHmwplZ7SzcbpsZ8izs9ZBPKPdZz7zmRAvXLgwajdt2rQQP/PMMyF+4YUXona2L6e/JyIi0njoirGIiIiICDoxFhEREREBdGIsIiIiIgI0wRxjm5toc4xt2bW0XTqFq811tHnFdjrnVPPmO/8p7RTQEJdhs+XV7HMgzk1O1xW1E2noxowZE+LLLrssxGmers37XblyZbRu0aJFIbZ5ynYKeIjvMbBl2NI+aUuq2emcbdk1iKdjt78Taak5m0ed5jOLiEjjoSvGIiIiIiLoxFhEREREBGiCqRS2NFq5WetsaTQ7NAvxsKgdcrWz0UGc7mBfy6ZwQJyOYdMq7Mx5EJeDGj16dIjTFI50Zj2RhuTVV1+Nlu+8884QX3LJJSFOZ360JQrtDJEA7du3L7ku7ZPlZoy0imajTFOYbN+1/fqcc86J2i1evDjETz/9dLTu0ksvLdwPkYYmnbnRpjjZ1CKAd955J8RHHHFEiG+55Zaone0Dffv2DXHaz22pVCv9rUhLpxaxx8pyqZAilq4Yi4iIiIigE2MREREREaAJplLYoVQ7G1WafmBnj7OzakF8Z7sdfkmHb+ywqx3qSYdsWrRoEWI7XJy65557Qjx06NAQ26EniNNFRBqaDRs2RMs2zeD2228PcTrz3bXXXhti+/0H6NWrV4htisR7770XtTv++ONDbPtrz549o3a2csSQIUMK29k0qwsvvDDEb7zxRtSuqqoqxEcddVS0TqkUsjcUpdQVpQyklVls+t9TTz0V4p///OdRu7fffjvEad+26UWDBg0KsU1VBDj55JNDfOONN4b4iSeeiNo9+OCDIT7uuONCXC51wh7z0zRGpU9IbeiKsYiIiIgIOjEWEREREQF0YiwiIiIiAjTBHOMtW7aE2JZ+SfOxZs6cGeK0lJudnc7OkJfmaFl2XZoPZfOPbdmp1J/+9KcQ/8u//EuI07ypdLYvkYZk+PDh0fIPfvCDEJ911lkhtjNMAtx7770hTss4HXjggSG2/euOO+6I2g0cODDENjfSzpwH8Nxzz4XY/k68++67UTs7e541bty4aPnUU08Ncfr+RfamSkuZpbO/Tp06NcQ/+clPQnzooYdG7caPHx9iO4slxKVN7T0DEydOjNr97//+b4g7dOgQYnvvAMR5/IccckiIv/71r0ftzj///BCnx0eRPaUrxiIiIiIi6MRYRERERARogqkUtjyLnVnOplgAzJs3L8R2aCdta0uj2bJrEA9Z2TgdsrLKlZCzZeNsGaojjzwyapcOnYk0JG+99Va0/Oabb4bY9o2lS5dG7WwpwzRtyaY02W2kqQ+vvfZaiG26VNr/bd+z5d/sTF4AK1euDPHhhx8e4nQI2L7n6dOnR+vS/itSF6qPdeWON+XYtAg7250tZVgTl112Wck4NXfu3BBfd9110bpp06aF2KYM2nSsdBt9+vQJse2vEPfz9DfFHkeLfg8ATjvttBLvQpoyXTEWEREREUEnxiIiIiIiQBNIpUhngbPDJba6hJ3pLrVx48ZouV27diG2s9ulqRTpkEu1dHY7m95h76BNZ+1auHBhiBcsWFC4v0qlkIYsTaWwVV9sn/njH/8Ytbv++utDbNMWIL773X7/bWoSwMc//vEQv/LKKyX3AeKh2HPPPTfEduY8iIdmv/zlL5fcNsS/IenvhJ1J074PkdraunVrOEbYVCWI+0SbNm1CnFaruOqqq0JsU41eeOGFqJ39/qbHW9uf7bH3pZdeitrZ2S9tiuOwYcOidmeeeWaI7YyUtioNwP333x9iW2EmTYu0fTE9btrjtF1n3y/A0UcfjexfdMVYRERERASdGIuIiIiIADoxFhEREREBmkCOcbnZ6GwuU5qHZdk8LIhzk+320xnnbJkcm6NUbuY7m9fUr1+/qJ0tAZXmaVo2Zzl9/7Ut3SNSV6ZMmRIt2/JPtizUrFmzonY2n/+pp56K1tnZuGw/fOaZZ6J2o0ePDrHt82neoN2Pk046KcTpjF32noCDDz44xGmOse3Ly5cvj9YtW7YsxMoxlrrQrFmzMItqmvdrSw7ae1XS49KIESNC/Ktf/arwtWz+cTrLnL0fp2fPniG+6KKLonZ2FjtbXq22rrzyyhDb+4fsbwjser+PZUu0paVTLfXZ/Y+uGIuIiIiIoBNjERERERGgCaRSpOxwkS1bM3Xq1MLnpKkURbNspWWYitIW0uEcu0/lhmyqh8Zg12Fmqyg1o9w+iewracmz4447LsQzZswI8Qc+8IGoXZcuXUL86quvRuu2bt0a4qIZqyBOLbL936YzpO1sH0pLMNqhY9s/0/KPdlh63bp10To7xCxSF5o1axaG+MeNG1fPe1O/bMqkSF3QFWMREREREXRiLCIiIiICNIFUinTo0w6z2uoNdgarVDpbzoYNG0Jsh3DTChB2mLXc3a82vcGmaaSpGd26dQtx0ax6UHlqhkh9mDZtWrQ8ePDgkuvSqiyLFi0KcTorpL2T3aYq2DvwIb4L385ul84kaWeqW7JkSeH2bJ8cOnRoiO3vAsQzc82fPz9at2rVqhB36tQJERFpuHTFWEREREQEnRiLiIiIiAA6MRYRERERAZpAjnGa62dzjG3ZNJvbm0rz/hYvXhxim8+bznxnZwSy7WxuM8T5wnb/0jIzdj/SXEfLvi+7PZGG4M9//nO0bPPgf/rTn4b47LPPjtqNGTMmxOksXUcddVSI33333RAfc8wxUbvDDz88xLZvpH3c3hMwcuTIEKf3ItgScrbk21e+8pWonS2vmOZHf+Mb3wjxgAEDEBGRhktXjEVERERE0ImxiIiIiAjQBFIp0nJlaRpDNVsKCmDIkCGFz7Hl1WzaQjqjnV22pdzKlVBLh4itww47LMQzZ84sbKdUCmnI/uu//itatjPh2XSkQYMGRe1Wr14d4rRcYevWrUNcPeMXQO/evaN2tgSc7RsLFy6M2tmZ62z/P+igg6J2mzdvDrFN2/rMZz4TtbOz+KV9Mp3hT0REGi5dMRYRERERQSfGIiIiIiLAfpRKkVZ5sDNVpduw1SZsikRa2aJolr10KNWuK1cdo3379iVfN51xz6Z6lJtxT6Q+zJkzJ1q2aRD2u3zooYdG7Z588skQ33fffdG6qVOnhtimRdx+++1ROzvLnK1e8cYbb0TtbIqE3V46a9+KFStCfNZZZ4XYVqiAePa8tFKOTRHp0aMHIiLScOmKsYiIiIgIOjEWEREREQF0YiwiIiIiAjSBHONUWuapWprbO3jw4BDbnF2AVq1ahdjmB6ft7Lo0r9BKn1ekXbt2Jfd348aNUTtbrq3c64rUhw0bNkTLNh/XxmPHjo3a2dntbDlFiEueVVVVhdjmLwNcfPHFIX7ttddKbhviXOePf/zjhftkZ8I755xzSm4b4jJ06fsvd1+BiIg0LLpiLCIiIiKCToxFRERERIAmkEphyy5BcdrCvHnzouUTTjghxHPnzo3W2Vny2rRpE+IuXbpE7Wzahh2aTUuo2XZFqR7pa61Zs6bktmHXGfhEGpJ169ZFy7Zs2uzZs0Pctm3bqN2jjz4a4vQ7b/vU4sWLQzx8+PDC/bDbHzFiRLTOlpSzM+n17NkzamfLsNnfBVtaEeJykOn7T3+jRESk4dIVYxERERERdGIsIiIiIgLoxFhEREREBGgCOcZpPm/R9LNpnp8ty5ROCd2yZcuS27ClmyDOM7TTQKflmmzO4QEH7PxbJN0nW1Kqd+/eIbY5mhBPpVsuZ1mkPqT5vMcdd1yI33zzzRC3aNEiard27doQ2z4Icc79xIkTQ9y9e/eo3RNPPBFiW0Jt4MCBUbsXX3wxxGeeeWaI075m700YOnRoiE8++eSo3euvvx7ijh07RusGDRqEiIg0DrpiLCIiIvL/27vzeCuKM//jnwdQuGwCgoJEFlFERUDFfU/UmIxLjGb8adwnyRjjmsTEiTFGTdSMUceYUeM+ibtxiWvcUZKIooAsCgoKiiCCigqySv3+6LrN08U5517gXu72fb9evHhOd53uPkvdrtP1dJUIahiLiIiIiADNIJXCzz6XPp41a1YepzPEHXHEEfV7YM6GG25Yq3I+vcN3Az/77LOFcr6rOk3bEGloffr0KTx+5pln8tgPa+bTigDGjx+fx5tssklhnZ/90ac3dOvWrexx+DSrdPY5/9inOqWzTPrUCp9y5WfHhOKwbr179y6sS4d5FBGRxktXjEVEREREUMNYRERERARoBqkUM2bMKDz2d6/Pnz8/j88777x1dkx14Ywzzsjj/v37F9b5mb/8aBigbltpeOmoFFdffXUev/zyy2Wfd9xxx+XxqFGjCuv8jJY+zShNU5o2bVoe+1Ev0hQJ/9indKQpV74+DRo0KI992kf6uF+/foV1abqXiIg0XrpiLCIiIiKCGsYiIiIiIoAaxiIiIiIiQDPIMfazz0FxJjg/A9U+++xT6236YZkaKj/w8MMPz+N0FjA/G59IY9OmTfHPyre//e089jM6pgYPHlwyTp100kl5vMMOOxTW+frvh3xL83579eqVx1tvvXXZcgcffHDJY0j36/OUN91008I65RiLiDQdumIsIiIiIkIzuGIsLcc555xTdt2ll166Do+kcR2LSFOn+iQijYX5tIGGZmZzgRk1FpS61DeE0KMuN6jPsUHV6eepz7LB6HNsXvR5Ng/6HJuPsp9lo2oYi4iIiIg0FOUYi4iIiIighrGIiIiICNCEGsZm9DTjLjOmmfG6GY+ZMXANttPFjFMqrD/DjIlmTDLjTLd8qBkvmjHBjIfN6ByX727GeDNGm7G528cTZpQdp8mMv5qxWYw7mvGn+NommfGCGTuv7muL2/qFi9eP29JNllLnzDg3fl/HmzGu+jtrxnQzupcof4gZJe+yMmMfM3Yrs66rGQ/E/bxsxmC3rlx9/V0s/2e37Fgzzki379b3MuORGLc34/ZY3yea8Y9YT/uZMbHM8y80Y78y604wYxP3+C4ztih3LNKylatbdbDdEWYMX5MyZpxqxlQzgq/fZpgZf4jrxpuxvVt3vBlvxX/Hx2Vtzfh7rFenuLLXm7FdheP6lhm/ivGW8TjHmfGGGdev3jtRdh/7VP8NqE0ZMw4y44K62Lc0Hk2iYRwbmA8AI0JgQAhsDfwC2HgNNtcFSjeM4wn3+8BOwFDgIHfyuhE4JwS2jcdydlz+E+DweDw/jMvOAy4OgZIJ3GZsA7QOgbfdtj8GtgiBbYATYNWGRS3lDeMQWAo8Axy5htsSKcmMXYGDgO1DYAiwH/BepeeEwEMhsMoQA/GH2z5QumFM9p0eF/dzHHBVfF7J+mrGBsBusXxrM7Y1o4qsXl1T4RB/DNwQ4zOAOSGwbQgMBv4DWFb2mdnr+1UIPF3i9bWO+97ELb4W+Fml7UnLtCZ1ax35J9mxpDeLfQPYIv77Adl3GzO6AecDO5PV0fPN6Ap8HXgVGBLLY8ZQoFUIjK2w/5+xsv7+AbgyBIaFwFbA1Wv96tbMo8AhZrRvoP1LPWgSDWNgX2BZCFxXvSAExoXAyPhr9bL463OCWdYIjFd3njFjTFx+aHzqpcCA+EvzsmQ/WwGjQuCLEFgOPA8cFtdtCbwQ46fIGsOQnSyrgPbAMjMGAL1D4PkKr+e7wN/icQ4g+8PxyxBYEV/b2yHwaFz/4/jaJiZXxB4049V4VaH6j8ulQFV8bbfHog/G/YnUpV7AvBBYAhAC80Jgllt/mqt7gyC/avrHGN9qxhVmPAfcDZwMnBW/u3sm+9qa7AceITAZ6GfGxpSvryuA9eMP6iqyOno28IcQKjZuDwf+7l7f+9UrQmBK9Wsla2zfEOvek7HRXf2ajojxdDN+ZcY/gKOA4cDt8fVVASOB/Uy9ObKqsnUrfqdGx/PB9fE7Xn2V93eW9ai8WV2HzKiKvRPjzbibrD4Q111rxivxe1zjVc8QGBsC00usOhT4cwiEEBgFdDGjF1kD+KkQ+DgEPiE7bx7IynOm/+5fBNnV4FIs6x1eEgLz3Hs00x3bhFiunxkj49+eMRZ7oeJV3hGW9dROtqw3qPq9OzAu+wfwbbfPncz4lxlj4/9blnhPAjCC7IeMNBNNpWE8mOwXZinfBoaRXTHaD7gsVsrFwGEhsD1Zw/ryWBHOAabFX5pnJ9uaCOxlxobxF+A3gU3dukNi/B23/BLgeuBM4I/Ab8muGFeyu3s925BdDVtlOjszdgBOJGs47wJ833U1nRQCO5CdcE83Y8MQOAdYFF9bdWN4IrBjDccjsrqeBDaNJ+FrzNg7WT8v1r1rgZ+W2cZAYL8QOBy4jpVXgEYm5V4jnrDM2AnoC3yFMvU1BD4H7gPGAu8AnwI7hpD9GC3FjP7AJ67xezPwc8vSp35jxbSHLYD/jb0781n5Izm1OAT2CIHbgFeA78bXtyj+CJ5K9ndLxKtUt/4YAjvGXowqig2yNiGwE9m56Py47IfAF/HK828BP2XjuSEwnOzK7d5mDFnD4+1N8Yr2zLis3PKngJ7AS8B/m3EI8Grywzq1OzDGPb4SeNaMx804y4wucfmHwP7xb8+RZFeWq21H9t5sDWwG7G5GO7JeooOBPeNxVZsM7BUC25E12i8uc2yvxOdKM9FUGsaV7AHcGQJfhsAcsqtGOwIGXGzGeOBpsgpZMfUiBN4AfkdWcf9OdkJeHlefBPzIjFeBTsDS+JxxIbBLCOxLVtlmkc0Ce7cZt8UrW6lewNxavrYHQmBhCCwA7mdlBTzdjNeAUWSN9JL5irHBvdSMTrXYn0itxO/jDmRdoXOBu804wRW5P/7/KtCvzGbuLfWDsIRLga5mjANOI2vwLq9UX0Pgv2Mj9CfEq1FmfM+Me8z4ZYl9FOpkCIwjq8+XAd2A0WZsFVe/E9fX9PruruF1fUgxvUKkprq1rxkvmTEB+CrZhZVqpercXsBtcbvjgfGu/L+bMYasPm1D1mBcE6XupQnllofA8hA4OjY47yVrrF4ee5D+GhvKqbR+3kLWY3QvWRrWKDPaAusBN8T3597kNb0cAjPjj9JxZO/RILL6/Fa8+nubK78BcK9l9xRcSfG99lSPm5mm0jCeRPGXrlfuBrfvAj2AHUJgGDAHaFfTjkLgphDYPgT2Isv7fSsunxwCB8SrtHcC0woHkV2N/iXZSfj8+O824PQSu1nkjmUSMNSs5GdR8rWZsQ/Z1fFdQ2Ao2R+2Sq+tLdkVdJE6E3+MjgiB84FTKV45rb7y+iXlZ9hcWMv9fBYCJ8Z6fBxZvX4nritZX6u5HpY3geNC4N+BwbbqjW++Tlbvd0EI3B8Cp5DV5W8mr21tX1+7uF+RglJ1K17dvAY4It7rcgPF72y5OrfKvS6xh+SnwNfi1eRHqcX5sYyZrOxBhaw3Z1aF5d4pwP8Bu5JdbDoSSv5wLVU/Z4XAzSFwKNkP4sHAWWTn+qFkvanru6eUq7flJnO4CHguXp0/ON2/o3rczDSVhvGzQFszvl+9wIwdYxfTC8CRZrQ2owfZL+SXyX7tfRgCy8zYl6z7FeBzKH/11IyN4v99yLpv70yWtyKruNclTz0eeDTmUrUny3NcEePUG5CNYBEC08i6Yi5wOU9bWJYT/QLwLcvukO9Alj85Mr62T0LgC8vyN3dx215mxnru9WwIzK0ht1JktVh2V7hvXA5j7WZwKlsvLRvlpfoE9z3ghRD4LK4rWV+d6tzF9YDWcVmpevkm7sqvZaPNdI3x+mRXnur69Q0k+2EskqtQt6obZvPM6AhZPnsNXiDeY2LZzarV6RKdyX64fRp7Nb+xFof8EHCcZff77AJ8GgKzgSeAAywbVaYrcEBcRjyermSpIH9m5TkzULoBmp8z43MPrD7PmdET2JDsnoANgNnxqvCxrKzz5UwG+lt2rw9k9wNU24CV9xmcUGEbA6H0SDXSNDWJhnHs4jgM2N/ikGbAr8l+fT5A1j30GlkD+mch8AFwOzDcLMvtI6sAhMBHwD8tu3khvfkO4D4zXgceBn4UG7oAR5nxZtzOLOCW6ifE/MbjWXnH7BVkOY6XEO/QTTxK1v1T7XtkuU1TYxfQDcCsEBgD3ErW0H8JuDFkd+3+HWgT00QuIkunqHY9MN5W3ny3L/BYiWMQWRsdgf+zbOjE8WQNx1+vxfYeBg6z0jffbQVMMmMy2QncD7lWrr5ixreA0fHK0nzIhlsk6859ze8gBBYC08zyk+8A4PlYfizZj9f71uL13QpcF19fVWyMLIoNCBGvZN2K3+EbgAlkN1WPrsW2rgU6xu38jOxcQvz+jyX7YXYz2YgTFZlxuhkzya78jjfjxrjqMeBtspz5G4ijPoXAx2Tnp9Hx34VxWbVfAb+J5/cnyK7wVp//Ui8A29nKIVAPACbGdMIngLPjef8a4HgzRpE1WCv22oTAYrKUlUctu/nO//j9b+ASM/5J5Qb2vmTndGkmNCV0A7DsrvTngN1rmWO5Nvu6H/ivEJhSn/sRaerMOIws9apUV25d7+ss4LMQuKm+9yXSHJhxFfBwKDEkYkOJP3DvCIGvNfSxSN1pEleMm5sQWESWg9y7PvcTu4AfVKNYpGYh8ACUHI6qPswny60Ukdq5mNKpiQ2pD9lcBtKM6IqxiIiIiAi6YiwiIiIiAqhhLCIiIiICqGEsIiIiIgKoYSwiIiIiApSfsalBdO/ePfTr16+hD6NFmT59OvPmzSs3e+Aa0eeYee01WL689Lo2bWDo0Lrf56uvvjovhNCjrrbXGD/L9957L48XLSpOONWtW7c8XrFiRR6bFb/in3ySD3fMxhuvnLV9gw02qLPjXBst4XNsSfR5Ng/6HIsqneOg/s5zdaHSZ9moGsb9+vXjlVdeaejDaFGGDx9e59vU55ixCj83li+H+niLzGxtZmdbRWP8LM84Y+X8HhMmTCisO/bYY/N4wYIFedymTfFP3f33319yewcddFCtjsE3ugFatarbzreW8Dm2JPo8mwd9jkWVznFQf+e5ulDps2xUDWMREYARI0YUHl9zzTV53LZt2zz++OOPC+VOP/30PG7deuVkVe3bF4c/3WWXlbOo33PPPXn80EMPFcpdeumleeyvRtd1Q1hERBoH/XUXEREREUENYxERERERQA1jERERERFAOcYi0kCmTJlSePy73/0uj998883CuiFDhuTxG2+8kcdVVVWFct27d8/jefPm5fHgwYML5fyoFP7GPJ+/DHDmmWfm8eabb57HJ598cqHcRhtthIiINH26YiwiIiIighrGIiIiIiKAUilEpI59+eWXhcd+2LRrr702j0eNGlUo16FDhzzeaaedCus6duyYx4sXL87jyZMnF8r51Aqf3pAe0+jRo/P4P/7jP/K4a9euhXKfffZZHs+ePTuP//M//7NQ7rrrrstjP2EIFMc81jBvIiKNm/5Ki4iIiIighrGIiDSwnj2zWbRK/evZs6GPTkRaEqVSiEid8qkTKT+Fc8+kxeOfl07h7EeROOSQQ/L49ddfL5Tz6Q6XX355Hl944YWFcgcccEDJ/fo0DSjOmNe5c+c8TqeEvuOOO/L4rLPOKqxT+kTN5sxZs3UiInVNf7FFRERERFDDWEREREQEUMNYRERERARQjrGI1DOfH+xzeHv06FG23PLlywvrOnXqlMdz587N43322adQbo5LSL3nnnvyuH///oVygwYNyuOFCxfm8dKlSwvlli1blsd+KLg0P3rmzJl5XGm4OhERadx0xVhEREREBDWMRUREREQApVKISD175513Si5Ph0ZbsmRJHqfpB37mu3fffTeP/cx0AL169cpjnz7xwQcfFMpNnz49j32aRjprnZnlsU+R+Pzzzwvl/Gv59NNPC+u6deuGiIg0DbpiLCIiIiKCGsYiIiIiIoBSKUSknr3//vt57FMO0vQGP9JDmiLxxhtv5PH8+fPz2M90B8WRI3y5sWPHFsp17949j/0IFe+9916hnE+fWLBgQcljTU2ePLnweLfdditbVkREGhdKqD6qAAAgAElEQVRdMRYRERERQQ1jERERERFADWMREREREUA5xiWFEErGrVqt/e+IF154IY/32muvtd5ebfnZvQA6dOiwzvYtLZvPMW7btm0ep99JP9vdhhtuWFg3Y8aMPPYz5LVr165Qzm9/o402yuOtttqqUG699dYruY10CLmBAwfm8dNPP53Hfvg4KOYsT5o0qbBOOcYipfnzKxTvGdhkk03yOP1bccUVV+TxqaeemsfpeW399dcvu29//4BmpxRPV4xFRERERFDDWEREREQEUCpFSX62Kx9Xcvrpp+exn5kLYM8998zjZ555Jo/9zFwAm266aa325buc27Qp/xFedtlleXzvvfcW1j377LMArFixolb7FFlTPj3BD3k2derUQrlFixblcb9+/QrrfGqFT4P46KOPCuV8msUXX3yRx+lMdZtttlnJ7aVdqn4WuxdffDGPBw8eXCh3wAEH5HH6ukRamjRFwp9H33777Tw+88wzC+VOPvnkPB4zZkwen3HGGYVyd999dx4/+uijeXzHHXcUyh100EF5nA7t2L59+zz+wQ9+kMdpGlf6WqT50xVjERERERHUMBYRERERAdQwFhEREREBWlCOcZpLuyZ5xD43CmDHHXfM46OPPjqPt99++0I5n7fo85dOO+20QrkHH3ywVsdRKa/4L3/5Sx7fddddeexzO2HltLXp8FQidc1P7+yHXUq/kz7nPl03YMCAPPZDsr388suFcnPnzs3jrbfeuuz2li1blsc+t9nnHabHdNNNN+XxueeeWyjn85nToaVEWppK51Sf3//QQw+VLXf//ffn8f77719Y54dEXLJkSR6n9+k8//zzeZwO7ehVOqdKy6MrxiIiIiIiqGEsIiIiIgI00VQKP3xK2mVTbl2lWeuWLl1aePzBBx/k8XbbbZfH6dAyP//5z/N4yJAheTx9+vRCOd+16mfg8jNpAXTt2jWPf/GLX+Txt771rUI5P7zUP/7xj8K6a665pmS5oUOHFsr17t17lTIi9cHXB58GkQ6N9t3vfjePL7300sI6/z31ddmnaUBx+LYPP/wwj1977bVCOV9f/exYfihEKA7z5oeQS1MufKqGhncSKa96qFCAadOmFdb16dMnj2+99dY8Tmeu9GmHfra7tD3gh2jbY489Cuv8vh9++OE8PuaYYwrl/Ax50jLoirGIiIiICGoYi4iIiIgATTSVotIdr+XWjRw5suxzzj///MLj6jQDKN6Jno5sMXPmzDxO7473/F3vvpv13/7t3wrlNthggzy+9tpr8/jmm28ulOvUqVMez5s3r7DOd0XtuuuuefzSSy8VylV3QaubSOqb787s3r17Hs+fP79QzteTLbbYorDOpzhUj6gCq6ZB+TrkUzhmzZpVKLf77ruXfM6MGTMK5Xxd86PSpDPp+Tve0xEw/IgVaQqGyJoql7Ljz4G+THr+SlOZyvF1z4/mUmkbPj0J4JJLLsljX4/SkSJ69uyZx3/605/y2I8ABcV69NWvfjWPu3XrVijnUw39iDVQTM+477778jhNpdCIFS2PrhiLiIiIiKCGsYiIiIgIoIaxiIiIiAjQRHOMK5k6dWoe+xzGO++8s1DO5ymed955hXV+eDU/dFs6o5XPvfK5Umners/t8jPN+Rl7AL7zne/k8SGHHJLHU6ZMKZTzw8ykM/3st99+eexzJ+++++5CueocsNrO+idSW2ner3/sh1pL82394zRP19flvn37llwOxSHa/Db8sItQrIe+nN82FIeD69ixYx6nuYw+19/nSULxb4if9UtkbdTmb3elMrXJUYZijm1t8239UGtQzPffdttt8zg9p/qZYXv16pXH/n4egFNOOSWP58yZk8eDBg0qlPPnw86dOxfWnXTSSXns/27cdttthXJpzrE0f7piLCIiIiKCGsYiIiIiIkAjS6VYsmQJb731FgB33XVXYd1GG22Ux74bNB02yQ8n47s7991330I5P/xLOtSa7+713S/p0DQ+ZeLjjz/OY991mh6jH5IqTaXw63y37ZZbblko52fw8bPlpcfhZwfyXVQAkyZNAorvpUhd8OlMUJztztfPTz/9tFDOd52mXbY+bamqqqrsNvzMd77Ov/nmm4Vy6TCH1dL0Dl/n/TH4YdzSx/4YYNW/USJ1YXVnWKzt8Gwp/72/7rrrCuvGjh2bx34oxhNOOKFQzg+pdscdd+Tx66+/Xijn/z7stttuZY/pf//3f/P4rLPOKnk8UDx/+yEaoTi0qY9feeWVsvuVlkFXjEVEREREUMNYRERERARoZKkUH374YT7j22uvvVZY57tjvbTL1Y/E4Ge6SbtcfWpGhw4dCuveeeedPJ44cWIep3fG+jvifRpEmp5Qbna59DX5LuLhw4fn8ejRowvl/vjHP+axT/sA2GabbfLY312cltt8881LHoPI2kpHiiiXSjFkyJBCOT+aQ1rXfGqRH0Ui3Zf/zvvtVadolToO3yXtR6GAYjdyjx498jitT+XSoGDVvz0idWF1RxRKz0M+tcKn3aV1z6cnpKPFHH/88Xn8/PPP57GfVQ6Ks93583J6rvTn5Ur8a/cjSqSv0c86mY6UccABB+Sxr7M+rQLg3XffrdUxSfOhK8YiIiIiIqhhLCIiIiICqGEsIiIiIgI0shzjrl27csQRRwCrziz13nvv5fEnn3ySx+lQSLNmzcpjn2/sZ95J1/mcYijOxuNzmNO8Qr8NP8yTn9kHisNG+aGc7r///kK5J598ktrwr9nnUKV87nT1THfVqnPFajuTkUht+Zw/KD/UWjpDnM/7TXMPN9544zz2wxym319f7tlnn83jdFgoPwOdH/Iw3a8/Xp+TmdYnn/PoXwcU849F6lqlYdv8rKuVhmsbN25cHqd1YL311svjs88+u7DOzyjpzzdvvPFGoZzPz/c5y+mx+1nnTj755LLH6/n6NmPGjMK6gQMH5nF6T8MDDzyQx8cee2weDxs2rFBuwoQJtToOaT50xVhEREREBDWMRURERESARpZKUVVVlQ831rdv38I6PyuWlw7P4ruB/BAxaffu448/nsfpLD2+y8XPGJd2n66tgw8+uPD473//ex4PHTo0j9MUDt8llg4N5bumfErI7NmzC+WqUzDSbl+RtZXOKudnhfPft/79+xfK+e7XdFgonz7hUzB8ihUU0xZ8OpZPiYBit69f59M+oPxwhmm98eXS7mHNLin1ofp7Vm44UCimGqVDEU6bNi2PfQpCmgro05B+/vOfF9bdc889Jbe/6aabFsr58+hzzz2Xx34GWiiep30qlJ85L+XPlXPmzCmsO/LII/M4Pd9+4xvfyOOjjz46j9P0TNXflkdXjEVEREREUMNYRERERARoZKkUrVu3zkd6SLt9nnnmmTz23Z3+jlmALl265PHgwYPzOB294dRTT81jf4c6wNKlS/PYdwunXSye78JN70L3Xau+a6t3796Fcr47duTIkXnsu4qg2I2b3mnsu9X8a067pn3XlkhdSr//7dq1K7mue/fuhXK+G9WP+ALFlCE/2106KoVPH/IpFx9//HGhnO8e/eCDD/LY//2A8nU+Tbnwj9Nj8n9PROpK9UgotR1ZKE3x+dvf/pbHU6ZMyeM0dcCPWOFngoXiKEt+RruHHnqoUO7MM8/M4xEjRuTxBRdcUCjn6+JFF12Ux2kqhZ9NstJseX57KX9Mnh81A1YdzUKaP10xFhERERFBDWMREREREUANYxERERERoJHlGHvpcC/p42pTp04tPPY5jG+99VYe+7xEKA6B5vOroDg0VOfOnfM4zWf2s135HMh01j6fE+zzvNL8Jz87kN+Xn70o3YafBTDlh8lKj2nAgAHAqsNYidQ1//33ubhpnu6kSZPyOB2i0D/2ddnXQSjOYuf3m9Zd/733uf1pzr7PD/b1Nb0vwUtzPivNTimyJhYuXMiLL74IwHXXXVdY5+8nqTRzq1/nzxXp0KY+7z4d9nPUqFF57IdA9efQlM/997nCKZ+/vPPOOxfW+fP8/vvvn8e+/gPcddddeXzGGWcU1m2xxRZ5vP322+dxOnveVVddVfYYpXnSFWMREREREdQwFhEREREBGnEqRW1tvvnmtSqXzuYjIvUjTW/waQw+5cjPdAew22675fGgQYMK63wag0938ENEQbF72A9dmM4O5tMsfHduOqSVn+3SpzSlM9/5Y/LD08GqKSMia6uqqiofRux73/teYZ2vEz7VLh1G0T/2Q7Sl5fx3+5e//GVhna8TPu0wHQ7UD4HmUzN+8pOfFMr5dMJKKRe//e1v83jmzJl5nM6Q6+tzus6nU/mZMNO/Paq/LY+uGIuIiIiIoIaxiIiIiAjQDFIpRKRxSdMRfHqDT7NIR0r54Q9/mMdvv/12Yd2YMWPy2He3TpgwoVDu9ddfL7n9NJXCd9P6VI9Zs2YVyh133HF5vMsuu+Rx2rWbHoeXjgYgsrZatWqVd//vueeeDXw0654fAUOkrukvtoiIiIgIahiLiIiIiABqGIuIiIiIAMoxFpE6lg7X5vlc3z322KNsuXRmuXIzze29995lt+GHkkpn4lrbGR99njNUfs3pzJUiItJ46YqxiIiIiAhqGIuIiIiIAEqlEJE61rZt28LjcmkGfpi0VDq8mp99yw8HVymFwQ+TtqapE+X21alTp7LHl6ZOLF26dI32LSIi656uGIuIiIiIoIaxiIiIiAighrGIiIiICKAcYxGpY/PmzSs8XrZsWR77XFw/VfTq8Lm+6fTTlXKO14TPF/bHnuYY++Hg0nWVcqlFRKRx0RVjERERERHUMBYRERERAZRKISJ1LB1qzacSLF++PI979eq11vuqbepEpZSLSsO/lUulSId/8+ki/jXCqqkVzck555xTdt2ll166Do9ERKRu6IqxiIiIiAhqGIuIiIiIAEqlEJE65mecA/j888/zeP78+Xmcplx46exxPo1hTVRKuViTkSzSETX8a0lHoejQocNqb19ERBqGrhiLiIiIiKCGsYiIiIgIoIaxiIiIiAigHGMRqWMnnnhi4fGrr76axz7HeIcddii7jTWdFa+upfnS1dKh5vzj9Ni7dOlS9wcmIiL1QleMRURERETQFWMREWkmNOGIiKwtS2eEakhmNheY0dDH0cL0DSH0qMsN6nNsUHX6eeqzbDD6HJsXfZ7Ngz7H5qPsZ9moGsYiIiIiIg1FOcYiIiIiIqhhLCIiIiICqGEsIiIiIgKsg4axGeeaMcmM8WaMM2PnOt7+PmY8UofbO8OMifGYz3TLh5rxohkTzHjYjM5x+e7xtY02Y/O4rIsZT5hhFfbzVzM2i/FJcbvj474PravXE7ffz4yJa/H89c14wUyjmMhKZvQ04y4zppnxuhmPmTFwDbbTxYxTKqw/K9bHiWbcaUa7uHxk/JsyzoxZZjwYlx8ey480Y8O4bIAZd1XYh5nxrKvX9fLazOhhxt9XdzvSstTXedOMEWYMX5MyZpxqxlQzghnd3XIz4w9x3Xgztnfrjjfjrfjv+LisrRl/j/XZ143rzdiuwnF9y4xfxXjLeJzjzHjDjOtX750ou48a2xO+jBkHmXFBXexbGo96bRibsStwELB9CAwB9gPeq899ro60oWfGYOD7wE7AUOAgM7aIq28EzgmBbYEHgLPj8p8AhwO/AH4Yl50HXBwCJe9sNGMboHUIvG3GV4BzgT3ie7QLML6OXuJaM6N1CCwFngGObOjjkcYh/uh7ABgRAgNCYGuyOrDxGmyuC5RuGJvRGzgdGB4Cg4HWwP8DCIE9Q2BYCAwDXgTuj0/7CVk9+jNwdFz2G7J6Wc43gddC4LP6fG0hMBeYbcbua7AtaQEa8Xnzn2THko6i8A1gi/jvB8C1AGZ0A84HdiY7p55vRlfg68CrwJBYHjOGAq1CYGyF/f8MuCbGfwCujPV/K+DqtX51a+ZR4BAz2jfQ/qUe1PcV417AvBBYAhAC80JgFoAZ0824wIwx8WrpoLi8gxk3xyuwY6uvnsarniNj+TFm7JbuzIwd43M2q7CdE8y414yHgSeTTWwFjAqBL0JgOfA8cFhctyXwQoyfImsMAywDqoD2wDIzBgC9Q+D5Cu/Ld4G/xXgj4HNgQXyPFoTAO/FYR5jxOzNeNuNNM/aMy1ubcVl8bePN+M+4vKMZz7j3dJUrz/G9GRvfq3Lb2ceM58y4A5gQn/pgPG4RgH2BZSFwXfWCEBgXAiPjFaTL4hWhCWbZD6oK389LgQHx6s9lJfbVBqiKP2TbQ/Y3pJoZnYCvkn1HAVYAbVlZJ/cEZofAWxVej6+T9f3aVJekkkrnzV/Fv9cT4xVWi8vLnSuqLOv5GG/G3WTnKuK6a814xbIr0zVe9QyBsSEwvcSqQ4E/h0AIgVFAFzN6kTWAnwqBj0PgE7Lz5oGsPGf6C1MXQXY1uBTLemuWhMA89x7NdMc2IZYr2U6I57QRlvXUTjbjdvfeHRiX/QP4ttvnTmb8K54v/2XGliXekwCMIPshI81FiN/m+vgHoSOEcRDehHANhL3duukQTovxKRBujPHFEI6JcZf43A4Q2kNoF5dvAeGVGO8D4REIu0F4FUKfGrZzAoSZELqVON6tYrkN4/5ehHB1XPcvCIfG+McQPo/xMAijIDwH4SsQ7oKwRQ3vy/MQto1xawhPQHgXwi0QDnblRkC4PMbfhPB0jH8A4ZcxbgvhFQj9IbSB0Dku7w5hKgSD0A/CRAhbQhgLYVgN29kHwkII/d2xtIYwtz6/L/rXdP5BOB3ClWXWHQ7hqfid2Th+t3vV9P2ssK8zICyAMBfC7SXWHwfhr+7x/vFvwcMQNoj1q2sNr2cGhE7r4rVB6A1hQkN/hvrXOP9R+bzZzcV/qT5fVDhX/BjCzTEeAmE5hOF+W/G7PALCELet4RWObzqE7u7xIxD2cI+fgTAcwk+rzy9x+XlxWRsId8Rz0dEQDoFwfg3vyYnVr889/hTC4xDOgtAlLq/UTviU7BzdiuzcvgeEdhDei2UNwj0QHonP6QyhTYz3g3Cf29Yj7li+S2wn6F/z+FevV4xDYAGwA1l3yVzgbjNOcEWquz5fBfrF+ADgHDPGkf0Sawf0AdYDbjBjAnAvsLXbzlbA9cDBIfBuDduB+Cu2xPG+AfyO7Jft34HXgOVx9UnAj8x4FegELI3PGRcCu4TAvsBmZFezzIy7zbjNrGT3a6/4fhACX5L9ij4CeBO40oxf1+I9Oi6+tpeADcm6sQy42IzxwNNAb1Z2//YguyJ2TAiMq2E7AC+HeOXaHefSeHVOpJI9gDtD4MsQmEPW87Ijlb+fJVnW9Xoo0B/YBOhgxjFJsaOAO6sfhMBTIbBDCBwMfAt4DNgyXi26wUp3e3YLgc/X0Wv7ML4WkVXUcN7c14yX4nnwq8A27qmlzhV7AbfF7Y6nmKb372aMAcbG7fhz6uoodS9NKLc8BJaHwNEhsB3ZufxM4HIzroh19JASz8vPmfG13EJ23r8X2AcYZUZbKrcTXg6BmSGwAhhH9h4NAt4JgbdCIBDfq2gD4F7L7s+5kuJ77ak+NzP1fjNVbFCNAEbEL+vxwK1x9ZL4/5fuWAw4PASm+O3ExuIcstzfVsBit3o2WcN3O1Z2s5bbzs7AwgrHexNwUyx7MbG7JgQmkzUkq7t1/i3ZrgG/JMvD/SNZblU/svzIc5PdLIrHW73PALwMvGzGU8AtkDeOy71Hp4XAE8kxnEDWAN4hBJaZMd3t51OyPLXdgUk1bGcfSr9HbSm+79JyTSL7MVdKuZtOv0v572c5+5GduOYCmHE/sBvxBGbZzXU7sTLlaeVBZA3g48m6dJ8ka2AfHY/jhqT4cjNaxZNmfb+2dmR/A0RKKnXetOzm0WvI8u3fi+dE/x0rda4AVr3XxYz+wE+BHUPgEzNupea6WM5MYFP3+Ctk5+GZZI1Wv3xE8txTgP8DdiW72HQk2f0CDyXlFpE1VHMhSy+5Gbg5Nl4HAwdTvp2wxMX+PSo3y9lFwHMhcJgZ/UocezXV52amvm++29JW3rwGMIyapz98AjjN5f9U36W6AVme4ArgWLKbcKrNJ2uoXhwbdZW2U9MxbxT/70OWb3RnsrwVWQP4uuSpxwOPhiyXqj1ZnuOKGKfegHwEi03M3cVL7d+jH5qxXtzGQDM6kL1HH8YT875AX/ecpWRXz44zy29IKredVcQGyNwQWFbDsUnL8CzQ1ozvVy+wLG99b7Jc/CMty2HvQXbV6mXKfz8/h7I9Ee8Cu5jRPtblr5HVn2rfAR4JoeQPtp8BV8XvbBXZCbBcnZxC1uOzLl7bQFjzUWKkeatw3qxuuM4zoyPlf7x5LxDz2S27uXxIXN6Z7OLHp7FX8xtrccgPkZ1XzIxdgE9DYDbZ+eUAM7rGnp8D4jLi8XQly839MyvPmYHSDfT8nBmfe6A7b/Uk6+18n8rthFImA/0tuzcIst6nahvEbQKFnu6U6nMzU99XjDsCV5vRhSwlYSrxLtQKLgL+BxgfT4TTySrPNcB9ZnwHeI7kimYIzDHjYOBxM06qsJ2a3BcbgcuAH8WGLsBRZvwoxveTXdUFClemDoiLrgDuI2uM+opW7VGyX9JPk3X9/N6MTch+3c4FTq7hGG8kuxo9Jr62uWSN3tuBh814hayraLJ/UggsNOMg4CkzFlbYTin7knVJixACwYzDgP8x4xyy7+50sm7RF8iuAL1GdqL7WQh8YFb6+xkCH5nxz3jV5/EQ8hFfCIGXzPgrMIbsb8hYKAzN9P/IbnAriPVpeAh5z8vlwCiyH9GlvuPVdXLqOnht+8b9iZRS8rwZAvPNuIHshujpwOhabOta4JaY4jOO7EccIfCaGWPJekfeJhtxoiIzTif7sdmT7Lz6WAh8j+y88M14nF8AJ8Z9fGzGRe44L0xSGH8F/CbWtyeAH8XXll50gqzeXW6GxR7WA4CrzPIfxGfHelixnZAKgcVm/AB41Ix5wD/IrjwD/Dfwf2b8mOzHcjn7Av9VaT/StFiWPC7rkhlVZJV299hl1ujFLuz/SlNTRJoDy+6i/3MI7L8O9vUCcKj70S0iNTDjKuDhEHi6oY+lWrzafkcIfK2hj0Xqjma+awAhsIgsB7l3Qx9LbZixPvCgGsXSXMWu3xssTvBRX2L6xRVqFIustospnQbVkPqQjZsuzYiuGIuIiIiIoCvGIiIiIiKAGsYiIiIiIoAaxiIiIiIiwDqY4GN1dO/ePfTr16+hD6NFmT59OvPmzSs3acEa0efYcF599dV5IYQedbW9xvhZLlmycpz+tm3brvX2Fi1aOTZ/VVXVWm+vLjSnz/G112D58tLr2rSBoUPX7fE0hOb0edbGvHnzCo+Xl/kCtGpVvDa3/vrr53GXLl3q/sDWUkv7HJuzSp9lo2oY9+vXj1deeaWhD6NFGT58eJ1vU59jwzGzmiaHWS2N5bP88suVoxpOnz49jwcMGFCidOXnA7RuvXLc/wkTJuTx4MGDC+XM6vQ3Y601p8+x0lu4fDk0gq9XvWtOn2dt3HBDcWLJ+fPn57FvJHfs2LFQ7itf+UoeH3bYKpNZNriW9jk2Z5U+S6VSiIiIiIjQyK4Yi4iUsmzZypnI33vvvTyudMXYD0XprxCnZs2alcfbbrvtmh6iSKOWDs1arjckLeev8K633nqFdb4npk2blc2JNMWp3L7S5T6t6cADD8zjxx9/vOTz0+PzxyCypnTFWEREREQENYxFRERERAA1jEVEREREAOUYi0gT0K5duzy+8cYb8zgd0mnYsGF5XGlEib/97W95fNVVV+Xx17/+9bU6TpHGqlKO8YoVK/I4HUItzSv2Tj311Dz2ecW9evUqlPPDsC1evDiPly5dWijXqVOnPB43blzZ/Xo+r7jS6DMitaUrxiIiIiIiqGEsIiIiIgIolUJEmgA/XNvIkSPzePTo0YVyQ4YMyeMTTzwxjy+88MJCOd+dm07qIdIcpSkSvk5VSpd47LHH8vj3v/99Yd20adPyuFu3bnmcpjH17t07j/3wiGnqg3+eT/1IUzPOPvvsPD7zzDPzWKkTUhd0xVhEREREBDWMRUREREQApVKISBPgu3p79uyZx37WK4DJkyfn8Y9+9KM89qNaAHTt2jWPe/ToUWfHKdJY+ZEnoHz6xFFHHVV4fM899+Rxx44dC+vat2+fxz4NYsGCBYVys2fPLrkvP9MdQFVVVR77NIslS5YUyp177rl5fNlll+Xx1VdfXSh3xBFH5HH6t0Kz5Ek5umIsIiIiIgU9e4JZ6X/u+kSzo4axiIiIiBTMmbNm65o6NYxFRERERFCOsYg0MT4P8f333y+s8zNn+Vnx/KxcUByurUOHDnV9iCJNynPPPZfHDz74YGFd375989gP8Qar5u1WS2e0mz59eh5vvfXWeZzmDs+fPz+P/X0B6T0Cvs76YzrppJMK5fxMmJtvvnlhnR8OrtIsmdLy6IqxiIiIiAhqGIuIiIiIAEqlEJEmxnfF+pm3oPwQVOlyn0rhZ+VKqbtVmot05jvvT3/6Ux6ns8f5dIl0pjpfP/xwcGl984/9zHdpilO5+uaXp8fkt52+xrPOOiuPH3744cI61WcpR1eMRepJSx3qRkREpKlSw1iknrTUoW5ERESaKqVSiEijk3ad+m5Pf0d6OntVua7YjTfeuFDuo48+KrsvkZbAf+//8Y9/5LGfzQ6Koz6k6Qd+G75cmiLh0zN8ysXChQsL5fyIM37bleqoT6vo3LlzYd0LL7yQxxMmTCis23bbbctuU1o2XTEWEREREUENYxERERERQA1jERERERFAOcYi0ghVGkpp6tSpeVxpCCo/q9bnn39eWLfhhhvm8YwZM9boOESasrvvvjuPP/744zxO83R9TnBaHzbYYIM8/uKLL/I4nSHPD/Pm7xHw24ZinfWz3VXKba603D++/PLLC+tuvfXWktsQ0RVjERERERHUMBYRERERAVmGex4AABY/SURBVJRKUaNrrrkmjydOnFh2XSWaPUuk7jz33HN53KdPn8I6PwtW2k3r+Xo4efLkOjw6kabhX//6Vx774dTSNAhv/fXXLzxetGhRyeelM9/5IdW6dOlSdvv+XOnTL9KUqXLnVL8fKL6ukSNHlt2viKcrxiIiIiIiqGEsIiIiIgKoYSwiIiIiAjTiHGOfuwTFqSIrlUtzoMrxuUepRx55JI9nzZqVxxtttFGh3HHHHZfHv/3tb/N40003LZQrl1fsc6hW5/hEWpq33norj3v06JHH6dSznh9KKq2D/vHs2bPr4hBFmpQxY8bksc/hTYc88+fUtB4tXrw4j/3wammub7n6lm6v3Pl76dKlZcv5faXH7v8+pFNdi5SjK8YiIiIiIqhhLCIiIiICNOJUCp+mAHDqqafm8d57753H5VIs1oYfhm2nnXbK47Sb5ytf+Uoe+1mE0pSLww47LI87deqUx2m6hE+tKDezT000HJw0R77b13erpt/3ckNG+S5fKHYdz5w5s86OU6SpmDZtWh77c1F67vHDHqbDprVps7IJUSmlwZfz20iHhktTMMrtt1y5ND3R73fBggUlnyOS0hVjERERERHUMBYRERERARpZKsWKFStYuHAhsGr35kMPPZTHX3zxRR4PHjy4UK5bt2557O9CTWfBevfdd/P4lltuKazr2bNnHnfv3j2PH3744UK5Qw89NI/nz5+fx4899lihnJ9Za7PNNsvj/fffv1Cub9++rK6066hct5dGuZCm7KWXXspj/71Ov/++C7fSnfY+BaNXr155PHXq1EK5zTfffA2PWKRxmzNnTh7781xt0xugWMd8nUpTnPw2/DkqLee358ulM+n5Y6xt+uD06dMLjz/77LM87ty5c622IS2DrhiLiIiIiKCGsYiIiIgIoIaxiIiIiAjQyHKMFy1axMSJE0uuq849Brj99tvzeMiQIYVyfkg1H6e5gxMmTMjjdFadPffcM4/9MFFf//rXC+V8DrPf14EHHlgo9+GHH+bxm2++mccvvvhiodxWW22Vx9tss00eDx8+vFDOz/yV5g4rl1iao0mTJuWxz0NMh1D0QzL53MNKM3H5fMWPPvqoUE45xtJc+bx7f95Iz4e+rqQ5/ZXyij2fL+zzmf39Quljf0zpPUKeP6ZK5VJTpkzJ4x133LHWz5PmT1eMRURERERQw1hEREREBGhkqRRffvllPuzZxx9/XFjnZ7D59NNP8/iBBx4olOvatWse+y5SP+McwK677prHAwcOLKzzXbV+OLh58+YVyvluHz9MXHrsPuWiT58+JWMoDh8zcuTIPB49enTZ7XXp0qWwzg/55mfgGzRoUKFc27ZtEWkq/FBLPn0iTZHwj/3fjLR7uNxz3nrrrcK6nXfeebWPVaQxev/998uu82kQazrraiV+mz7dIa2//pydznZXjn9OmlpV6bW88847eaxUCvF0xVhEREREBDWMRURERESARpZK0apVKzp06AAUR28AOPHEE/O4X79+eZymLSxevDiPfZpBu3btypYbP3582WPq2LFjHvsUBih2z37wwQd5nHbn+Fl1/HN86gQU79b1qRkpf+x+xAuAWbNmlTze3/zmN4VyxxxzDFCcsU+ksfIzVW655ZZ5nM7S5fnuYZ9WAeVniPSj1Yg0J34UhkrSkR1qm9JQiR9hwo/8ko6i5M/T/jgqHZNPx0jPvZVGqZg9e3ZNhy0tlK4Yi4iIiIighrGIiIiICKCGsYiIiIgI0MhyjOfPn89DDz0EQK9evQrrfO6sz83dbLPNCuX8EGg+98g/H2DJkiV5nM7mkx5TNT9MHMB6662Xx35otEo5xl6as7zxxhuXPKZ0qCmfh5XmTvv3xr/mdFaiK664AoA5c+aUPDaRhpTWSZ9X7/MLKw3D5vML0++/r/8+z9HfKyDSnLz99tu1Kpfm4/shz9J65OtipXKeHyo0ree+ztZ2vz5Oy1XKMZ47d27ZddKy6YqxiIiIiAhqGIuIiIiIAI0slWLJkiVMnToVgAEDBhTW+RnoJk6cmMczZ84slCs3XFmlLpV0ne+e9XHaTeO7hHy3TDqrXFVVVR779IuUn1nPH9Pnn39eKOfTO9J1fng53/2czuhVvY1KXdEiDWXGjBll1/l6vXDhwsI6X7/Kdcumj306kh8WTqQ5SYf2LCc9z/l0h3R4tdoqN/NdWi/9vn2cplz4c6xPpUiHb6x0vk2HehWppivGIiIiIiKoYSwiIiIiAjSyVIpWrVrl3aSjRo0qrPNd/r7rM00F+OKLL/LYjwbhZ5UDWLBgQR5XGpXCdx2ld+v6x747Jx2VwvNdOz7tAYpdXf51pDPk+RSJtOvIH5MflcM/B+CCCy4A4Pzzzy97rCINZfLkyWXXVeo69XXPl0vruO/C9XXm/fffX/2DFWkCpk2bVnadrytpusSiRYvyuFJqQiU+fWKTTTbJYz8LHhTPU5VmrvTn/a5du5bdnj/edBsalULK0RVjERERERHUMBYRERERAdQwFhEREREBGlmOcZ8+fbj66qvz2OvWrVse+2HN0hxjn2Po83TToVk6deqUxz4XF4r5Vj4vKR3Wzede+XyoNMfYH2O5bVda5187QJcuXfI4nfnOl91yyy3zeP/996eUP/zhDyWXizSk2ub6pnXXqzQslM9N9nU3Hf5QpLnw500onmN8fUjPc75cWo88vy4t589ts2fPLruvcs9Jz5V+Ftp99903jx999NFCOf/3Ic2PTvORRarpirGIiIiICGoYi4iIiIgAjSyVonXr1vnQKxdffHEDH42INJQ0paG23b6+69SvS2fz8nyXbaXUDJGmLK1TPrXApx327du3UM6nHb700kuFdb17987jJUuW5HGl+lZpnefrr6+jUBxu1fNDt0ExXSJNx6g0TKu0bLpiLCIiIiKCGsYiIiIiIkAjS6UQEYFVR6Xw3b6+izXtDi3XTZt2xfrHfnu+OxiKaRtrOuuXSGOQplJUVVXlsR+1adiwYYVyPgUhnZHWjz5RKUXCl6uUruS3US5Ot+fTJwYOHFgo9/TTT+dxOvttpRExpGXTFWMREREREdQwFhEREREBlEohsopzzjmn7LpLL710HR6JiIiIrEtqGItIo/PZZ58VHrdt2zaPK82+1bp165Ll0hxFn2Oc5h97Pvdy4403rnDEIo1bmo9fLmfezyQHMGnSpLLbrFR3PF///PBvfpg4WLPhEjfccMM8TvOIfY5xeqyV/o5Iy6ZUChERERER1DAWEREREQGUSiEijVA6s1Vth0rz3aM+9ikWlbbnh2cDmD9/fh4rlUKaMp+OBOVnfjv00EMLj8eNG1d2m+VmoUzTFvw6Xy+XLl1aKOef58ulwyh666+/fh7vtddehXWXXHJJHqfpVJ07dy67TWnZdMVYRERERAQ1jEVEREREADWMRUREREQA5RiLSCO0ePHiwuMOHTrksc+NTPMkfS6jH/opza/0Occ+z7F///4Vj0OkqfK5uKmOHTvmcTrk2cKFC/M4zdP19a22Uyz7qanTXGRfnytNCe35XOG0nvu/AenxlcuxFtEVYxERERERdMVYREREpNnQ7K1rRw1jEWl0/vnPfxYe+9myvKqqqrKPfddxOjyb75r1w0KlqRNTpkzJ46FDh9Z02CKNlk9HguKQiJVShnzdSVMVys0gmQ6P6OubT2lIUyT8Y7+9Nm2KTZV27drlsZ8lM50x00uP3c+YJ+IplUJEREREBDWMRUREREQApVKISCN08sknFx77Gaz8KBL+DneA2bNn53G3bt3yOJ3RzqdZ+DSNL774olCua9euq3PYIo3WY489Vng8b968PF60aFHZ502dOrVW2680WoxPV/JpEWkqhU/B8CNK+Oenxo8fn8fnnXde2f2K1JauGIuIiIiIoIaxiIiIiAighrGIiIiICKAcYxFphC688MLC42233TaPX3/99TxOcyMHDhyYx8OGDcvjNHe4ffv2eeyHZDvqqKPW8IhFmpZ0hrtyfD6+HyYNikO5+TjN6fe5vn4blXKRvbScvy9g0KBBZY9dGl5THFNZV4xFRERERFDDWEREREQEAGtMw5mY2VxgRkMfRwvTN4TQoy43qM+xQdXp56nPssHoc2xe9Hk2D/ocm4+yn2WjahiLiIiIiDQUpVKIiIiIiKCGsYiIiIgIsA4axmaca8YkM8abMc6Mnet4+/uY8UgdbWvLeIzV/z4z48y4bpgZo+LyV8zYKS4/PL6+kWZsGJcNMOOuCvsxM541o3N83KjfIzN6mPH3ujwmafzM+DJ+HyeZ8ZoZPzZbNz+mzRhkxotmLDHjp8m6A82YYsZUM85xy/ub8ZIZb5lxtxnrx+WnmTHRjMfcsj3MuKLC/qvMeN6M1mb0M2ORGWPNeMOMl804vr5ee9z/7834an3uQ5onM3qacZcZ08x4PX7vB9b8zFW208WMUyqsPyv+bZhoxp1mtIvLbzXjHXceHRaX18W5sl5em85x4tXrSc6MXYGDgO1DYAiwH/Befe5zdZgVx3EOgSkhMCwEhgE7AF8AD8TV/w1cENf9Kj4G+AmwC/Bn4Oi47DdAcdL2om8Cr4XAZ03hPQqBucBsM3Zv6OORdWpRrA/bAPuTfW/PTwul9aiOfAycDvw+2Vdr4H+BbwBbA0eZsXVc/TvgyhDYAvgE+I+4/HvAEGAs8HUzjKx+XlRh/ycB94dA9QCq00JguxDYCvh/wFlmnJg+qQ7fi6uB8gOAipQQv9sPACNCYEAIbA38Ath4DTbXBUo3jM3oTVY/h4fAYKA1Wb2odnb1uTQExsVla3uurLfXpnOcePV99acXMC8ElgCEwLwQmAVgxnQzLjBjjBkTzBgUl3cw42YzRscrNIfG5f3iL80x8d9u6c7M2DE+Z7MK2znBjHvNeBh4ssKxf43sZFh9x2iA7FcrsAFkrwNYAbQF2gPLzNgTmB0Cb1XY9neBvzWx9+jBeNzSAoXAh8APgFPjVZxVviNmnB2/S+PNuCAu62DGo5ZdcZ5oxpFx+aXxis94s2Ljt3p/ITAaWJas2gmYGgJvh8BS4C7g0HjS/Crw11ju/4BvueetR6yjwLHAYyHwSYWX7OtoemxvAz8maxhgxq/NuN6MJ4E/W3aV+TL3XvxnLNfLjBfiVbSJZuwZy94aH08w46y4jxnAhmb0rHCMIql9gWUhcF31ghAYFwIjY729zH3XqutiRzOeceeZQ+NTLwUGxO/rZSX21Qaoij8G27PynFjO2p4r6/u16RwnmRBCvf2D0BHCOAhvQrgGwt5u3XQIp8X4FAg3xvhiCMfEuEt8bgcI7SG0i8u3gPBKjPeB8AiE3SC8CqFPDds5AcJMCN1qOPabIZzqHm8F4V0I70F4H0LfuHz/uN+HIWwA4QkIXWvY9gwInZrSewShN4QJ9fl90b/G9Q/CghLLPoGwcfodgXAAhOshGIRW8fu2F4TDIdzgnr8BhG4QpkCIo+KELhWO4dcQfuoeH1FdD+LjYyH8EUJ3CFPd8k0hTHRlxkK4DUInCM9AWK/CPteH8IF73K96W25ZFwiL3DG+CqEqPv4BhF/GuC2EVyD0h/ATCOfG5a3jsewA4Sm/XRffAOHwhv4e6F/T+QfhdAhXlll3OISn4ndv43g+6wWhDYTOsUx3CFNjPV7le59s7wwICyDMhXC7W35rrN/jIVwJoW1cvrbnynp9bTrH6V/1v3q9YhwCC8hSEn4AzAXuNuMEV+T++P+rQL8YHwCcY8Y4YATQDuhDdsXnBjMmAPdC3n0KsBVwPXBwCLxbw3YAngqBj8sdt2V5iIfE/VT7IXBWCGwKnAXcFF/jUyGwQwgcTHaF6jFgSzP+asYNZrRnVd1C4PMm9h59CGxS8g2TlsRc7L8jB8R/Y4ExwCBgC2ACsJ8ZvzNjzxD4FPgMWAzcaMa3yVKW1mT/1UKF5YTAX0KWBnEM2ZXePwDfiHX0Sls1b7o7MH81j+OhEKien/oA4LhYr14CNiR7L0YDJ5rxa2Db+DfgbWAzM64240Cy96aa6pzUpT2AO0PgyxCYAzwP7Ej2Xb7YjPHA00BvakhPMKMrcCjQn+w72sGMY+Lq/yKr/zsC3YCfw9qfK9fBa1N9E2Ad3HwXv6gjQuB84FTgcLd6Sfz/S8hz8ww4PKzMT+oTAm+QNUbnAEOB4cD6bjuzyU6027ll5bYDsLCGw/4GMCZWsGrHs7KRei9Zl+7KnWWV+njgGuASshzFVyndNbPcn4ybyHvUDvITv7RAZmxG9j38MC7y3xEDLnHfpc1D4KYQeJPsh98E4BIzfhUCy8nqz31kJ8jVuellJrCpe/wVsi7ceUAXW5njW73cH/8mwI4h8Dfgl8CRZPXra8k+FpF93yvZDvK6Aqu+F6e596J/CDwZAi8AewHvA38x47iQpXMMJfth+iPgRrcd1TlZXZPI6lsppX48QnaO6gHsELJ7aOZQ8/d/P+CdEJgbAsvIzo27AYTA7HjhbQlwC3V3rqzv16b6JkD933y3pRlbuEXDqHmWlyeA02LOIGZ5Q24DsnykFWQ5gq3dc+YD/0b2y3CfGrZTG0cBdybLZgF7x/irsEpe1M+Aq+IfiSqyq1UroOSv4CnAZvG4msp7NBCYWMNxSTNlRg/gOuCPIVBqVqAngJPM6BjL9zZjo9gY/SIEbiO7kW77WGaDEHgMOJPsO19bo4EtLBuBYn2yG34eisf0HHBELHc8q+YIX8TKG33K1tHYWG1tVvoEaka/+FquLnOMTwA/NGO9WH5gzLXuC3wYAjeQ9Thtb0Z3oFUI3BePbXu3HdU5WV3PAm3N+H71AsvuK9kbeAE4Mua19yD7kfYy2XnjwxBYZsa+QN/41M+BTmX28y6wixnt4/nja8Qfimb0iv8b2Q/f9Du8RufKdfDaVN8EoF7uJvc6Aleb0QVYDkwlSxmo5CLgf4DxsWJNJxu14RrgPjO+Q3YCLFzRDIE5ZhwMPG7GSRW2U1H8Nbs/ZDfMON8HropXpBb71xFP/sND4Ndx0eXAKLLG6LdY1aPAPmTvR1N5j/aNxy0tR1VMB1iP7Lv5Fyg9xFkIPGnGVsCLll27WQAcA2wOXGbGCrIb335IdkL6W2x4GllPR4FlN529QnbD6wrLhk3cOmR3p59K1vhsDdwcApPi034O3GXGb8hSOm5y29suHufYuOgmsqvY70F2o2DiSbLu2afj4wFmjCW7qvQ5cHUI3FLmfbuRLO1pTKxXc8n+DuwDnG3Gsvj+HEfWtXuLuyr2X/F414vv3Stl9iGyihAIZhwG/I9lQxkuJvu7fiZZ43FX4DWyxujPQuADM24HHjbjFWAcMDlu6yMz/mnGRODxEDjb7eclM/5Klja1nKy+XR9X3x4bpxa3d3L189bmXLkOXpvOcQJoSugGEX9R/zkE9m/oY6ktM14ADg2V7+QXaRZiQ/rHIXBsA+3/MLIhHCsNZSXSrK3Lc6XOcVJNM981gBCYTXaTXOcaCzcC8df/FfqDIS1FvLL8nFkhHWldakN2NU2kxVpX50qd48TTFWMREREREXTFWEREREQEUMNYRERERARQw1hEREREBFDDWEREREQEUMNYRERERARQw1hEREREBID/D+o5nyHWlWYPAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 864x720 with 30 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot the first X test images, their predicted label, and the true label\n",
+    "# Color correct predictions in blue, incorrect predictions in red\n",
+    "num_rows = 5\n",
+    "num_cols = 3\n",
+    "num_images = num_rows*num_cols\n",
+    "plt.figure(figsize=(2*2*num_cols, 2*num_rows))\n",
+    "for i in range(num_images):\n",
+    "  plt.subplot(num_rows, 2*num_cols, 2*i+1)\n",
+    "  plot_image(i, predictions[i], test_labels, test_images)\n",
+    "  plt.subplot(num_rows, 2*num_cols, 2*i+2)\n",
+    "  plot_value_array(i, predictions[i], test_labels)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "R32zteKHCaXT"
+   },
+   "source": [
+    "Finally, use the trained model to make a prediction about a single image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "yRJ7JU7JCaXT"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(28, 28)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Grab an image from the test dataset\n",
+    "img = test_images[0]\n",
+    "\n",
+    "print(img.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "vz3bVp21CaXV"
+   },
+   "source": [
+    "`tf.keras` models are optimized to make predictions on a *batch*, or collection, of examples at once. So even though we're using a single image, we need to add it to a list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "lDFh5yF_CaXW"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1, 28, 28)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Add the image to a batch where it's the only member.\n",
+    "img = (np.expand_dims(img,0))\n",
+    "\n",
+    "print(img.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "EQ5wLTkcCaXY"
+   },
+   "source": [
+    "Now predict the image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "o_rzNSdrCaXY"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[9.4569641e-09 9.1678389e-09 8.5359018e-09 2.8125953e-11 4.8381224e-08\n",
+      "  1.5418796e-03 7.6329041e-09 2.6696799e-03 5.2743690e-08 9.9578828e-01]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "predictions_single = model.predict(img)\n",
+    "\n",
+    "print(predictions_single)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "6Ai-cpLjO-3A"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAEbCAYAAADkhF5OAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAdMElEQVR4nO3debgcVZ3/8fdJQiTsS4BAWCKQsLuxRhaRBCFE9i0CGhRkDcoyCoMiAUED/tx/oKAgEMRhFAHB0ShugKIYnHEU/angjOuAMoPDPIoLk/P743vaW1wTyL1d3edy8349z33S3bdzT1V11afOVtUp54wkqf/G1F4ASVpRGcCSVIkBLEmVGMCSVIkBLEmVGMCSVMm4obx54sSJecqUKT1aFEkanR544IHHcs7rDX59SAE8ZcoUFi9e3N5SSVKXJk2CRx/tbRkbbACPPDL8/59S+tnSXrcLQtJzWq/Dt5dlGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVIkBLEmVGMCSVMm42gsgqR3nnXdez8tYsGBBz8tYkaSc8/K/OaXfAj/r3eI8zUTgsT6VZdkjo3zLtuzRWvZmOef1Br84pADup5TS4pzzTpa94pRv2Za9IpTdZB+wJFViAEtSJSM5gK+27BWufMu27BWh7L8asX3AkjTajeQasCSNagawJFViAA9DSik903ONHiml1Vb0z3dFX/+OlNKY8m9r22NUBfDSNkzbO09KKeXScZ5SekNKaffc54705jr1+uDo98GXUlqn8Xirfpa9lGWZCiwEXtSn8kbclamD9vc1ellOr/52G1JKawOd9W9tfxhVAZxzzimlmSmlk1JK8zqvtV0GQEppNjAD+EWbf//ZpJTGNJbhcGC7HpbVPPiOTikd2quyShljgH1SSh9IKZ0CnNvLg/7Z5Jx/AvwbcF5K6QW9LCultCawc3m8b0pp216Wt7wan/9JwFUppXE9qNRMA16TUhrf5t9t2Z7E/ngRsLC1llHO+Tn/w8Bsjp2AHwLnAPcDNw1+T0vlbQF8A7iyPB/T5t9fzmXYDbgNWLsPZf0dcB+wzaDXx/SovH8G/gvYpDxfqd/7U3PdgAXALcALeljmNOBc4Hbg/wGr9nOdn2XZ9i7LtVab27j8uyfwKeDbwFHA82qv7zMs85eA3wF7tfU3R0UNOOecU0q7ACcAb885vzvnvAuwTkppYec9w/37SznT/Qr4GPCylNJhOeclZRl63oxK4eXAPcDncs6Pp5RW7mF5WwKvzDlPB35eamdvBsg5L2mpjGaXyvOIHf1e4J0ppXE557+0Uc7yLksOS1JK6wLknM8DfgBc1HZNuLPuOecfA5OBXYB/BP7UZjnDWabyeF1gv7JcU9sqoxwvewIfAq4B/gXYCzh6pNSEl3I8f4D4bI5LKW3dShld5NKIklJ6DXAB8Gng0pzzEyml1YF/AI7LOT8+zL/bbIbPATYAHgT+FdgHmANcl3O+rYXVeNZlaLz2MWDfnPPG5fnYnPP/tllWSmk1IANfAH4NPA6MJw7Gz5RgarO8bYAncs6/Ks8/AYzLOR+ZUtqbqB0t6rbM5VyuecCuRBfTNTnnh1NK84kun3fmnL/TQhnNdZ8LzAS+TATdfxEtuF+nlCYC/9lNJWKYy7QK8CRx45o3AasSrb4HWyrrzcBqOee3lRPvCcChwEeBW3POf26jnGEuW3M7HE7cOfL3Oec7U0rvAjYEzgIOA/6Yc75+WAXVrtZ30RzonDw2A1Ypj2cCXwVmEzvNzsD3gfVbKO9kotvhSOD3wMHAWkQAf4WoJfZsPcvjQ4HjgZ3K8xuImsPY8nxsi2XNI05oY4CtgXcB25bfHQ5c2Hx/C+t5FnA3Ufu9qpS7OnFC/Q7RLbFFn/at15dl2Rh4iKj17Fl+9y5iYK6rpjKwRuPxbsAniDCi7FvvA94AnE/UvFbux7o3lukc4HpgETCdGHi6AHg/LXXFAAeVv79t47UvAu8Fdujn+j7DMr4B+BbwjrIvXldefw9wY9k/hr09qq9glxtnVtk4Hy8bZ7Py2reBW4luggO7LGMMMKnsjOsCry4h0Qm91Usob9LjdT2nBP35ZZ33K69fB/ycFvtjgZOAbwIbL+V384DvAtu3WN5xwD3l8TuIE9y1jd8fAUzp4bbduYTe84DVSshOKgffXUQf8KJGCE/ssrwtgL8HVgbWLvvqYuCljffMLoF3X1uBN4TlOwb4Ynn8APCh8nhb4PLyM36If7NTYdqRGLzelGhNvQN4C9GqmgZ8juhvv6Cf67yMZV65fDZblufjS9acW55vTZeVu6or2OXGeT7RL/fS8mGeUnbi9YADiT7Eo4f5t/+mZleC77ZyII4pr53dq4ODp9dGN6AMKBJNwX+iUQMDPgxs3kKZY8pO96myDdcrgXtNKXdiOTi6Ct/B2xd4QfkMTycGe9YEHiZOquP6sC8dQwzazi7Px5eQXNR4z8PAOymtrRb23bWIWuWWRMXhhrI/bdF43xj6MBjHoJM3cBrwcqJV8vnOvkacoCYzxBNQI3xnAT8G3go8Sgya70gMPn6TqFhsTVRoLqfLFl0L++UqwNc6+0VjHd7TWpn9XMEuN85KwITGjrAxcOOg9/wf4MTy+LVETXjG0gJ1eT6EEgjnEqPi55e/t3353ZHA9yhnxx6u9/PLgbiQaArfSZkVQNTGJ7e10zFQqz++rOtngUuAU4Ery3J02/RulrcmpSle/vYNwKzy/OJyUK7Xw23bnOnwduKkfWR5vikxG2E3YH/ixNPmtl4duJQ4uU0Btiqf8VnA1F7uU8+wfPuXY+s0YpD3U4197e+BDw7lWBr0t7ejdCMRg3qPlu07o/x+PaI1sB9RsWqthTWMz2Y6URtfo2yThymtE6J76naiotJ1F1zfP+RhbpzViBHSXYFXAe8mugMeBN7aeN9bgAsbz48DNh1mmeeUA/IF5fmEsgPeUELwr2Hcw/WeSnQxbEjUQO8Hdiy/ey3Rv/033QTDLOvVJWwPIWom21GmuBH93HfTYm2MmNp2G9GHfSxxQn0TcAXRv/zpttZtOZblNKIP9uPEoNuh5fVTgK8TzfDtuixjaa2qTco+++ESwtPKNjmd/tT8X8JAt8rqRHfH2PJZfAM4D9gBmFs+p22H8Le3IAaoDm68Ng3YHVhcnp8L/BnYpzxfg+j/72pbd7lNzijH9vXEeNIrgAOImU9XEieH5d4Oz1perRUdwgZZq4TDkUQT5aeNA2QqUQv9YPn9dzsf5jDKaZ4BVwU+WXbKjUv57y471eZEf9WGfVj3LYma13SihtCpFV5NnHxa2VFL0NxLDIr8HDi5vD4WeF0pq9tuhx3LdluLmD1yfzngjioH3fHECfaNwB39OAiJls0WRNdVZ87xq8oBeER5vj7d9vM1uoeAM4mxibcRXUsTy+Mryr61JbBRH9Z9HNGy+TKwe3ntfspcX2AbYjbCR4l+0OX+PErQfr8cM98ATmn87kQG5s+/rJS/W+P3fZ3zPWi5pxIn20lE98NMYgB4KtFC2ZaWx3qqrOgQN8oLgZvKRvgAMQA2s3NQlI11BdGEnN1CeVuVfz9XguBW4KKyo7yvjztCp5/5teXAWJto9uxEtAaGvSPw9JPNSsSZfSJxormLga6IyUQrYusu12c2cXKcS5zQjgYWNn7/CuICms07y9TDbTu4n288Ufvdk1LrJE50/wPs30J56wI/Ivo9dyGa9scBlwGfIVo36xIDfe+hDzXfQct2UtnPZxDT66DMuADWKf8ud8unhNQ/Uwa/y7qeCryoPN+T6Ep7P3Gi22Vpn0uf1n9Ms2ziBPjZQe+ZT+nW7Mky9Hulh7mhTicGvyYSTeSFlAE2oh9xg8Z7h/1BErWPTxIDUKsSteop5XeziRPBhB6sXzMQtyG6Hb5ADM6sSfQ/79uDsl5F1PDOJZrazUGnM4ig72p2BVHLeQjYtfHai4gmXvO1a4E9uv0Mh7DuUyh9usSAzwWNz/qAEhLd9vm+smzbfYgm/CLKdEWiRTOf6HKYDKxDl7MrhroNyvM1iC6Y+4ElRBfbl4gpVh8hWkFDGUPZA1jSeP6vRGXmX8pnPJaoQM2nhRNcG9uCMiOjPL4NuL7xnkuBS3q2DDU3wDNsmL856IlBgM4o9YklpBYAv6XMi22h3PWJEfHrgDmN188ianCtz03kbwelxhHN9AuImtnlRF/UVS2Xe3A50DYmTjRfZKDWModoQnY9GESM7L+xPO7UMNckph9dRvQFH08MdPSsz3fQdj6b6Fa5o5Q/oXzmC4GbiS6JrmaVlPD9LgNdGZPL3/1I4z3rElPe/oE+jPgP2gYziP7YDcrzU8t+9rqyT0xhmPOuiZkCPyVaU28rr40nZkCcs6xl6tdPWfeZ5fEZxMnhRqLLZC2i229ROQa/S2kV92RZ+r3yy7FxnldCcAJxDfql5fU5wIJBH/JJtFAzpDGbgKiZHFkOyM6I+LtpseN9GctwGjHrYCHR7bASUSM/hKhB/oLoM+x+5DW6Mb5E6ZtjoJZ9I1Hz/hYtTTUj+ucv6bzGQLNvbaJZ/lFiJkBfBl6IfuYbidklWxN9fp15nS8u+0JXF3wQ3WJfAXYuz1ct/+5J3NxnXuO9fan5Dlq+eUSN9wLgJ5SBamIs4B5Kn3CXZcwAnuLpM01OGBzANX6Ilt8SYp73lWU/2L7shzcQM3JOLsdhV91vz7ostTfGMjbQqcAjRC1l1/LaGKI/dv5S3j+kUGqEQ+ff/wv8B2XwowTdVcQAQk+aSTy9NnIAUePcgjipXErMBOhMu9uULgb9iD7l3Yim8JpEv+PVRI1nh/Ke8SUMprUZCKXMuxiYvTGGgZrwWaW8nt+ApYT/C4km8bUM9HNvVsLo/S2WtTZxItuB6LefX7b1zcRskl8AF/V6nZexbDOJ7qZVgTcTg66/Y6D//fW0NNBU9uuHyuMtiWlnr6ix3s39oPx7GPAHylgE0fJcg5h6t3PflqfmxljKxunUjjYjpno9BKzZ+P36xGWKu3ZRRjP4Nmw8Ph/4WSOE5xFdHK2PSBNXXs1tBOxc4LLyeCViEvzNtNAkJ/quv0OcvO4C/p04229MDC5+kB7WPsuBPp/oStmx8fqcslw9u4KQpU/96lxm/FIG5rg+n6ixttXCSMQ0xkXAL4nW1IlEk38B0e1xLz2c47ysbUCcZDcs+9xd5bWFxHSw1j8LYh7tH4jKVNU+38Zn0wnhw4ma8Msav78JOKxvy1N7gwzeUYhm4NeJ/rG30uiDKcHxBoZ5hdug8s4grii7jahxjyfmPf6yHCQP0qPLX4mulW8TNwmC6BL4FrB34z13NHeMYZazPzFtrbmDXVhCeBvihHZhCYhpPfxsJxNTrb5GXCxzCVEb6stke+JS5pOAF5bnJxM11D0aIdzq7ANi7vp0Bt1ikWji7ttG0C/HMjQrG1vRuJ1oObZOL49PICo8PbmoiOiOOLQfn/XybpdG3hwL/KVsj4NK3vTtQpiRsDFWY6A5uA8xAb956d9FxLSWznzUM2lcfDHMMmcS84cnE31+84GLy++OImorrff9EE3SV5fHexHN0rlEk/WUcnCeUALjO3QxCk/UdJYwMOq+cuN3FxF9fxOIy4DfBEzq8ec8oQTe/BKAvQz8VRqPzyT6NS8karmdOc4nEie96b1c70HLdSTR59zTqyeXUu7ZRJ//54nZHesQFZmriamdd/f68y/LUWPAball0riHd/lclhD9wX25+Oevy9HvDTJoI3SufFm3PJ9eNsTbB73vZGK0eFYLZY4vIXtl47U9icsLh3XV3BDKPqacYI4pz/cuIXw00f97YFmO6yi1tS7Lm11ONJ3t26yJfRV48eDXn+s/ZZ3fR5xcdwVuLq//XTmpXc3A4ONrev2Zl3I2LCeCri9oGUbZ+xL3jYZoeSwqj9chBqMu6/cy9XHdmy2AWeW434qBrr9mTfgAejjbYZnLOAI20vrEBOjDy/O9gD92QqrxvvGNx0OZlzil8fjkshNuS/TBzWr87tP0Z8DtMGJ6Waf74eVEzezY8nwsLV6IUHa8hxm4rLjT5L6dPt9lqw/7Umfq1yHl+YQSxLPLCWccUQN/kFIT7tNyTSjL0Neabyn7JUTr8RKiT7rz+fet5l9hnQf3e59N1PIXEK2emc33DiVP2v6p8iWA5U7zKcc3SfwmpbQ/8MaU0pKc860ppf2AW1JK43PO1wHkxs2Zc9lyy1HOAcD7U0ovIYLoxcTVPj9LKd1A3H1/W6Lfd0tiJkLrOsubUtqeuPrpz8CxKSVyzjemlJaU5VySc/4E0PWN1Rtlf67cXHxxSmmnHN+g8RpiqtQjbZVTW0ppEjHwdWLO+dsppQlEayoR/d1fyDk/lVL6KXEw3tqvZcs5P0lMMeypwTfuL8fZU0T31mNEBSOnlE4E5qaUDgJ+t7zH03PIusBj5TsGNyeuttsrpXQm8aUCX04prQQ8VX3dK5+pNmo8PpQYpOnUhGcQo6cbMYyrsRi4q9Ju5flNwG8YuOn15FLGzcTXovS0NkjsCB8hQmIsUVv7BAPdEbsDm/Ww/FlEd8SpxPS6UdXsZOlTv+4i+j07V3ldSwz+9az/eST8EPfTuIaY57smcTnwvcQVpRcTU/Gq3fCmh+udiBb174GDymvrEDN9biKuyOtMgZxD4wraasvc5w20EfC68ng/ok/uDgYGijpXZ80pz4f1hZPEvQUeJeb0TSuvrVHKunXQe/86L7XNHWEZrx9BTKM7sxHCdwJH9Wn7v5KofY/Wg29ZU78uJS50OZ4K3QB9WPfmoOMeDNxv4nKipr96OSbOLttiVJ6AGOjPPRr4Twau7FxQTkCdb3SZWyojXV1q3sZPX78TLqW0D3FW/ioxKf5SYj7mDsQ3IixMKR1BBNQRwKM5x5dd5uVc0JTSDKJGexHRzF4fuDPnfE/5ivMriLm2r1revzlU5YsknyqPDycGet5bnh9CDIx8P+f8odL98r1cvget11JKq+Sc/9CPsvqtfIfdDsRtHm/POf+pvH498R12t9Rcvl5IKc0m9qfLifGT04DLc3x32XrEdMvtgTNzzj+vt6T9VY6rfyQqdT8kWkSTiVsX7EpUelr5bruu9PkMtQqxs9wC3NF4fS4xG6JTOx727f+Iixw6N0/eirhL2gIGbrm3BjH397oereO+RNfCeUSzf1eiyXdy4z0XEbX/U3qxDP487fPoTP3qy/fJ9XndOoOOB5fnm5R97cON96xLhPMniYpHa19dNVJ+ePrlzsdQLncmKnFPMHCTp5cSM416PvNluZe9TxuoU9Ner/w7i+ifPaPxntcT90ltpVnAwFV1U4l+rwWNYF6d3lzhtj/R33hGCf6PEQN/e5QQOLW87yjiJtzV+6BG6w8Vp371af2Wdb+JPRgB95vo43Z4IdG321n/NwHHN35/GNEdMWIuBGn+9K0LojSVLiNC6jfERRcnAV/KOV9R3jM596ApnlKaSpwZJxJfY/StHpSxDjHSfHDO+Y6U0qaUO13lmNmxO1Hzv5vYaQ7MOf+47eVQKLMg9gF+lHN+qPbytC2ltDYxgHwOcVHNecS88keJk8/ziS82vbDWMvZLSukOYgzgUKKr4Se5zJ4qvz+cmBu+DfCHnPOSCou5VH0J4JTSHsQMgNfmnL+ZUloFyMQAyTnERPEP9HgZtiY+oGtyzr/pURmziebe9JzzEymljwN355yvKr/fmKgRfy/n/O+9WAatGMoUs7OJwbXtiBkf9xL9nQcSlYFDiJrfb2stZ6+U9R+Tc/7f8vwWYoD54fLvD4E/lbd/nQjeJ2ss6zPpVwAfTPRPLSYCqHPrxeuIM/Vvc86L+7AcK+Wc/9LjMmYRl3cuImZ9HJtzfjKlNLazs0hteIZBxxuIG+zclfvVxO2j5qB8s9WcUrqK6Mq8ipiKtiZxEcz5eYQOQLYewOXChh1yzjc3Xtub6JtZhfjiw18S9zx4V875/lYXYARIKc0k5qROynGhyco55z/WXi6NfimlI4nuiKNHaddLM3znETfTeYC4tcAPUkpXEHd1O6i8Z3xuXMQ10oxp84+llKYRAbtq47WxOeevEpcBH5Jz/ijxHVlb0OIVXyNJzvku4tLTr6SU1jd81WsppQ3LlV7zgbmjMXzhaVeVHkL08c8j+n9PTilNzzmfDoxJKX26cSXgiNXapcgppa2Iiwo+lXO+try2Us75LymlycRI9OdTSgcS07Auzjk/0Fb5I02OS4DHA59PKe0UL42+5qBGjN8Rg3EHj9bw7SjjORcDN+WcHyiXl78RmFMqfK9MKW1UjrcRfcy1UgMu3Q43EveZ/e8y4k8J30nE941NLW//FTH/9bZyhhq1cs63A3vluOfFiN4R9NyWc34y5/zZ0Ri+KaUNBr30BHHzrGNLrfdx4mvD/gwcVLr8ft3v5RyOrvuAy3SffyK+2+tOYlbDeOLqs3tTSocSl0p+vNuFlbRiKbXdHxDTyH6Yc/5IeX1l4iZDM4B35JzvK4OSK+ecH6u2wEPUyiBcSmlSzvmR8ngromN8JaI74oHG+8aMpDl4kka2lNImxLdGf4bo832UuMT4Kznn36eUTifu/fDmnPM36y3p8LQ6C6ITsOXCh1cTN5z5Qs75a60VImmFklJ6L2VKJ3Fp+Rzi6+PPJqaZbQTcl3P+RbWFHKZWZ0F0arc5558QX68zDpidUlqrzXIkjX6NMaJzicG0icS3l+9A3Fb0LUQYL3ouhi/0+EKMUhPuBLIkDUkJ4fHEXRQ3J77h47wyiD+NuIjr8ZrL2I2+3o5SkoajjC3dA3ww5/z22svTlla7ICSpF3LOPyK6IsaWe8mMCgawpOeK+4Aday9Em+yCkPScMdq+0cUAlqRK7IKQpEoMYEmqxACWpEoMYEmqxACWpEoMYEmq5P8DG+xHPgtxVAwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_value_array(0, predictions_single[0], test_labels)\n",
+    "plt.xticks(range(10), class_names, rotation=45)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "cU1Y2OAMCaXb"
+   },
+   "source": [
+    "`model.predict` returns a list of lists, one for each image in the batch of data. Grab the predictions for our (only) image in the batch:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "2tRmdq_8CaXb"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "9\n"
+     ]
+    }
+   ],
+   "source": [
+    "prediction_result = np.argmax(predictions_single[0])\n",
+    "print(prediction_result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "YFc2HbEVCaXd"
+   },
+   "source": [
+    "And, as before, the model predicts a label of 9."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "basic_classification.ipynb",
+   "private_outputs": true,
+   "provenance": [],
+   "toc_visible": true,
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
The current implementation of methods `plot_image` and `plot_value_array` works well when the size of  `predictions_array` is greater than `1`. But this implementation gives error while performing prediction on a single image which is not at `0`<sup>th</sup> position in `test_images`.

---
For example, the current implementation of single image prediction uses the first image from the `test_images`,
```python
# Grab an image from the test dataset
img = test_images[0]

print(img.shape)
```
which works well while plotting the value array graph (_the first argument of the `plot_value_array` method is the index of the image being used for the test purpose, which in this case is `0`_),
```python
plot_value_array(0, predictions_single, test_labels)
plt.xticks(range(10), class_names, rotation=45)
plt.show()
```
But, if we use an image other than the first one (let's say the second image from the `test_image`),
```python
# Grab an image from the test dataset
img = test_images[1]

print(img.shape)
```
and try to plot the value array graph using,
```python
plot_value_array(1, predictions_single, test_labels)
plt.xticks(range(10), class_names, rotation=45)
plt.show()
```
it will throw following error:
```python
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-57-358696683377> in <module>
----> 1 plot_value_array(1, predictions_single, test_labels)
      2 plt.xticks(range(10), class_names, rotation=45)
      3 plt.show()

<ipython-input-48-290e8ffd30e7> in plot_value_array(i, predictions_array, true_label)
     19 
     20 def plot_value_array(i, predictions_array, true_label):
---> 21   predictions_array, true_label = predictions_array[i], true_label[i]
     22   plt.grid(False)
     23   plt.xticks([])

IndexError: index 1 is out of bounds for axis 0 with size 1
```
---
In this PR, I update both the methods and also its references to work perfectly even in case of using any test image to perform single image prediction.

Now, if you perform single image prediction (_in this case, the second image from `test_images`_), it will give you the following graph instead of throwing an error.

![image](https://user-images.githubusercontent.com/14276147/62374139-8a547700-b53b-11e9-9753-ecef7264da10.png)

Let me know if further explanation (_or proof_) is required.
Thank you.

Best regards,
Harshil Darji
