### PR TITLE
take(5) should be called only once

### DIFF
--- a/site/en/guide/migrate.ipynb
+++ b/site/en/guide/migrate.ipynb
@@ -896,8 +896,8 @@
       },
       "outputs": [],
       "source": [
-        "train_data = mnist_train.map(scale).shuffle(BUFFER_SIZE).batch(BATCH_SIZE).take(5)\n",
-        "test_data = mnist_test.map(scale).batch(BATCH_SIZE).take(5)\n",
+        "train_data = mnist_train.map(scale).shuffle(BUFFER_SIZE).batch(BATCH_SIZE)\n",
+        "test_data = mnist_test.map(scale).batch(BATCH_SIZE)\n",
         "\n",
         "STEPS_PER_EPOCH = 5\n",
         "\n",


### PR DESCRIPTION
I think the intention here is to only call .take() once after .batch()