### PR TITLE
Fix bug: call tf.random.set_random_seed instead of tf.random.set_seed

### DIFF
--- a/site/en/r2/tutorials/text/time_series.ipynb
+++ b/site/en/r2/tutorials/text/time_series.ipynb
@@ -254,7 +254,7 @@
       },
       "outputs": [],
       "source": [
-        "tf.random.set_seed(13)"
+        "tf.random.set_random_seed(13)"
       ]
     },
     {


### PR DESCRIPTION
tf.random.set_seed(13) produces 

AttributeError: module 'tensorflow._api.v1.random' has no attribute 'set_seed'

In new versions of Tensorflow this is renamed to

tf.random.set_random_seed(13)