### PR TITLE
Fix: Ubuntu Sanity Check: Internal CI build failed

### DIFF
--- a/site/en/tutorials/images/cnn.ipynb
+++ b/site/en/tutorials/images/cnn.ipynb
@@ -178,7 +178,7 @@
         "    plt.grid(False)\n",
         "    plt.imshow(train_images[i], cmap=plt.cm.binary)\n",
         "    # The CIFAR labels happen to be arrays, \n",
-        "    # which is why we need the extra index\n",
+        "    # which is why you need the extra index\n",
         "    plt.xlabel(class_names[train_labels[i][0]])\n",
         "plt.show()"
       ]
@@ -202,7 +202,7 @@
       "source": [
         "The 6 lines of code below define the convolutional base using a common pattern: a stack of [Conv2D](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Conv2D) and [MaxPooling2D](https://www.tensorflow.org/api_docs/python/tf/keras/layers/MaxPool2D) layers.\n",
         "\n",
-        "As input, a CNN takes tensors of shape (image_height, image_width, color_channels), ignoring the batch size. If you are new to these dimensions, color_channels refers to (R,G,B). In this example, we will configure our CNN to process inputs of shape (32, 32, 3), which is the format of CIFAR images. We do this by passing the argument `input_shape` to our first layer.\n",
+        "As input, a CNN takes tensors of shape (image_height, image_width, color_channels), ignoring the batch size. If you are new to these dimensions, color_channels refers to (R,G,B). In this example, you will configure our CNN to process inputs of shape (32, 32, 3), which is the format of CIFAR images. You can do this by passing the argument `input_shape` to our first layer.\n",
         "\n"
       ]
     },
@@ -254,7 +254,7 @@
         "id": "_j-AXYeZ2GO5"
       },
       "source": [
-        "Above, you can see that the output of every Conv2D and MaxPooling2D layer is a 3D tensor of shape (height, width, channels). The width and height dimensions tend to shrink as we go deeper in the network. The number of output channels for each Conv2D layer is controlled by the first argument (e.g., 32 or 64). Typically,  as the width and height shrink, we can afford (computationally) to add more output channels in each Conv2D layer."
+        "Above, you can see that the output of every Conv2D and MaxPooling2D layer is a 3D tensor of shape (height, width, channels). The width and height dimensions tend to shrink as you go deeper in the network. The number of output channels for each Conv2D layer is controlled by the first argument (e.g., 32 or 64). Typically,  as the width and height shrink, you can afford (computationally) to add more output channels in each Conv2D layer."
       ]
     },
     {
@@ -265,7 +265,7 @@
       },
       "source": [
         "### Add Dense layers on top\n",
-        "To complete our model, we will feed the last output tensor from the convolutional base (of shape (3, 3, 64)) into one or more Dense layers to perform classification. Dense layers take vectors as input (which are 1D), while the current output is a 3D tensor. First, we will flatten (or unroll) the 3D output to 1D,  then add one or more Dense layers on top. CIFAR has 10 output classes, so we use a final Dense layer with 10 outputs and a softmax activation."
+        "To complete our model, you will feed the last output tensor from the convolutional base (of shape (3, 3, 64)) into one or more Dense layers to perform classification. Dense layers take vectors as input (which are 1D), while the current output is a 3D tensor. First, you will flatten (or unroll) the 3D output to 1D,  then add one or more Dense layers on top. CIFAR has 10 output classes, so you use a final Dense layer with 10 outputs and a softmax activation."
       ]
     },
     {


### PR DESCRIPTION
I noticed that the merged commit #1054 passed only 2 out of 3 checks.

Check failed: `Ubuntu Sanity Check Internal CI build failed`

[Build Status Details](https://source.cloud.google.com/results/invocations/a8758598-e7bc-464a-830a-18dd0d00d80d/targets/tensorflow_docs%2Fubuntu%2Fpresubmit/log) reveal the warning message is:

```
WARNING: Please use 'you' instead of 'we'. See the documentation style (https://www.tensorflow.org/community/contribute/docs_style)
```

I've changed the "we" words to "you" in the file to adhere to the [TensorFlow documentation style guide](https://www.tensorflow.org/community/contribute/docs_style). Hopefully, this should fix the failing check.