### PR TITLE
Remove redundant code cell that only declare encoder variable

### DIFF
--- a/site/en/tutorials/text/word_embeddings.ipynb
+++ b/site/en/tutorials/text/word_embeddings.ipynb
@@ -538,19 +538,6 @@
       "metadata": {
         "colab": {},
         "colab_type": "code",
-        "id": "tG8wExJn_XsX"
-      },
-      "outputs": [],
-      "source": [
-        "encoder = info.features['text'].encoder"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "GsjempweP9Lq"
       },
       "outputs": [],


### PR DESCRIPTION
Removed the code cell that only declare encoder variable.
It is duplicated in the code cell below.