### PR TITLE
Remove random flip in load_image_train()

### DIFF
--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -212,10 +212,6 @@
         "  input_image = tf.image.resize(datapoint['image'], (128, 128))\n",
         "  input_mask = tf.image.resize(datapoint['segmentation_mask'], (128, 128))\n",
         "\n",
-        "  if tf.random.uniform(()) \u003e 0.5:\n",
-        "    input_image = tf.image.flip_left_right(input_image)\n",
-        "    input_mask = tf.image.flip_left_right(input_mask)\n",
-        "\n",
         "  input_image, input_mask = normalize(input_image, input_mask)\n",
         "\n",
         "  return input_image, input_mask"


### PR DESCRIPTION
Because the results of this function are cached (with `train.cache()`), I think it doesn't make sense to do random augmentation here. If one wants to keep this then it would be necessary to split `load_image_train()` into two separate parts (e.g. `load_resize()` and `random_flip()`) and modify the mapping as:
```
train = dataset['train'].map(load_resize, num_parallel_calls=tf.data.experimental.AUTOTUNE)
train = train.cache()
train = train.map(random_flip)
train_dataset = train.map(random_flip).shuffle(BUFFER_SIZE).batch(BATCH_SIZE).repeat()
train_dataset = train_dataset.prefetch(buffer_size=tf.data.experimental.AUTOTUNE)
```