### PR TITLE
Fix Ubuntu 16.04 nvidia driver package name

### DIFF
--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -134,7 +134,7 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 # Install NVIDIA driver
 # Issue with driver install requires creating /usr/lib/nvidia
 <code class="devsite-terminal">sudo mkdir /usr/lib/nvidia</code>
-<code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-driver-418</code>
+<code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-418</code>
 # Reboot. Check that GPUs are visible using the command: nvidia-smi
 
 # Install development and runtime libraries (~4GB)


### PR DESCRIPTION
On ubuntu 18, it's "nvidia-driver-418". However, on ubuntu 16 it's for whatever reason named "nvidia-418", i.e. without the "-driver" part.