### PR TITLE
Add pip uninstall before pip install

### DIFF
--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -296,8 +296,9 @@ these two configurations in the same source tree.
 The filename of the generated `.whl` file depends on the TensorFlow version and
 your platform. Use `pip install` to install the package, for example:
 
-<pre class="devsite-terminal prettyprint lang-bsh">
-pip install /tmp/tensorflow_pkg/tensorflow-<var>version</var>-<var>tags</var>.whl
+<pre class="prettyprint lang-bsh">
+<code class="devsite-terminal">pip uninstall tensorflow  # remove current version</code>
+<code class="devsite-terminal">pip install /tmp/tensorflow_pkg/tensorflow-<var>version</var>-<var>tags</var>.whl</code>
 </pre>
 
 Success: TensorFlow is now installed.

--- a/site/en/install/source_rpi.md
+++ b/site/en/install/source_rpi.md
@@ -85,8 +85,9 @@ When the build finishes (~30 minutes), a `.whl` package file is created in the
 output-artifacts directory of the host's source tree. Copy the wheel file to the
 Raspberry Pi and install with `pip`:
 
-<pre class="devsite-terminal devsite-click-to-copy">
-pip install tensorflow-<var>version</var>-cp34-none-linux_armv7l.whl
+<pre class="prettyprint lang-bsh">
+<code class="devsite-terminal">pip uninstall tensorflow  # remove current version</code>
+<code class="devsite-terminal">pip install tensorflow-<var>version</var>-cp34-none-linux_armv7l.whl</code>
 </pre>
 
 Success: TensorFlow is now installed on Raspian.

--- a/site/en/install/source_windows.md
+++ b/site/en/install/source_windows.md
@@ -230,8 +230,9 @@ these two configurations in the same source tree.
 The filename of the generated `.whl` file depends on the TensorFlow version and
 your platform. Use `pip3 install` to install the package, for example:
 
-<pre class="devsite-terminal tfo-terminal-windows prettyprint lang-bsh">
-pip3 install C:/tmp/tensorflow_pkg/tensorflow-<var>version</var>-cp36-cp36m-win_amd64.whl
+<pre class="prettyprint lang-bsh">
+<code class="devsite-terminal tfo-terminal-windows">pip3 uninstall tensorflow  # remove current version</code>
+<code class="devsite-terminal tfo-terminal-windows">pip3 install C:/tmp/tensorflow_pkg/tensorflow-<var>version</var>-cp36-cp36m-win_amd64.whl</code>
 </pre>
 
 Success: TensorFlow is now installed.


### PR DESCRIPTION
Otherwise an already installed version will not be installed over, causing
confusion, for example https://github.com/tensorflow/tensorflow/issues/7449