### PR TITLE
Mention Bazel version dependency

### DIFF
--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -55,6 +55,8 @@ the build tool used to compile TensorFlow.
 
 Add the location of the Bazel executable to your `PATH` environment variable.
 
+Note: Make sure your Bazel version matches the minimum/maximum version as specified by `_TF_MIN_BAZEL_VERSION` and `_TF_MAX_BAZEL_VERSION` in `tensorflow/configure.py`.
+
 ### Install GPU support (optional, Linux only)
 
 There is *no* GPU support for macOS.

--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -55,8 +55,7 @@ the build tool used to compile TensorFlow.
 
 Add the location of the Bazel executable to your `PATH` environment variable.
 
-Note: Make sure your Bazel version matches the minimum/maximum version as specified by `_TF_MIN_BAZEL_VERSION` and `_TF_MAX_BAZEL_VERSION` in <a href="https://github.com/tensorflow/tensorflow/blob/master/configure.py" class="external"><code>
-  `tensorflow/configure.py`</code></a>.
+Note: Make sure your Bazel version matches the minimum/maximum version as specified by `_TF_MIN_BAZEL_VERSION` and `_TF_MAX_BAZEL_VERSION` in <a href="https://github.com/tensorflow/tensorflow/blob/master/configure.py" class="external"><code>tensorflow/configure.py</code></a>.
 
 ### Install GPU support (optional, Linux only)
 

--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -55,7 +55,8 @@ the build tool used to compile TensorFlow.
 
 Add the location of the Bazel executable to your `PATH` environment variable.
 
-Note: Make sure your Bazel version matches the minimum/maximum version as specified by `_TF_MIN_BAZEL_VERSION` and `_TF_MAX_BAZEL_VERSION` in `tensorflow/configure.py`.
+Note: Make sure your Bazel version matches the minimum/maximum version as specified by `_TF_MIN_BAZEL_VERSION` and `_TF_MAX_BAZEL_VERSION` in <a href="https://github.com/tensorflow/tensorflow/blob/master/configure.py" class="external"><code>
+  `tensorflow/configure.py`</code></a>.
 
 ### Install GPU support (optional, Linux only)
 

--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -55,7 +55,9 @@ the build tool used to compile TensorFlow.
 
 Add the location of the Bazel executable to your `PATH` environment variable.
 
-Note: Make sure your Bazel version matches the minimum/maximum version as specified by `_TF_MIN_BAZEL_VERSION` and `_TF_MAX_BAZEL_VERSION` in <a href="https://github.com/tensorflow/tensorflow/blob/master/configure.py" class="external"><code>tensorflow/configure.py</code></a>.
+Note: To build TensorFlow, the Bazel version must conform to the minimum and maximum
+versions specified by `_TF_MIN_BAZEL_VERSION` and `_TF_MAX_BAZEL_VERSION` in
+[`tensorflow/configure.py`](https://github.com/tensorflow/tensorflow/blob/master/configure.py).
 
 ### Install GPU support (optional, Linux only)
 


### PR DESCRIPTION
Some struggle with choosing the correct version of Bazel for building TF from scratch (see, e.g., https://github.com/tensorflow/tensorflow/issues/24101 ). This patch mentions such a dependency explicitly.