### PR TITLE
Fixed minor typo in site/en/guide/autograph.ipynb

### DIFF
--- a/site/en/guide/autograph.ipynb
+++ b/site/en/guide/autograph.ipynb
@@ -205,7 +205,7 @@
         "id": "xpK0m4TCvkJq"
       },
       "source": [
-        "Code written for eager execution can run in a `tf.Graph` with the same results, but with the benfits of graph execution:"
+        "Code written for eager execution can run in a `tf.Graph` with the same results, but with the benefits of graph execution:"
       ]
     },
     {
@@ -403,7 +403,7 @@
       "source": [
         "### Print\n",
         "\n",
-        "Optionally, you may use the Python `print` function in-graph, when combined with the autmoatic control dependency management of `tf.function`:"
+        "Optionally, you may use the Python `print` function in-graph, when combined with the automatic control dependency management of `tf.function`:"
       ]
     },
     {


### PR DESCRIPTION
minor typos are corrected
benfits -> benefits
autmoatic -> automatic