### PR TITLE
Fix issues in text_classification keras tutorial

### DIFF
--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -154,7 +154,8 @@
         "  %tensorflow_version 2.x\n",
         "except Exception:\n",
         "  pass\n",
-        "import tensorflow as tf"
+        "import tensorflow as tf",
+        "tf.enable_eager_execution()"
       ]
     },
     {

--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -154,7 +154,7 @@
         "  %tensorflow_version 2.x\n",
         "except Exception:\n",
         "  pass\n",
-        "import tensorflow as tf",
+        "import tensorflow as tf\n",
         "tf.enable_eager_execution()"
       ]
     },
@@ -395,11 +395,11 @@
         "train_batches = (\n",
         "    train_data\n",
         "    .shuffle(BUFFER_SIZE)\n",
-        "    .padded_batch(32, train_data.output_shapes))\n",
+        "    .padded_batch(32, tf.compat.v1.data.get_output_shapes(train_data)))\n",
         "\n",
         "test_batches = (\n",
         "    test_data\n",
-        "    .padded_batch(32, train_data.output_shapes))"
+        "    .padded_batch(32, tf.compat.v1.data.get_output_shapes(train_data)))\n"
       ]
     },
     {


### PR DESCRIPTION
- `  print('Label:', train_label.numpy())` was causing `AttributeError: 'Tensor' object has no attribute 'numpy'`, setting `tf.enable_eager_execution()` fixes this.

- `train_data.output_shapes` was causing deprecation warning:
```
WARNING:tensorflow:From <ipython-input-13-5710cd302ddc>:6: DatasetV1.output_shapes (from tensorflow.python.data.ops.dataset_ops) is deprecated and will be removed in a future version.
Instructions for updating:
Use `tf.compat.v1.data.get_output_shapes(dataset)`.
```
I've updated uses of `output_shapes` as suggested by the warning.