### PR TITLE
Small typo fixes for into_to_cnns.ipynb

### DIFF
--- a/site/en/tutorials/images/cnn.ipynb
+++ b/site/en/tutorials/images/cnn.ipynb
@@ -231,7 +231,7 @@
         "id": "lvDVFkg-2DPm"
       },
       "source": [
-        "Let display the architecture of our model so far."
+        "Let's display the architecture of our model so far."
       ]
     },
     {
@@ -394,11 +394,7 @@
         "id": "8cfJ8AR03gT5"
       },
       "source": [
-        "### Next Steps\n",
-        "\n",
-        "As you can see, our simple CNN has achieved a test accuracy of about 70%. Not bad for a few lines of code!\n",
-        "\n",
-        "The architecture used here has not been optimized in any way. As a next step you could experiment with different designs for your CNN, or you could experiment writing a CNN using the Keras Subclassing API and a GradidentTape. You can find an example of that [here](https://github.com/tensorflow/docs/blob/master/site/en/tutorials/quickstart/advanced.ipynb)."
+        "Our simple CNN has achieved a test accuracy of over 99%. Not bad for a few lines of code! For another CNN style, see an example using the Keras subclassing API and a `tf.GradientTape` [here](https://github.com/tensorflow/docs/blob/r2.0rc/site/en/r2/tutorials/quickstart/advanced.ipynb)."
       ]
     }
   ],

--- a/site/en/tutorials/images/cnn.ipynb
+++ b/site/en/tutorials/images/cnn.ipynb
@@ -394,7 +394,7 @@
         "id": "8cfJ8AR03gT5"
       },
       "source": [
-        "Our simple CNN has achieved a test accuracy of over 99%. Not bad for a few lines of code! For another CNN style, see an example using the Keras subclassing API and a `tf.GradientTape` [here](https://github.com/tensorflow/docs/blob/r2.0rc/site/en/r2/tutorials/quickstart/advanced.ipynb)."
+        "Our simple CNN has achieved a test accuracy of over 99%. Not bad for a few lines of code! For another CNN style, see an example using the Keras subclassing API and a `tf.GradientTape` [here](https://www.tensorflow.org/tutorials/quickstart/advanced)."
       ]
     }
   ],


### PR DESCRIPTION
Here's the page in question: https://www.tensorflow.org/beta/tutorials/images/intro_to_cnns

It's a fantastically written article, but I found a small typo under the "Create a convolutional base" heading. Additionally, I removed "As you can see" from the final paragraph, given that the same phrase was used at the start of the previous paragraph. As you're reading through the page it can seem a bit clumsy.