### PR TITLE
Markdown list is not properly displayed

### DIFF
--- a/site/en/guide/keras/masking_and_padding.ipynb
+++ b/site/en/guide/keras/masking_and_padding.ipynb
@@ -212,6 +212,7 @@
         "Now that all samples have a uniform length, the model must be informed that some part of the data is actually padding and should be ignored. That mechanism is <b>masking</b>.\n",
         "\n",
         "There are three ways to introduce input masks in Keras models:\n",
+        "\n",
         "- Add a `keras.layers.Masking` layer.\n",
         "- Configure a `keras.layers.Embedding` layer with `mask_zero=True`.\n",
         "- Pass a `mask` argument manually when calling layers that support this argument (e.g. RNN layers)."

--- a/site/en/guide/keras/masking_and_padding.ipynb
+++ b/site/en/guide/keras/masking_and_padding.ipynb
@@ -4,7 +4,6 @@
   "metadata": {
     "colab": {
       "name": "masking_and_padding.ipynb",
-      "version": "0.3.2",
       "provenance": [],
       "private_outputs": true,
       "collapsed_sections": [],
@@ -241,7 +240,7 @@
         "embedding = layers.Embedding(input_dim=5000, output_dim=16, mask_zero=True)\n",
         "masked_output = embedding(padded_inputs)\n",
         "\n",
-        "print(masked_output._keras_mask)\n"
+        "print(masked_output._keras_mask)"
       ],
       "execution_count": 0,
       "outputs": []
@@ -453,7 +452,7 @@
         "\n",
         "first_half, second_half = TemporalSplit()(masked_embedding)\n",
         "print(first_half._keras_mask)\n",
-        "print(second_half._keras_mask)\n"
+        "print(second_half._keras_mask)"
       ],
       "execution_count": 0,
       "outputs": []
@@ -525,13 +524,10 @@
         "To write such a layer, you can simply add a `mask=None` argument in your `call` signature. The mask associated with the inputs will be passed to your layer whenever it is available.\n",
         "\n",
         "```python\n",
-        "\n",
         "class MaskConsumer(tf.keras.layers.Layer):\n",
         "  \n",
         "  def call(self, inputs, mask=None):\n",
         "    ...\n",
-        "\n",
-        "\n",
         "```"
       ]
     },


### PR DESCRIPTION
Added a newline before list so docs show up properly on 
https://www.tensorflow.org/guide/keras/masking_and_padding