### PR TITLE
Revise tf.summary section to eager.ipynb with tf.compat.v2.summary

### DIFF
--- a/site/en/guide/eager.ipynb
+++ b/site/en/guide/eager.ipynb
@@ -935,7 +935,8 @@
         "understanding, debugging and optimizing the model training process. It uses\n",
         "summary events that are written while executing the program.\n",
         "\n",
-        "You can use `tf.summary` of Tensorflow 2.x (`tf.compat.v2.summary` in Tensorflow 1.x) to record summaries of variable in eager execution. For example, to record summaries of `loss` once every 100 global steps:"
+        "You can use `tf.summary` to record summaries of variable in eager execution.\n",
+        "For example, to record summaries of `loss` once every 100 training steps:"
       ]
     },
     {
@@ -946,13 +947,8 @@
         "colab": {}
       },
       "source": [
-        "if tf.version.VERSION.startswith('2.'):\n",
-        "  tf_summary = tf.summary\n",
-        "else:\n",
-        "  tf_summary = tf.compat.v2.summary\n",
-        "\n",
         "logdir = \"./tb/\"\n",
-        "writer = tf_summary.create_file_writer(logdir)\n",
+        "writer = tf.summary.create_file_writer(logdir)\n",
         "\n",
         "with writer.as_default():  # or call writer.set_as_default() before the loop.\n",
         "  for i in range(1000):\n",
@@ -960,7 +956,7 @@
         "    # Calculate loss with your real train function.\n",
         "    loss = 1 - 0.001 * step\n",
         "    if step % 100 == 0:\n",
-        "      tf_summary.scalar('loss', loss, step=step)"
+        "      tf.summary.scalar('loss', loss, step=step)"
       ],
       "execution_count": 0,
       "outputs": []

--- a/site/en/guide/eager.ipynb
+++ b/site/en/guide/eager.ipynb
@@ -953,7 +953,6 @@
         "\n",
         "logdir = \"./tb/\"\n",
         "writer = tf_summary.create_file_writer(logdir)\n",
-        "writer.set_as_default()  # or Run code under `with writer.as_default():`\n",
         "\n",
         "with writer.as_default():  # or call writer.set_as_default() before the loop.\n",
         "  for i in range(1000):\n",

--- a/site/en/guide/eager.ipynb
+++ b/site/en/guide/eager.ipynb
@@ -145,6 +145,11 @@
         "  pass\n",
         "import tensorflow as tf\n",
         "\n",
+        "if tf.version.VERSION.startswith('1.'):\n",
+        "  # In Tensorflow 1.x, call enable_eager_execution() or enable_v2_behavior()\n",
+        "  # to enable eager execution.\n",
+        "  tf.enable_v2_behavior()\n",
+        "\n",
         "import cProfile"
       ],
       "execution_count": 0,
@@ -913,6 +918,63 @@
         "m.result()  # => 2.5\n",
         "m([8, 9])\n",
         "m.result()  # => 5.5"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "aB8qWtT955pI"
+      },
+      "source": [
+        "### Summaries and TensorBoard\n",
+        "\n",
+        "[TensorBoard](../guide/summaries_and_tensorboard.md) is a visualization tool for\n",
+        "understanding, debugging and optimizing the model training process. It uses\n",
+        "summary events that are written while executing the program.\n",
+        "\n",
+        "You can use `tf.summary` of Tensorflow 2.x (`tf.compat.v2.summary` in Tensorflow 1.x) to record summaries of variable in eager execution. For example, to record summaries of `loss` once every 100 global steps:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "z6VInqhA6RH4",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "if tf.version.VERSION.startswith('2.'):\n",
+        "  tf_summary = tf.summary\n",
+        "else:\n",
+        "  tf_summary = tf.compat.v2.summary\n",
+        "\n",
+        "logdir = \"./tb/\"\n",
+        "writer = tf_summary.create_file_writer(logdir)\n",
+        "writer.set_as_default()  # or Run code under `with writer.as_default():`\n",
+        "\n",
+        "with writer.as_default():  # or call writer.set_as_default() before the loop.\n",
+        "  for i in range(1000):\n",
+        "    step = i + 1\n",
+        "    # Calculate loss with your real train function.\n",
+        "    loss = 1 - 0.001 * step\n",
+        "    if step % 100 == 0:\n",
+        "      tf_summary.scalar('loss', loss, step=step)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "08QQD2j36TaI",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!ls -lh tb/"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
This pull request revives "Summaries and TensorBoard" section to https://www.tensorflow.org/guide/eager with `tf.compat.v2.summary`.

See https://github.com/tensorflow/tensorflow/issues/32588 for the background.
