### PR TITLE
Fixed link for Loading text tutorial

### DIFF
--- a/site/en/tutorials/text/word_embeddings.ipynb
+++ b/site/en/tutorials/text/word_embeddings.ipynb
@@ -275,7 +275,7 @@
       "source": [
         "In this tutorial you will train a sentiment classifier on IMDB movie reviews. In the process, the model will learn embeddings from scratch. We will use to a preprocessed dataset.\n",
         "\n",
-        "To load a text dataset from scratch see the  [Loading text tutorial](../load_data/text)."
+        "To load a text dataset from scratch see the  [Loading text tutorial](../load_data/text.ipynb)."
       ]
     },
     {


### PR DESCRIPTION
When running this notebook from colab Loading text tutorial link is broken and needs file extension to open text.ipynb