### PR TITLE
multi_worker_with_estimator.ipynb: Remove softmax to get logits

### DIFF
--- a/site/en/tutorials/distribute/multi_worker_with_estimator.ipynb
+++ b/site/en/tutorials/distribute/multi_worker_with_estimator.ipynb
@@ -234,7 +234,7 @@
         "      tf.keras.layers.MaxPooling2D(),\n",
         "      tf.keras.layers.Flatten(),\n",
         "      tf.keras.layers.Dense(64, activation='relu'),\n",
-        "      tf.keras.layers.Dense(10, activation='softmax')\n",
+        "      tf.keras.layers.Dense(10)\n",
         "  ])\n",
         "  logits = model(features, training=False)\n",
         "\n",


### PR DESCRIPTION
The rest of the `model_fn` assumes that the output from the model is logits,
so remove the softmax activation function from the last layer. Training did
not converge in my testing because the loss calculation assumed the inputs
were logits (`from_logits=True`) when they in fact were the output of a softmax.