### PR TITLE
Pix2pix.ipynb/custom8

### DIFF
--- a/site/en/tutorials/generative/pix2pix.ipynb
+++ b/site/en/tutorials/generative/pix2pix.ipynb
@@ -1,5 +1,6 @@
-{
-  "cells": [
+  "I'm
+  ✓call +
+
     {
       "cell_type": "markdown",
       "metadata": {


### PR DESCRIPTION
  DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support