### PR TITLE
Fix normalize in segmentation.ipynb

### DIFF
--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -192,7 +192,7 @@
       "outputs": [],
       "source": [
         "def normalize(input_image, input_mask):\n",
-        "  input_image = tf.cast(input_image, tf.float32)/128.0 - 1\n",
+        "  input_image = tf.cast(input_image, tf.float32) / 255.0\n",
         "  input_mask -= 1\n",
         "  return input_image, input_mask"
       ]


### PR DESCRIPTION
Text says "image is normalized to [0, 1]", but it is
normalized to have the range [-1, 1].
Divide images by 255.0 like other tutorials.