### PR TITLE
Change model.fit to model.fit_generator

### DIFF
--- a/site/en/r2/tutorials/images/hub_with_keras.ipynb
+++ b/site/en/r2/tutorials/images/hub_with_keras.ipynb
@@ -700,7 +700,7 @@
         "id": "58-BLV7dupJA"
       },
       "source": [
-        "Now use the `.fit` method to train the model.\n",
+        "Now use the `.fit_generator` method to train the model.\n",
         "\n",
         "To keep this example short train just 2 epochs. To visualize the training progress, use a custom callback to log the loss and accuracy of each batch individually, instead of the epoch average."
       ]
@@ -740,7 +740,7 @@
         "\n",
         "batch_stats_callback = CollectBatchStats()\n",
         "\n",
-        "history = model.fit(image_data, epochs=2,\n",
+        "history = model.fit_generator(image_data, epochs=2,\n",
         "                    steps_per_epoch=steps_per_epoch,\n",
         "                    callbacks = [batch_stats_callback])"
       ]


### PR DESCRIPTION
Running the current TensorFlow Hub with Keras (TF 2.0) tutorial fails when running `model.fit` with this error:
```
InvalidArgumentError: ValueError: `generator` yielded an element of shape (22, 224, 224, 3) where an element of shape (32, 224, 224, 3) was expected.
Traceback (most recent call last):

  File "/tensorflow-2.0.0-rc0/python3.6/tensorflow_core/python/ops/script_ops.py", line 221, in __call__
    ret = func(*args)

  File "/tensorflow-2.0.0-rc0/python3.6/tensorflow_core/python/data/ops/dataset_ops.py", line 621, in generator_py_func
    "of shape %s was expected." % (ret_array.shape, expected_shape))

ValueError: `generator` yielded an element of shape (22, 224, 224, 3) where an element of shape (32, 224, 224, 3) was expected.


	 [[{{node PyFunc}}]] [Op:IteratorGetNextSync]
```
The Colab notebook runs successfully using `model.fit_generator` instead.