### PR TITLE
Fix FGSM tutorial

### DIFF
--- a/site/en/tutorials/generative/adversarial_fgsm.ipynb
+++ b/site/en/tutorials/generative/adversarial_fgsm.ipynb
@@ -289,7 +289,7 @@
       "source": [
         "# Get the input label of the image.\n",
         "label = np.zeros(image_probs.shape)\n",
-        "label[0][np.argmax(image_probs)] = 1\n",
+        "label[0][208] = 1\n",
         "\n",
         "perturbations = create_adversarial_pattern(image, label)\n",
         "plt.imshow(perturbations[0])"

--- a/site/en/tutorials/generative/adversarial_fgsm.ipynb
+++ b/site/en/tutorials/generative/adversarial_fgsm.ipynb
@@ -116,7 +116,6 @@
         "import tensorflow as tf\n",
         "import matplotlib as mpl\n",
         "import matplotlib.pyplot as plt\n",
-        "import numpy as np\n",
         "\n",
         "mpl.rcParams['figure.figsize'] = (8, 8)\n",
         "mpl.rcParams['axes.grid'] = False"
@@ -288,8 +287,8 @@
       "outputs": [],
       "source": [
         "# Get the input label of the image.\n",
-        "label = np.zeros(image_probs.shape)\n",
-        "label[0][208] = 1\n",
+        "labrador_retriever_index = 208\n",
+        "label = tf.one_hot(labrador_retriever_index, image_probs.shape[-1])\n",
         "\n",
         "perturbations = create_adversarial_pattern(image, label)\n",
         "plt.imshow(perturbations[0])"

--- a/site/en/tutorials/generative/adversarial_fgsm.ipynb
+++ b/site/en/tutorials/generative/adversarial_fgsm.ipynb
@@ -116,6 +116,7 @@
         "import tensorflow as tf\n",
         "import matplotlib as mpl\n",
         "import matplotlib.pyplot as plt\n",
+        "import numpy as np\n",
         "\n",
         "mpl.rcParams['figure.figsize'] = (8, 8)\n",
         "mpl.rcParams['axes.grid'] = False"
@@ -286,7 +287,11 @@
       },
       "outputs": [],
       "source": [
-        "perturbations = create_adversarial_pattern(image, image_probs)\n",
+        "# Get the input label of the image.\n",
+        "label = np.zeros(image_probs.shape)\n",
+        "label[0][np.argmax(image_probs)] = 1\n",
+        "\n",
+        "perturbations = create_adversarial_pattern(image, label)\n",
         "plt.imshow(perturbations[0])"
       ]
     },


### PR DESCRIPTION
## Overview
This PR will fix https://github.com/tensorflow/tensorflow/issues/32715.

## Page concerned
https://www.tensorflow.org/beta/tutorials/generative/adversarial_fgsm

## Description
The implementaion of FGSM in the doc is incorrect, because the `create_adversarial_pattern` function, which must take the image and the label of the image, takes the image and the predicted probability of the image.
Thus, by this PR, the `create_adversarial_pattern` function is going to take `label` instead of `image_probs` (`== model.predict(image)`), where the `label` is the one-hot vector of the label of the image.