### PR TITLE
Update transformer.ipynb

### DIFF
--- a/site/en/r2/tutorials/text/transformer.ipynb
+++ b/site/en/r2/tutorials/text/transformer.ipynb
@@ -146,6 +146,7 @@
         "!pip install tensorflow-gpu==2.0.0-beta1\n",
         "import tensorflow_datasets as tfds\n",
         "import tensorflow as tf\n",
+        "tf.enable_eager_execution()\n"
         "\n",
         "import time\n",
         "import numpy as np\n",


### PR DESCRIPTION
This error is coming as eager mode is needed to use numpy with tensor data
`Tensor' object has no attribute 'numpy'`
so to solve this error we need to execute this below line 
tf.enable_eager_execution()