### PR TITLE
Fixed a minor typo in docs/site/en/guide/keras.ipynb

### DIFF
--- a/site/en/guide/keras.ipynb
+++ b/site/en/guide/keras.ipynb
@@ -283,7 +283,7 @@
       },
       "cell_type": "code",
       "source": [
-        "model = tf.keras.Sequential([\n",
+        "model = tf.keras.Sequential()\n",
         "# Adds a densely-connected layer with 64 units to the model:\n",
         "layers.Dense(64, activation='relu', input_shape=(32,)),\n",
         "# Add another:\n",


### PR DESCRIPTION
Fixed a minor typo in code docs/site/en/guide/keras.ipynb line 286:
`tf.keras.Sequential([` should be `tf.keras.Sequential()`