### PR TITLE
Fix typo in site/en/r2/guide/keras/rnn.ipynb 

### DIFF
--- a/site/en/r2/guide/keras/rnn.ipynb
+++ b/site/en/r2/guide/keras/rnn.ipynb
@@ -256,7 +256,7 @@
         "id": "1HagyjYos5rD"
       },
       "source": [
-        "In addition, a RNN layer can return its final internal state(s). The returned states can be used resume the RNN execution later, or [to initialize another RNN](https://arxiv.org/abs/1409.3215). This setting is commonly used in the encoder-decoder sequence-to-sequence model, where the encoder final state is used as the initial state of the decoder.\n",
+        "In addition, a RNN layer can return its final internal state(s). The returned states can be used to resume the RNN execution later, or [to initialize another RNN](https://arxiv.org/abs/1409.3215). This setting is commonly used in the encoder-decoder sequence-to-sequence model, where the encoder final state is used as the initial state of the decoder.\n",
         "\n",
         "To configure a RNN layer to return its internal state, set the `return_state` parameter to `True` when creating the layer. Note that `LSTM` has 2 state  tensors, but `GRU` only has one.\n",
         "\n",


### PR DESCRIPTION
"The returned states can be used resume the RNN execution" -> "The returned states can be used **to** resume the RNN execution"