### PR TITLE
Updated typo

### DIFF
--- a/site/en/tutorials/keras/classification.ipynb
+++ b/site/en/tutorials/keras/classification.ipynb
@@ -1006,7 +1006,7 @@
         "id": "YFc2HbEVCaXd"
       },
       "source": [
-        "And the model predicts a label of 2."
+        "And the model predicts a label as expected."
       ]
     }
   ]


### PR DESCRIPTION
When we change input test_images from the currently selected image to other in the tutorial, then the prediction will change and reports correctly. But, the static text at the end of the tutorial And the model predicts a label of 2. will not change.

So I changed the static text from And the model predicts a label of 2. to And the model predicts a label as expected.
Thanks