### PR TITLE
Fix typo in eager.ipynb

### DIFF
--- a/site/en/guide/eager.ipynb
+++ b/site/en/guide/eager.ipynb
@@ -1044,7 +1044,7 @@
         "def line_search_step(fn, init_x, rate=1.0):\n",
         "  with tf.GradientTape() as tape:\n",
         "    # Variables are automatically tracked.\n",
-        "    # But to calculate a gradient from a tensor, you must `warch` it.\n",
+        "    # But to calculate a gradient from a tensor, you must `watch` it.\n",
         "    tape.watch(init_x)\n",
         "    value = fn(init_x)\n",
         "  grad = tape.gradient(value, init_x)\n",


### PR DESCRIPTION
Fixes a typo in the Dynamic models example of eager execution.