### PR TITLE
fix typo of batch size csv.ipynb

### DIFF
--- a/site/en/tutorials/load_data/csv.ipynb
+++ b/site/en/tutorials/load_data/csv.ipynb
@@ -274,7 +274,7 @@
         "id": "vHUQFKoQI6G7"
       },
       "source": [
-        "Each item in the dataset is a batch, represented as a tuple of (*many examples*, *many labels*). The data from the examples is organized in column-based tensors (rather than row-based tensors), each with as many elements as the batch size (12 in this case).\n",
+        "Each item in the dataset is a batch, represented as a tuple of (*many examples*, *many labels*). The data from the examples is organized in column-based tensors (rather than row-based tensors), each with as many elements as the batch size (5 in this case).\n",
         "\n",
         "It might help to see this yourself."
       ]


### PR DESCRIPTION
fix typo. batch size is 5 rather than 12 in this example.