### PR TITLE
pix2pix: Always same test_dataset picture 

### DIFF
--- a/site/en/r2/tutorials/generative/pix2pix.ipynb
+++ b/site/en/r2/tutorials/generative/pix2pix.ipynb
@@ -403,10 +403,10 @@
         "# shuffling so that for every epoch a different image is generated\n",
         "# to predict and display the progress of our model.\n",
         "test_dataset = test_dataset.shuffle(BUFFER_SIZE)\n",
-		  "test_dataset = test_dataset.repeat()\n",
+        "test_dataset = test_dataset.repeat()\n",
         "test_dataset = test_dataset.map(load_image_test)\n",
         "test_dataset = test_dataset.batch(1)\n",
-		  "test_iterator = iter(test_dataset)"
+        "test_iterator = iter(test_dataset)"
       ]
     },
     {

--- a/site/en/r2/tutorials/generative/pix2pix.ipynb
+++ b/site/en/r2/tutorials/generative/pix2pix.ipynb
@@ -402,7 +402,7 @@
         "test_dataset = tf.data.Dataset.list_files(PATH+'test/*.jpg')\n",
         "# shuffling so that for every epoch a different image is generated\n",
         "# to predict and display the progress of our model.\n",
-        "train_dataset = train_dataset.shuffle(BUFFER_SIZE)\n",
+        "test_dataset = test_dataset.shuffle(BUFFER_SIZE)\n",
         "test_dataset = test_dataset.map(load_image_test)\n",
         "test_dataset = test_dataset.batch(1)"
       ]

--- a/site/en/r2/tutorials/generative/pix2pix.ipynb
+++ b/site/en/r2/tutorials/generative/pix2pix.ipynb
@@ -403,8 +403,10 @@
         "# shuffling so that for every epoch a different image is generated\n",
         "# to predict and display the progress of our model.\n",
         "test_dataset = test_dataset.shuffle(BUFFER_SIZE)\n",
+		  "test_dataset = test_dataset.repeat()\n",
         "test_dataset = test_dataset.map(load_image_test)\n",
-        "test_dataset = test_dataset.batch(1)"
+        "test_dataset = test_dataset.batch(1)\n",
+		  "test_iterator = iter(test_dataset)"
       ]
     },
     {
@@ -939,8 +941,8 @@
         "      train_step(input_image, target)\n",
         "\n",
         "    clear_output(wait=True)\n",
-        "    for inp, tar in test_dataset.take(1):\n",
-        "      generate_images(generator, inp, tar)\n",
+        "    inp, tar = test_iterator.next()\n",
+        "    generate_images(generator, inp, tar)\n",
         "\n",
         "    # saving (checkpoint) the model every 20 epochs\n",
         "    if (epoch + 1) % 20 == 0:\n",


### PR DESCRIPTION
- The shuffle operation had been applied on the train_dataset for a second time.
- The .take(1) operation will always return the same element, as it does not iterate the dataset

I fixed the dataset shuffle operation and replaced the .take(1) problem by defining an iterator. In order for the iterator to work for more than 107 epochs I defined a repeat operation.