### PR TITLE
Fix wording in Load images tutorial

### DIFF
--- a/site/en/tutorials/load_data/images.ipynb
+++ b/site/en/tutorials/load_data/images.ipynb
@@ -177,7 +177,7 @@
       "source": [
         "### Retrieve the images\n",
         "\n",
-        "Before you start any training, you will need a set of images to teach the network about the new classes you want to recognize. You have already created an archive of creative-commons licensed flower photos to use initially:\n",
+        "Before you start any training, you will need a set of images to teach the network about the new classes you want to recognize. You can use an archive of creative-commons licensed flower photos from Google.\n",
         "\n",
         "Note: all images are licensed CC-BY, creators are listed in the `LICENSE.txt` file."
       ]


### PR DESCRIPTION
The user did not create this archive. Therefore, saying "You have already created" is incorrect.