### PR TITLE
Updated typo

### DIFF
--- a/site/en/tutorials/keras/basic_classification.ipynb
+++ b/site/en/tutorials/keras/basic_classification.ipynb
@@ -987,7 +987,7 @@
         "colab_type": "text"
       },
       "source": [
-        "And the model predicts a label of 2."
+        "And the model predicts a label as expected."
       ]
     }
   ]


### PR DESCRIPTION
When we change input `test_images` from the currently selected image to other in the [tutorial](https://www.tensorflow.org/tutorials/keras/basic_classification), then the prediction will change and reports correctly. But, the static text at the end of the tutorial `And the model predicts a label of 2.` will not change.

So I changed the static text from `And the model predicts a label of 2.` to `And the model predicts a label as expected.` 
Thanks