### PR TITLE
Update text_generation.ipynb

### DIFF
--- a/site/en/tutorials/text/text_generation.ipynb
+++ b/site/en/tutorials/text/text_generation.ipynb
@@ -379,7 +379,7 @@
       "source": [
         "# The maximum length sentence we want for a single input in characters\n",
         "seq_length = 100\n",
-        "examples_per_epoch = len(text)//seq_length\n",
+        "examples_per_epoch = len(text)//(seq_length+1)\n",
         "\n",
         "# Create training examples / targets\n",
         "char_dataset = tf.data.Dataset.from_tensor_slices(text_as_int)\n",


### PR DESCRIPTION
We must divide by (seq_length+1) since char_dataset is broken into sequences of length (seq_length+1) not of length seq_length.