### PR TITLE
Removing redundant use of np.array & unnecessary spaces

### DIFF
--- a/site/en/tutorials/generative/deepdream.ipynb
+++ b/site/en/tutorials/generative/deepdream.ipynb
@@ -111,7 +111,7 @@
         "\n",
         "Let's demonstrate how you can make a neural network \"dream\" and enhance the surreal patterns it sees in an image.\n",
         "\n",
-        "![Dogception](https://github.com/sayakpaul/docs/blob/master/site/en/tutorials/generative/images/dogception.png?raw=1)"
+        "![Dogception](https://github.com/tensorflow/docs/blob/master/site/en/tutorials/generative/images/dogception.png?raw=1)"
       ]
     },
     {

--- a/site/en/tutorials/generative/deepdream.ipynb
+++ b/site/en/tutorials/generative/deepdream.ipynb
@@ -111,7 +111,7 @@
         "\n",
         "Let's demonstrate how you can make a neural network \"dream\" and enhance the surreal patterns it sees in an image.\n",
         "\n",
-        "![Dogception](https://github.com/tensorflow/docs/blob/master/site/en/tutorials/generative/images/dogception.png?raw=1)"
+        "![Dogception](images/dogception.png)"
       ]
     },
     {

--- a/site/en/tutorials/generative/deepdream.ipynb
+++ b/site/en/tutorials/generative/deepdream.ipynb
@@ -1,669 +1,664 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "1SgrstLXNbG_"
-   },
-   "source": [
-    "##### Copyright 2019 The TensorFlow Authors."
-   ]
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "deepdream.ipynb",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.1"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "cellView": "form",
-    "colab": {},
-    "colab_type": "code",
-    "id": "k7gifg92NbG9"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "# https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "dCMqzy7BNbG9"
-   },
-   "source": [
-    "# DeepDream"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "2yqCPS8SNbG8"
-   },
-   "source": [
-    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/generative/deepdream\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/generative/deepdream.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/generative/deepdream.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/generative/deepdream.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
-    "  </td>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "XPDKhwPcNbG7"
-   },
-   "source": [
-    "This tutorial contains a minimal implementation of DeepDream, as described in this [blog post](https://ai.googleblog.com/2015/06/inceptionism-going-deeper-into-neural.html) by Alexander Mordvintsev.\n",
-    "\n",
-    "DeepDream is an experiment that visualizes the patterns learned by a neural network. Similar to when a child watches clouds and tries to interpret random shapes, DeepDream over-interprets and enhances the patterns it sees in an image.\n",
-    "\n",
-    "It does so by forwarding an image through the network, then calculating the gradient of the image with respect to the activations of a particular layer. The image is then modified to increase these activations, enhancing the patterns seen by the network, and resulting in a dream-like image. This process was dubbed \"Inceptionism\" (a reference to [InceptionNet](https://arxiv.org/pdf/1409.4842.pdf), and the [movie](https://en.wikipedia.org/wiki/Inception) Inception.\n",
-    "\n",
-    "Let's demonstrate how you can make a neural network \"dream\" and enhance the surreal patterns it sees in an image.\n",
-    "\n",
-    "![Dogception](images/dogception.png)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "GUSXlFNkxrqh"
-   },
-   "outputs": [],
-   "source": [
-    "from __future__ import absolute_import, division, print_function, unicode_literals"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Sc5Yq_Rgxreb"
-   },
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "  # %tensorflow_version only exists in Colab.\n",
-    "  %tensorflow_version 2.x\n",
-    "except Exception:\n",
-    "  pass\n",
-    "import tensorflow as tf"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "g_Qp173_NbG5"
-   },
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "\n",
-    "import matplotlib as mpl\n",
-    "\n",
-    "from IPython.display import clear_output\n",
-    "from matplotlib import pyplot as plt\n",
-    "from tensorflow.keras.preprocessing import image"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "wgeIJg82NbG4"
-   },
-   "source": [
-    "## Choose an image to dream-ify"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "yt6zam_9NbG4"
-   },
-   "source": [
-    "For this tutorial, let's use an image of a [labrador](https://commons.wikimedia.org/wiki/File:YellowLabradorLooking_new.jpg)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "0lclzk9sNbG2"
-   },
-   "outputs": [],
-   "source": [
-    "url = 'https://storage.googleapis.com/download.tensorflow.org/example_images/YellowLabradorLooking_new.jpg'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Y5BPgc8NNbG0"
-   },
-   "outputs": [],
-   "source": [
-    "# Download an image and read it into a NumPy array.\n",
-    "def download(url, target_size=None):\n",
-    "  name = url.split('/')[-1]\n",
-    "  image_path = tf.keras.utils.get_file(name, origin=url)\n",
-    "  img = tf.keras.preprocessing.image.load_img(image_path, target_size=target_size)\n",
-    "  return img\n",
-    "\n",
-    "# Normalize an image\n",
-    "def deprocess(img):\n",
-    "  img = 255*(img + 1.0)/2.0\n",
-    "  return tf.cast(img, tf.uint8)\n",
-    "\n",
-    "\n",
-    "# Display an image\n",
-    "def show(img):\n",
-    "  plt.figure(figsize=(12,12))\n",
-    "  plt.grid(False)\n",
-    "  plt.axis('off')\n",
-    "  plt.imshow(img)\n",
-    "  plt.show()\n",
-    "\n",
-    "# Downsizing the image makes it easier to work with.\n",
-    "original_img = download(url, target_size=[225, 375])\n",
-    "original_img = np.array(original_img)\n",
-    "\n",
-    "show(original_img)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "F4RBFfIWNbG0"
-   },
-   "source": [
-    "## Prepare the feature extraction model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "cruNQmMDNbGz"
-   },
-   "source": [
-    "Download and prepare a pre-trained image classification model. You will use [InceptionV3](https://keras.io/applications/#inceptionv3) which is similar to the model originally used in DeepDream. Note that any [pre-trained model](https://keras.io/applications/#models-for-image-classification-with-weights-trained-on-imagenet) will work, although you will have to adjust the layer names below if you change this."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "GlLi48GKNbGy"
-   },
-   "outputs": [],
-   "source": [
-    "base_model = tf.keras.applications.InceptionV3(include_top=False, weights='imagenet')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Bujb0jPNNbGx"
-   },
-   "source": [
-    "The idea in DeepDream is to choose a layer (or layers) and maximize the \"loss\" in a way that the image increasingly \"excites\" the layers. The complexity of the features incorporated depends on layers chosen by you, i.e, lower layers produce strokes or simple patterns, while deeper layers give sophisticated features in images, or even whole objects."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "qOVmDO4LNbGv"
-   },
-   "source": [
-    "The InceptionV3 architecture is quite large (for a graph of the model architecture see TensorFlow's [research repo](https://github.com/tensorflow/models/tree/master/research/inception)). For DeepDream, the layers of  interest are those where the convolutions are concatenated. There are 11 of these layers in InceptionV3, named 'mixed0' though 'mixed10'. Using different layers will result in different dream-like images. Deeper layers respond to higher-level features (such as eyes and faces), while earlier layers respond to simpler features (such as edges, shapes, and textures). Feel free to experiment with the layers selected below, but keep in mind that deeper layers (those with a higher index) will take longer to train on since the gradient computation is deeper."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "08KB502ONbGt"
-   },
-   "outputs": [],
-   "source": [
-    "# Maximize the activations of these layers\n",
-    "names = ['mixed3', 'mixed5']\n",
-    "\n",
-    "# Grab the outputs of the above layers\n",
-    "layers = [base_model.get_layer(name).output for name in names]\n",
-    "\n",
-    "# Create the feature extraction model\n",
-    "dream_model = tf.keras.Model(inputs=base_model.input, outputs=layers)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "sb7u31B4NbGt"
-   },
-   "source": [
-    "## Calculate loss\n",
-    "\n",
-    "The loss is the sum of the activations in the chosen layers. The loss is normalizaed at each layer so the contribution from larger layers does not outweigh smaller layers. Normally, loss is a quantity you wish to minimize via gradient descent. In DeepDream, you will maximize this loss via gradient ascent."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "8MhfSweXXiuq"
-   },
-   "outputs": [],
-   "source": [
-    "def calc_loss(img, model):\n",
-    "  # Pass forward the image through the model to retrieve the activations.\n",
-    "  # Add a batch dimension to the image\n",
-    "  img_batch = tf.expand_dims(img, axis=0)\n",
-    "\n",
-    "  layer_activations = model(img_batch)\n",
-    "\n",
-    "  losses = []\n",
-    "  for act in layer_activations:\n",
-    "    loss = tf.math.reduce_mean(act)\n",
-    "    losses.append(loss)\n",
-    "\n",
-    "  return  tf.reduce_sum(losses)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "k4TCNsAUO9kI"
-   },
-   "source": [
-    "## Gradient ascent\n",
-    "\n",
-    "Once you have calculated the loss for the chosen layers, all that is left is to calculate the gradients with respect to the image, and add them to the original image. \n",
-    "\n",
-    "Adding the gradients to the image enhances the patterns seen by the network. At each step, you will have created an image that increasingly excites the activations of certain layers in the network."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "qRScWg_VNqvj"
-   },
-   "outputs": [],
-   "source": [
-    "@tf.function\n",
-    "def deepdream(model, img, step_size):\n",
-    "    with tf.GradientTape() as tape:\n",
-    "      # This needs gradients relative to `img`\n",
-    "      # `GradientTape` only watches `tf.Variable`s by default\n",
-    "      tape.watch(img)\n",
-    "      loss = calc_loss(img, model)\n",
-    "\n",
-    "    # Calculate the gradient of the loss with respect to the pixels of the input image.\n",
-    "    gradients = tape.gradient(loss, img)\n",
-    "\n",
-    "    # Normalize the gradients.\n",
-    "    gradients /= tf.math.reduce_std(gradients) + 1e-8 \n",
-    "    \n",
-    "    # In gradient ascent, the \"loss\" is maximized so that the input image increasingly \"excites\" the layers.\n",
-    "    # You can update the image by directly adding the gradients (because they're the same shape!)\n",
-    "    img = img + gradients*step_size\n",
-    "    img = tf.clip_by_value(img, -1, 1)\n",
-    "\n",
-    "    return loss, img"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "9vHEcy7dTysi"
-   },
-   "outputs": [],
-   "source": [
-    "def run_deep_dream_simple(model, img, steps=100, step_size=0.01):\n",
-    "  # Convert from uint8 to the range expected by the model.\n",
-    "  img = tf.keras.applications.inception_v3.preprocess_input(img)\n",
-    "\n",
-    "  for step in range(steps):\n",
-    "    loss, img = deepdream(model, img, step_size)\n",
-    "    \n",
-    "    # Logging\n",
-    "    if step % 100 == 0:\n",
-    "      clear_output(wait=True)\n",
-    "      show(deprocess(img))\n",
-    "      print (\"Step {}, loss {}\".format(step, loss))\n",
-    "\n",
-    "  result = deprocess(img)\n",
-    "  clear_output(wait=True)\n",
-    "  show(result)\n",
-    "\n",
-    "  return result"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "tEfd00rr0j8Z"
-   },
-   "outputs": [],
-   "source": [
-    "dream_img = run_deep_dream_simple(model=dream_model, img=original_img, \n",
-    "                                  steps=800, step_size=0.001)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "2PbfXEVFNbGp"
-   },
-   "source": [
-    "## Taking it up an octave\n",
-    "\n",
-    "Pretty good, but there are a few issues with this first attempt: \n",
-    "\n",
-    "  1. The output is noisy (this could be addressed with a `tf.image.total_variation` loss).\n",
-    "  1. The image is low resolution.\n",
-    "  1. The patterns appear like they're all happening at the same granularity.\n",
-    "  \n",
-    "One approach that addresses all these problems is applying gradient ascent at different scales. This will allow patterns generated at smaller scales to be incorporated into patterns at higher scales and filled in with additional detail.\n",
-    "\n",
-    "To do this you can perform the previous gradient ascent approach, then increase the size of the image (which is reffered to as an octave), and repeat this process for multiple octaves.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "0eGDSdatLT-8"
-   },
-   "outputs": [],
-   "source": [
-    "OCTAVE_SCALE = 1.3\n",
-    "\n",
-    "img = tf.constant(original_img)\n",
-    "base_shape = tf.cast(tf.shape(img)[:-1], tf.float32)\n",
-    "\n",
-    "for n in range(3):\n",
-    "  new_shape = tf.cast(base_shape*(OCTAVE_SCALE**n), tf.int32)\n",
-    "\n",
-    "  img = tf.image.resize(img, new_shape).numpy()\n",
-    "\n",
-    "  img = run_deep_dream_simple(model=dream_model, img=img, steps=200, step_size=0.001)\n",
-    "\n",
-    "clear_output(wait=True)\n",
-    "show(img)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "s9xqyeuwLZFy"
-   },
-   "source": [
-    "## Scaling up with tiles\n",
-    "\n",
-    "One thing to consider is that as the image increases in size, so will the time and memory necessary to perform the gradient calculation. The above octave implementation will not work on very large images, or many octaves.\n",
-    "\n",
-    "To avoid this issue you can split the image into tiles and compute the gradient for each tile.\n",
-    "\n",
-    "Applying random shifts to the image before each tiled computation prevents tile seams from appearing.\n",
-    "\n",
-    "Start by implementing the random shift:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "oGgLHk7o80ac"
-   },
-   "outputs": [],
-   "source": [
-    "def random_roll(img, maxroll):\n",
-    "  # Randomly shift the image to avoid tiled boundaries.\n",
-    "  shift = tf.random.uniform(shape=[2], minval=-maxroll, maxval=maxroll, dtype=tf.int32)\n",
-    "  shift_down, shift_right = shift[0],shift[1] \n",
-    "  img_rolled = tf.roll(tf.roll(img, shift_right, axis=1), shift_down, axis=0)\n",
-    "  return shift_down, shift_right, img_rolled"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "sKsiqWfA9H41"
-   },
-   "outputs": [],
-   "source": [
-    "shift_down, shift_right, img_rolled = random_roll(original_img, 512)\n",
-    "show(img_rolled)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "tGIjA3UhhAt8"
-   },
-   "source": [
-    "Here is a tiled equivalent of the `deepdream` function defined earlier:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "x__TZ0uqNbGm"
-   },
-   "outputs": [],
-   "source": [
-    "@tf.function\n",
-    "def get_tiled_gradients(model, img, tile_size=512):\n",
-    "  shift_down, shift_right, img_rolled = random_roll(img, tile_size)\n",
-    "\n",
-    "  # Initialize the image gradients to zero.\n",
-    "  gradients = tf.zeros_like(img_rolled)\n",
-    "\n",
-    "  for x in tf.range(0, img_rolled.shape[0], tile_size):\n",
-    "    for y in tf.range(0, img_rolled.shape[1], tile_size):\n",
-    "      # Calculate the gradients for this tile.\n",
-    "      with tf.GradientTape() as tape:\n",
-    "        # This needs gradients relative to `img_rolled`.\n",
-    "        # `GradientTape` only watches `tf.Variable`s by default.\n",
-    "        tape.watch(img_rolled)\n",
-    "\n",
-    "        # Extract a tile out of the image.\n",
-    "        img_tile = img_rolled[x:x+tile_size, y:y+tile_size]\n",
-    "        loss = calc_loss(img_tile, model)\n",
-    "\n",
-    "      # Update the image gradients for this tile.\n",
-    "      gradients = gradients + tape.gradient(loss, img_rolled)\n",
-    "\n",
-    "  # Undo the random shift applied to the image and its gradients.\n",
-    "  gradients = tf.roll(tf.roll(gradients, -shift_right, axis=1), -shift_down, axis=0)\n",
-    "\n",
-    "  # Normalize the gradients.\n",
-    "  gradients /= tf.math.reduce_std(gradients) + 1e-8 \n",
-    "\n",
-    "  return gradients "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "hYnTTs_qiaND"
-   },
-   "source": [
-    "Putting this together gives a scalable, octave-aware deepdream implementation:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "gA-15DM4NbGk"
-   },
-   "outputs": [],
-   "source": [
-    "def run_deep_dream_with_octaves(model, img, steps_per_octave=100, step_size=0.01, \n",
-    "                                num_octaves=3, octave_scale=1.3):\n",
-    "  img = tf.keras.preprocessing.image.img_to_array(img)\n",
-    "  img = tf.keras.applications.inception_v3.preprocess_input(img)\n",
-    "\n",
-    "  for octave in range(num_octaves):\n",
-    "    # Scale the image based on the octave\n",
-    "    if octave>0:\n",
-    "      new_size = tf.cast(tf.convert_to_tensor(img.shape[:2]), tf.float32)*octave_scale\n",
-    "      img = tf.image.resize(img, tf.cast(new_size, tf.int32))\n",
-    "\n",
-    "    for step in range(steps_per_octave):\n",
-    "      gradients = get_tiled_gradients(model, img)\n",
-    "      img = img + gradients*step_size\n",
-    "      img = tf.clip_by_value(img, -1, 1)\n",
-    "\n",
-    "      if step % 10 == 0:\n",
-    "        clear_output(wait=True)\n",
-    "        show(deprocess(img))\n",
-    "        print (\"Octave {}, Step {}\".format(octave, step))\n",
-    "    \n",
-    "  clear_output(wait=True)\n",
-    "  result = deprocess(img)\n",
-    "  show(result)\n",
-    "\n",
-    "  return result"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "T7PbRLV74RrU"
-   },
-   "outputs": [],
-   "source": [
-    "dream_img = run_deep_dream_with_octaves(model=dream_model, img=original_img, step_size=0.01)\n",
-    "\n",
-    "clear_output()\n",
-    "show(original_img)\n",
-    "show(dream_img)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "0Og0-qLwNbGg"
-   },
-   "source": [
-    "Much better! Play around with the number of octaves, octave scale, and activated layers to change how your DeepDream-ed image looks.\n",
-    "\n",
-    "Readers might also be interested in [TensorFlow Lucid](https://github.com/tensorflow/lucid) which expands on ideas introduced in this tutorial to visualize and interpret neural networks."
-   ]
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "collapsed_sections": [],
-   "last_runtime": {
-    "build_target": "//research/colab/notebook:notebook_backend",
-    "kind": "private"
-   },
-   "name": "deepdream.ipynb",
-   "private_outputs": true,
-   "provenance": [],
-   "toc_visible": true,
-   "version": "0.3.2"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.1"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "1SgrstLXNbG_"
+      },
+      "source": [
+        "##### Copyright 2019 The TensorFlow Authors."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "cellView": "form",
+        "colab_type": "code",
+        "id": "k7gifg92NbG9",
+        "colab": {}
+      },
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "dCMqzy7BNbG9"
+      },
+      "source": [
+        "# DeepDream"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "2yqCPS8SNbG8"
+      },
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/generative/deepdream\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/generative/deepdream.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/generative/deepdream.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/generative/deepdream.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "XPDKhwPcNbG7"
+      },
+      "source": [
+        "This tutorial contains a minimal implementation of DeepDream, as described in this [blog post](https://ai.googleblog.com/2015/06/inceptionism-going-deeper-into-neural.html) by Alexander Mordvintsev.\n",
+        "\n",
+        "DeepDream is an experiment that visualizes the patterns learned by a neural network. Similar to when a child watches clouds and tries to interpret random shapes, DeepDream over-interprets and enhances the patterns it sees in an image.\n",
+        "\n",
+        "It does so by forwarding an image through the network, then calculating the gradient of the image with respect to the activations of a particular layer. The image is then modified to increase these activations, enhancing the patterns seen by the network, and resulting in a dream-like image. This process was dubbed \"Inceptionism\" (a reference to [InceptionNet](https://arxiv.org/pdf/1409.4842.pdf), and the [movie](https://en.wikipedia.org/wiki/Inception) Inception.\n",
+        "\n",
+        "Let's demonstrate how you can make a neural network \"dream\" and enhance the surreal patterns it sees in an image.\n",
+        "\n",
+        "![Dogception](https://github.com/sayakpaul/docs/blob/master/site/en/tutorials/generative/images/dogception.png?raw=1)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "GUSXlFNkxrqh",
+        "colab": {}
+      },
+      "source": [
+        "from __future__ import absolute_import, division, print_function, unicode_literals"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "Sc5Yq_Rgxreb",
+        "colab": {}
+      },
+      "source": [
+        "try:\n",
+        "  # %tensorflow_version only exists in Colab.\n",
+        "  %tensorflow_version 2.x\n",
+        "except Exception:\n",
+        "  pass\n",
+        "import tensorflow as tf"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "g_Qp173_NbG5",
+        "colab": {}
+      },
+      "source": [
+        "import numpy as np\n",
+        "\n",
+        "import matplotlib as mpl\n",
+        "\n",
+        "from IPython.display import clear_output\n",
+        "from matplotlib import pyplot as plt\n",
+        "from tensorflow.keras.preprocessing import image"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "wgeIJg82NbG4"
+      },
+      "source": [
+        "## Choose an image to dream-ify"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "yt6zam_9NbG4"
+      },
+      "source": [
+        "For this tutorial, let's use an image of a [labrador](https://commons.wikimedia.org/wiki/File:YellowLabradorLooking_new.jpg)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "0lclzk9sNbG2",
+        "colab": {}
+      },
+      "source": [
+        "url = 'https://storage.googleapis.com/download.tensorflow.org/example_images/YellowLabradorLooking_new.jpg'"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "Y5BPgc8NNbG0",
+        "colab": {}
+      },
+      "source": [
+        "# Download an image and read it into a NumPy array.\n",
+        "def download(url, target_size=None):\n",
+        "  name = url.split('/')[-1]\n",
+        "  image_path = tf.keras.utils.get_file(name, origin=url)\n",
+        "  img = tf.keras.preprocessing.image.load_img(image_path, target_size=target_size)\n",
+        "  return img\n",
+        "\n",
+        "# Normalize an image\n",
+        "def deprocess(img):\n",
+        "  img = 255*(img + 1.0)/2.0\n",
+        "  return tf.cast(img, tf.uint8)\n",
+        "\n",
+        "\n",
+        "# Display an image\n",
+        "def show(img):\n",
+        "  plt.figure(figsize=(12,12))\n",
+        "  plt.grid(False)\n",
+        "  plt.axis('off')\n",
+        "  plt.imshow(img)\n",
+        "  plt.show()\n",
+        "\n",
+        "# Downsizing the image makes it easier to work with.\n",
+        "original_img = download(url, target_size=[225, 375])\n",
+        "original_img = np.array(original_img)\n",
+        "\n",
+        "show(original_img)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "F4RBFfIWNbG0"
+      },
+      "source": [
+        "## Prepare the feature extraction model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "cruNQmMDNbGz"
+      },
+      "source": [
+        "Download and prepare a pre-trained image classification model. You will use [InceptionV3](https://keras.io/applications/#inceptionv3) which is similar to the model originally used in DeepDream. Note that any [pre-trained model](https://keras.io/applications/#models-for-image-classification-with-weights-trained-on-imagenet) will work, although you will have to adjust the layer names below if you change this."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "GlLi48GKNbGy",
+        "colab": {}
+      },
+      "source": [
+        "base_model = tf.keras.applications.InceptionV3(include_top=False, weights='imagenet')"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Bujb0jPNNbGx"
+      },
+      "source": [
+        "The idea in DeepDream is to choose a layer (or layers) and maximize the \"loss\" in a way that the image increasingly \"excites\" the layers. The complexity of the features incorporated depends on layers chosen by you, i.e, lower layers produce strokes or simple patterns, while deeper layers give sophisticated features in images, or even whole objects."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "qOVmDO4LNbGv"
+      },
+      "source": [
+        "The InceptionV3 architecture is quite large (for a graph of the model architecture see TensorFlow's [research repo](https://github.com/tensorflow/models/tree/master/research/inception)). For DeepDream, the layers of  interest are those where the convolutions are concatenated. There are 11 of these layers in InceptionV3, named 'mixed0' though 'mixed10'. Using different layers will result in different dream-like images. Deeper layers respond to higher-level features (such as eyes and faces), while earlier layers respond to simpler features (such as edges, shapes, and textures). Feel free to experiment with the layers selected below, but keep in mind that deeper layers (those with a higher index) will take longer to train on since the gradient computation is deeper."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "08KB502ONbGt",
+        "colab": {}
+      },
+      "source": [
+        "# Maximize the activations of these layers\n",
+        "names = ['mixed3', 'mixed5']\n",
+        "\n",
+        "# Grab the outputs of the above layers\n",
+        "layers = [base_model.get_layer(name).output for name in names]\n",
+        "\n",
+        "# Create the feature extraction model\n",
+        "dream_model = tf.keras.Model(inputs=base_model.input, outputs=layers)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "sb7u31B4NbGt"
+      },
+      "source": [
+        "## Calculate loss\n",
+        "\n",
+        "The loss is the sum of the activations in the chosen layers. The loss is normalizaed at each layer so the contribution from larger layers does not outweigh smaller layers. Normally, loss is a quantity you wish to minimize via gradient descent. In DeepDream, you will maximize this loss via gradient ascent."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "8MhfSweXXiuq",
+        "colab": {}
+      },
+      "source": [
+        "def calc_loss(img, model):\n",
+        "  # Pass forward the image through the model to retrieve the activations.\n",
+        "  # Add a batch dimension to the image\n",
+        "  img_batch = tf.expand_dims(img, axis=0)\n",
+        "\n",
+        "  layer_activations = model(img_batch)\n",
+        "\n",
+        "  losses = []\n",
+        "  for act in layer_activations:\n",
+        "    loss = tf.math.reduce_mean(act)\n",
+        "    losses.append(loss)\n",
+        "\n",
+        "  return  tf.reduce_sum(losses)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "k4TCNsAUO9kI"
+      },
+      "source": [
+        "## Gradient ascent\n",
+        "\n",
+        "Once you have calculated the loss for the chosen layers, all that is left is to calculate the gradients with respect to the image, and add them to the original image. \n",
+        "\n",
+        "Adding the gradients to the image enhances the patterns seen by the network. At each step, you will have created an image that increasingly excites the activations of certain layers in the network."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "qRScWg_VNqvj",
+        "colab": {}
+      },
+      "source": [
+        "@tf.function\n",
+        "def deepdream(model, img, step_size):\n",
+        "    with tf.GradientTape() as tape:\n",
+        "      # This needs gradients relative to `img`\n",
+        "      # `GradientTape` only watches `tf.Variable`s by default\n",
+        "      tape.watch(img)\n",
+        "      loss = calc_loss(img, model)\n",
+        "\n",
+        "    # Calculate the gradient of the loss with respect to the pixels of the input image.\n",
+        "    gradients = tape.gradient(loss, img)\n",
+        "\n",
+        "    # Normalize the gradients.\n",
+        "    gradients /= tf.math.reduce_std(gradients) + 1e-8 \n",
+        "    \n",
+        "    # In gradient ascent, the \"loss\" is maximized so that the input image increasingly \"excites\" the layers.\n",
+        "    # You can update the image by directly adding the gradients (because they're the same shape!)\n",
+        "    img = img + gradients*step_size\n",
+        "    img = tf.clip_by_value(img, -1, 1)\n",
+        "\n",
+        "    return loss, img"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "9vHEcy7dTysi",
+        "colab": {}
+      },
+      "source": [
+        "def run_deep_dream_simple(model, img, steps=100, step_size=0.01):\n",
+        "  # Convert from uint8 to the range expected by the model.\n",
+        "  img = tf.keras.applications.inception_v3.preprocess_input(img)\n",
+        "\n",
+        "  for step in range(steps):\n",
+        "    loss, img = deepdream(model, img, step_size)\n",
+        "    \n",
+        "    # Logging\n",
+        "    if step % 100 == 0:\n",
+        "      clear_output(wait=True)\n",
+        "      show(deprocess(img))\n",
+        "      print (\"Step {}, loss {}\".format(step, loss))\n",
+        "\n",
+        "  result = deprocess(img)\n",
+        "  clear_output(wait=True)\n",
+        "  show(result)\n",
+        "\n",
+        "  return result"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "tEfd00rr0j8Z",
+        "colab": {}
+      },
+      "source": [
+        "dream_img = run_deep_dream_simple(model=dream_model, img=original_img, \n",
+        "                                  steps=800, step_size=0.001)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "2PbfXEVFNbGp"
+      },
+      "source": [
+        "## Taking it up an octave\n",
+        "\n",
+        "Pretty good, but there are a few issues with this first attempt: \n",
+        "\n",
+        "  1. The output is noisy (this could be addressed with a `tf.image.total_variation` loss).\n",
+        "  1. The image is low resolution.\n",
+        "  1. The patterns appear like they're all happening at the same granularity.\n",
+        "  \n",
+        "One approach that addresses all these problems is applying gradient ascent at different scales. This will allow patterns generated at smaller scales to be incorporated into patterns at higher scales and filled in with additional detail.\n",
+        "\n",
+        "To do this you can perform the previous gradient ascent approach, then increase the size of the image (which is reffered to as an octave), and repeat this process for multiple octaves.\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "0eGDSdatLT-8",
+        "colab": {}
+      },
+      "source": [
+        "OCTAVE_SCALE = 1.3\n",
+        "\n",
+        "img = tf.constant(original_img)\n",
+        "base_shape = tf.cast(tf.shape(img)[:-1], tf.float32)\n",
+        "\n",
+        "for n in range(3):\n",
+        "  new_shape = tf.cast(base_shape*(OCTAVE_SCALE**n), tf.int32)\n",
+        "\n",
+        "  img = tf.image.resize(img, new_shape).numpy()\n",
+        "\n",
+        "  img = run_deep_dream_simple(model=dream_model, img=img, steps=200, step_size=0.001)\n",
+        "\n",
+        "clear_output(wait=True)\n",
+        "show(img)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "s9xqyeuwLZFy"
+      },
+      "source": [
+        "## Scaling up with tiles\n",
+        "\n",
+        "One thing to consider is that as the image increases in size, so will the time and memory necessary to perform the gradient calculation. The above octave implementation will not work on very large images, or many octaves.\n",
+        "\n",
+        "To avoid this issue you can split the image into tiles and compute the gradient for each tile.\n",
+        "\n",
+        "Applying random shifts to the image before each tiled computation prevents tile seams from appearing.\n",
+        "\n",
+        "Start by implementing the random shift:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "oGgLHk7o80ac",
+        "colab": {}
+      },
+      "source": [
+        "def random_roll(img, maxroll):\n",
+        "  # Randomly shift the image to avoid tiled boundaries.\n",
+        "  shift = tf.random.uniform(shape=[2], minval=-maxroll, maxval=maxroll, dtype=tf.int32)\n",
+        "  shift_down, shift_right = shift[0],shift[1] \n",
+        "  img_rolled = tf.roll(tf.roll(img, shift_right, axis=1), shift_down, axis=0)\n",
+        "  return shift_down, shift_right, img_rolled"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "sKsiqWfA9H41",
+        "colab": {}
+      },
+      "source": [
+        "shift_down, shift_right, img_rolled = random_roll(original_img, 512)\n",
+        "show(img_rolled)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "tGIjA3UhhAt8"
+      },
+      "source": [
+        "Here is a tiled equivalent of the `deepdream` function defined earlier:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "x__TZ0uqNbGm",
+        "colab": {}
+      },
+      "source": [
+        "@tf.function\n",
+        "def get_tiled_gradients(model, img, tile_size=512):\n",
+        "  shift_down, shift_right, img_rolled = random_roll(img, tile_size)\n",
+        "\n",
+        "  # Initialize the image gradients to zero.\n",
+        "  gradients = tf.zeros_like(img_rolled)\n",
+        "\n",
+        "  for x in tf.range(0, img_rolled.shape[0], tile_size):\n",
+        "    for y in tf.range(0, img_rolled.shape[1], tile_size):\n",
+        "      # Calculate the gradients for this tile.\n",
+        "      with tf.GradientTape() as tape:\n",
+        "        # This needs gradients relative to `img_rolled`.\n",
+        "        # `GradientTape` only watches `tf.Variable`s by default.\n",
+        "        tape.watch(img_rolled)\n",
+        "\n",
+        "        # Extract a tile out of the image.\n",
+        "        img_tile = img_rolled[x:x+tile_size, y:y+tile_size]\n",
+        "        loss = calc_loss(img_tile, model)\n",
+        "\n",
+        "      # Update the image gradients for this tile.\n",
+        "      gradients = gradients + tape.gradient(loss, img_rolled)\n",
+        "\n",
+        "  # Undo the random shift applied to the image and its gradients.\n",
+        "  gradients = tf.roll(tf.roll(gradients, -shift_right, axis=1), -shift_down, axis=0)\n",
+        "\n",
+        "  # Normalize the gradients.\n",
+        "  gradients /= tf.math.reduce_std(gradients) + 1e-8 \n",
+        "\n",
+        "  return gradients "
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "hYnTTs_qiaND"
+      },
+      "source": [
+        "Putting this together gives a scalable, octave-aware deepdream implementation:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "gA-15DM4NbGk",
+        "colab": {}
+      },
+      "source": [
+        "def run_deep_dream_with_octaves(model, img, steps_per_octave=100, step_size=0.01, \n",
+        "                                num_octaves=3, octave_scale=1.3):\n",
+        "  img = tf.keras.preprocessing.image.img_to_array(img)\n",
+        "  img = tf.keras.applications.inception_v3.preprocess_input(img)\n",
+        "\n",
+        "  for octave in range(num_octaves):\n",
+        "    # Scale the image based on the octave\n",
+        "    if octave>0:\n",
+        "      new_size = tf.cast(tf.convert_to_tensor(img.shape[:2]), tf.float32)*octave_scale\n",
+        "      img = tf.image.resize(img, tf.cast(new_size, tf.int32))\n",
+        "\n",
+        "    for step in range(steps_per_octave):\n",
+        "      gradients = get_tiled_gradients(model, img)\n",
+        "      img = img + gradients*step_size\n",
+        "      img = tf.clip_by_value(img, -1, 1)\n",
+        "\n",
+        "      if step % 10 == 0:\n",
+        "        clear_output(wait=True)\n",
+        "        show(deprocess(img))\n",
+        "        print (\"Octave {}, Step {}\".format(octave, step))\n",
+        "    \n",
+        "  clear_output(wait=True)\n",
+        "  result = deprocess(img)\n",
+        "  show(result)\n",
+        "\n",
+        "  return result"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "T7PbRLV74RrU",
+        "colab": {}
+      },
+      "source": [
+        "dream_img = run_deep_dream_with_octaves(model=dream_model, img=original_img, step_size=0.01)\n",
+        "\n",
+        "clear_output()\n",
+        "show(original_img)\n",
+        "show(dream_img)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "0Og0-qLwNbGg"
+      },
+      "source": [
+        "Much better! Play around with the number of octaves, octave scale, and activated layers to change how your DeepDream-ed image looks.\n",
+        "\n",
+        "Readers might also be interested in [TensorFlow Lucid](https://github.com/tensorflow/lucid) which expands on ideas introduced in this tutorial to visualize and interpret neural networks."
+      ]
+    }
+  ]
 }

--- a/site/en/tutorials/generative/deepdream.ipynb
+++ b/site/en/tutorials/generative/deepdream.ipynb
@@ -1,653 +1,669 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "1SgrstLXNbG_"
-      },
-      "source": [
-        "##### Copyright 2019 The TensorFlow Authors."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
-        "id": "k7gifg92NbG9"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "dCMqzy7BNbG9"
-      },
-      "source": [
-        "# DeepDream"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "2yqCPS8SNbG8"
-      },
-      "source": [
-        "\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/generative/deepdream\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/generative/deepdream.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/generative/deepdream.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003eView source on GitHub\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/generative/deepdream.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/download_logo_32px.png\" /\u003eDownload notebook\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "\u003c/table\u003e"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "XPDKhwPcNbG7"
-      },
-      "source": [
-        "This tutorial contains a minimal implementation of DeepDream, as described in this [blog post](https://ai.googleblog.com/2015/06/inceptionism-going-deeper-into-neural.html) by Alexander Mordvintsev.\n",
-        "\n",
-        "DeepDream is an experiment that visualizes the patterns learned by a neural network. Similar to when a child watches clouds and tries to interpret random shapes, DeepDream over-interprets and enhances the patterns it sees in an image.\n",
-        "\n",
-        "It does so by forwarding an image through the network, then calculating the gradient of the image with respect to the activations of a particular layer. The image is then modified to increase these activations, enhancing the patterns seen by the network, and resulting in a dream-like image. This process was dubbed \"Inceptionism\" (a reference to [InceptionNet](https://arxiv.org/pdf/1409.4842.pdf), and the [movie](https://en.wikipedia.org/wiki/Inception) Inception.\n",
-        "\n",
-        "Let's demonstrate how you can make a neural network \"dream\" and enhance the surreal patterns it sees in an image.\n",
-        "\n",
-        "![Dogception](images/dogception.png)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "GUSXlFNkxrqh"
-      },
-      "outputs": [],
-      "source": [
-        "from __future__ import absolute_import, division, print_function, unicode_literals"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "Sc5Yq_Rgxreb"
-      },
-      "outputs": [],
-      "source": [
-        "try:\n",
-        "  # %tensorflow_version only exists in Colab.\n",
-        "  %tensorflow_version 2.x\n",
-        "except Exception:\n",
-        "  pass\n",
-        "import tensorflow as tf"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "g_Qp173_NbG5"
-      },
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "\n",
-        "import matplotlib as mpl\n",
-        "\n",
-        "from IPython.display import clear_output\n",
-        "from matplotlib import pyplot as plt\n",
-        "from tensorflow.keras.preprocessing import image"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "wgeIJg82NbG4"
-      },
-      "source": [
-        "## Choose an image to dream-ify"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "yt6zam_9NbG4"
-      },
-      "source": [
-        "For this tutorial, let's use an image of a [labrador](https://commons.wikimedia.org/wiki/File:YellowLabradorLooking_new.jpg)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "0lclzk9sNbG2"
-      },
-      "outputs": [],
-      "source": [
-        "url = 'https://storage.googleapis.com/download.tensorflow.org/example_images/YellowLabradorLooking_new.jpg'"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "Y5BPgc8NNbG0"
-      },
-      "outputs": [],
-      "source": [
-        "# Download an image and read it into a NumPy array.\n",
-        "def download(url, target_size=None):\n",
-        "  name = url.split('/')[-1]\n",
-        "  image_path = tf.keras.utils.get_file(name, origin=url)\n",
-        "  img = tf.keras.preprocessing.image.load_img(image_path, target_size=target_size)\n",
-        "  return img\n",
-        "\n",
-        "# Normalize an image\n",
-        "def deprocess(img):\n",
-        "  img = 255*(img + 1.0)/2.0\n",
-        "  return tf.cast(img, tf.uint8)\n",
-        "\n",
-        "\n",
-        "# Display an image\n",
-        "def show(img):\n",
-        "  plt.figure(figsize=(12,12))\n",
-        "  plt.grid(False)\n",
-        "  plt.axis('off')\n",
-        "  plt.imshow(img)\n",
-        "  plt.show()\n",
-        "\n",
-        "# Downsizing the image makes it easier to work with.\n",
-        "original_img = download(url, target_size=[225, 375])\n",
-        "original_img = np.array(original_img)\n",
-        "\n",
-        "show(original_img)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "F4RBFfIWNbG0"
-      },
-      "source": [
-        "## Prepare the feature extraction model"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "cruNQmMDNbGz"
-      },
-      "source": [
-        "Download and prepare a pre-trained image classification model. You will use [InceptionV3](https://keras.io/applications/#inceptionv3) which is similar to the model originally used in DeepDream. Note that any [pre-trained model](https://keras.io/applications/#models-for-image-classification-with-weights-trained-on-imagenet) will work, although you will have to adjust the layer names below if you change this."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "GlLi48GKNbGy"
-      },
-      "outputs": [],
-      "source": [
-        "base_model = tf.keras.applications.InceptionV3(include_top=False, weights='imagenet')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Bujb0jPNNbGx"
-      },
-      "source": [
-        "The idea in DeepDream is to choose a layer (or layers) and maximize the \"loss\" in a way that the image increasingly \"excites\" the layers. The complexity of the features incorporated depends on layers chosen by you, i.e, lower layers produce strokes or simple patterns, while deeper layers give sophisticated features in images, or even whole objects."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "qOVmDO4LNbGv"
-      },
-      "source": [
-        "The InceptionV3 architecture is quite large (for a graph of the model architecture see TensorFlow's [research repo](https://github.com/tensorflow/models/tree/master/research/inception)). For DeepDream, the layers of  interest are those where the convolutions are concatenated. There are 11 of these layers in InceptionV3, named 'mixed0' though 'mixed10'. Using different layers will result in different dream-like images. Deeper layers respond to higher-level features (such as eyes and faces), while earlier layers respond to simpler features (such as edges, shapes, and textures). Feel free to experiment with the layers selected below, but keep in mind that deeper layers (those with a higher index) will take longer to train on since the gradient computation is deeper."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "08KB502ONbGt"
-      },
-      "outputs": [],
-      "source": [
-        "# Maximize the activations of these layers\n",
-        "names = ['mixed3', 'mixed5']\n",
-        "layers = [base_model.get_layer(name).output for name in names]\n",
-        "\n",
-        "# Create the feature extraction model\n",
-        "dream_model = tf.keras.Model(inputs=base_model.input, outputs=layers)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "sb7u31B4NbGt"
-      },
-      "source": [
-        "## Calculate loss\n",
-        "\n",
-        "The loss is the sum of the activations in the chosen layers. The loss is normalizaed at each layer so the contribution from larger layers does not outweigh smaller layers. Normally, loss is a quantity you wish to minimize via gradient descent. In DeepDream, you will maximize this loss via gradient ascent."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "8MhfSweXXiuq"
-      },
-      "outputs": [],
-      "source": [
-        "def calc_loss(img, model):\n",
-        "  # Pass forward the image through the model to retrieve the activations.\n",
-        "  # Converts the image into a batch of size 1.\n",
-        "  img_batch = tf.expand_dims(img, axis=0)\n",
-        "  layer_activations = model(img_batch)\n",
-        "\n",
-        "  losses = []\n",
-        "  for act in layer_activations:\n",
-        "    loss = tf.math.reduce_mean(act)\n",
-        "    losses.append(loss)\n",
-        "\n",
-        "  return  tf.reduce_sum(losses)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "k4TCNsAUO9kI"
-      },
-      "source": [
-        "## Gradient ascent\n",
-        "\n",
-        "Once you have calculated the loss for the chosen layers, all that is left is to calculate the gradients with respect to the image, and add them to the original image. \n",
-        "\n",
-        "Adding the gradients to the image enhances the patterns seen by the network. At each step, you will have created an image that increasingly excites the activations of certain layers in the network."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "qRScWg_VNqvj"
-      },
-      "outputs": [],
-      "source": [
-        "@tf.function\n",
-        "def deepdream(model, img, step_size):\n",
-        "    with tf.GradientTape() as tape:\n",
-        "      # This needs gradients relative to `img`\n",
-        "      # `GradientTape` only watches `tf.Variable`s by default\n",
-        "      tape.watch(img)\n",
-        "      loss = calc_loss(img, model)\n",
-        "\n",
-        "    # Calculate the gradient of the loss with respect to the pixels of the input image.\n",
-        "    gradients = tape.gradient(loss, img)\n",
-        "\n",
-        "    # Normalize the gradients.\n",
-        "    gradients /= tf.math.reduce_std(gradients) + 1e-8 \n",
-        "    \n",
-        "    # In gradient ascent, the \"loss\" is maximized so that the input image increasingly \"excites\" the layers.\n",
-        "    # You can update the image by directly adding the gradients (because they're the same shape!)\n",
-        "    img = img + gradients*step_size\n",
-        "    img = tf.clip_by_value(img, -1, 1)\n",
-        "\n",
-        "    return loss, img"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "9vHEcy7dTysi"
-      },
-      "outputs": [],
-      "source": [
-        "def run_deep_dream_simple(model, img, steps=100, step_size=0.01):\n",
-        "  # Convert from uint8 to the range expected by the model.\n",
-        "  img = tf.keras.applications.inception_v3.preprocess_input(img)\n",
-        "\n",
-        "  for step in range(steps):\n",
-        "    loss, img = deepdream(model, img, step_size)\n",
-        "    \n",
-        "    if step % 100 == 0:\n",
-        "      clear_output(wait=True)\n",
-        "      show(deprocess(img))\n",
-        "      print (\"Step {}, loss {}\".format(step, loss))\n",
-        "\n",
-        "\n",
-        "  result = deprocess(img)\n",
-        "  clear_output(wait=True)\n",
-        "  show(result)\n",
-        "\n",
-        "  return result"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "tEfd00rr0j8Z"
-      },
-      "outputs": [],
-      "source": [
-        "dream_img = run_deep_dream_simple(model=dream_model, img=original_img, \n",
-        "                                  steps=800, step_size=0.001)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "2PbfXEVFNbGp"
-      },
-      "source": [
-        "## Taking it up an octave\n",
-        "\n",
-        "Pretty good, but there are a few issues with this first attempt: \n",
-        "\n",
-        "  1. The output is noisy (this could be addressed with a `tf.image.total_variation` loss).\n",
-        "  1. The image is low resolution.\n",
-        "  1. The patterns appear like they're all happening at the same granularity.\n",
-        "  \n",
-        "One approach that addresses all these problems is applying gradient ascent at different scales. This will allow patterns generated at smaller scales to be incorporated into patterns at higher scales and filled in with additional detail.\n",
-        "\n",
-        "To do this you can perform the previous gradient ascent approach, then increase the size of the image (which is reffered to as an octave), and repeat this process for multiple octaves.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "0eGDSdatLT-8"
-      },
-      "outputs": [],
-      "source": [
-        "OCTAVE_SCALE = 1.3\n",
-        "\n",
-        "img = tf.constant(np.array(original_img))\n",
-        "base_shape = tf.cast(tf.shape(img)[:-1], tf.float32)\n",
-        "\n",
-        "for n in range(3):\n",
-        "  new_shape = tf.cast(base_shape*(OCTAVE_SCALE**n), tf.int32)\n",
-        "\n",
-        "  img = tf.image.resize(img, new_shape).numpy()\n",
-        "\n",
-        "  img = run_deep_dream_simple(model=dream_model, img=img, steps=200, step_size=0.001)\n",
-        "\n",
-        "clear_output(wait=True)\n",
-        "show(img)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "s9xqyeuwLZFy"
-      },
-      "source": [
-        "## Scaling up with tiles\n",
-        "\n",
-        "One thing to consider is that as the image increases in size, so will the time and memory necessary to perform the gradient calculation. The above octave implementation will not work on very large images, or many octaves.\n",
-        "\n",
-        "To avoid this issue you can split the image into tiles and compute the gradient for each tile.\n",
-        "\n",
-        "Applying random shifts to the image before each tiled computation prevents tile seams from appearing.\n",
-        "\n",
-        "Start by implementing the random shift:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "oGgLHk7o80ac"
-      },
-      "outputs": [],
-      "source": [
-        "def random_roll(img, maxroll):\n",
-        "  # Randomly shift the image to avoid tiled boundaries.\n",
-        "  shift = tf.random.uniform(shape=[2], minval=-maxroll, maxval=maxroll, dtype=tf.int32)\n",
-        "  shift_down, shift_right = shift[0],shift[1] \n",
-        "  img_rolled = tf.roll(tf.roll(img, shift_right, axis=1), shift_down, axis=0)\n",
-        "  return shift_down, shift_right, img_rolled"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "sKsiqWfA9H41"
-      },
-      "outputs": [],
-      "source": [
-        "shift_down, shift_right, img_rolled = random_roll(np.array(original_img), 512)\n",
-        "show(img_rolled)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "tGIjA3UhhAt8"
-      },
-      "source": [
-        "Here is a tiled equivalent of the `deepdream` function defined earlier:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "x__TZ0uqNbGm"
-      },
-      "outputs": [],
-      "source": [
-        "@tf.function\n",
-        "def get_tiled_gradients(model, img, tile_size=512):\n",
-        "  shift_down, shift_right, img_rolled = random_roll(img, tile_size)\n",
-        "\n",
-        "  # Initialize the image gradients to zero.\n",
-        "  gradients = tf.zeros_like(img_rolled)\n",
-        "\n",
-        "  for x in tf.range(0, img_rolled.shape[0], tile_size):\n",
-        "    for y in tf.range(0, img_rolled.shape[1], tile_size):\n",
-        "      # Calculate the gradients for this tile.\n",
-        "      with tf.GradientTape() as tape:\n",
-        "        # This needs gradients relative to `img_rolled`.\n",
-        "        # `GradientTape` only watches `tf.Variable`s by default.\n",
-        "        tape.watch(img_rolled)\n",
-        "\n",
-        "        # Extract a tile out of the image.\n",
-        "        img_tile = img_rolled[x:x+tile_size, y:y+tile_size]\n",
-        "        loss = calc_loss(img_tile, model)\n",
-        "\n",
-        "      # Update the image gradients for this tile.\n",
-        "      gradients = gradients + tape.gradient(loss, img_rolled)\n",
-        "\n",
-        "  # Undo the random shift applied to the image and its gradients.\n",
-        "  gradients = tf.roll(tf.roll(gradients, -shift_right, axis=1), -shift_down, axis=0)\n",
-        "\n",
-        "  # Normalize the gradients.\n",
-        "  gradients /= tf.math.reduce_std(gradients) + 1e-8 \n",
-        "\n",
-        "  return gradients "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "hYnTTs_qiaND"
-      },
-      "source": [
-        "Putting this together gives a scalable, octave-aware deepdream implementation:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "gA-15DM4NbGk"
-      },
-      "outputs": [],
-      "source": [
-        "def run_deep_dream_with_octaves(model, img, steps_per_octave=100, step_size=0.01, \n",
-        "                                num_octaves=3, octave_scale=1.3):\n",
-        "  img = tf.keras.preprocessing.image.img_to_array(img)\n",
-        "  img = tf.keras.applications.inception_v3.preprocess_input(img)\n",
-        "\n",
-        "  for octave in range(num_octaves):\n",
-        "    # Scale the image based on the octave\n",
-        "    if octave\u003e0:\n",
-        "      new_size = tf.cast(tf.convert_to_tensor(img.shape[:2]), tf.float32)*octave_scale\n",
-        "      img = tf.image.resize(img, tf.cast(new_size, tf.int32))\n",
-        "\n",
-        "    for step in range(steps_per_octave):\n",
-        "      gradients = get_tiled_gradients(model, img)\n",
-        "      img = img + gradients*step_size\n",
-        "      img = tf.clip_by_value(img, -1, 1)\n",
-        "\n",
-        "      if step % 10 == 0:\n",
-        "        clear_output(wait=True)\n",
-        "        show(deprocess(img))\n",
-        "        print (\"Octave {}, Step {}\".format(octave, step))\n",
-        "    \n",
-        "  clear_output(wait=True)\n",
-        "  result = deprocess(img)\n",
-        "  show(result)\n",
-        "\n",
-        "  return result"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "T7PbRLV74RrU"
-      },
-      "outputs": [],
-      "source": [
-        "dream_img = run_deep_dream_with_octaves(model=dream_model, img=original_img, step_size=0.01)\n",
-        "\n",
-        "clear_output()\n",
-        "show(original_img)\n",
-        "show(dream_img)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "0Og0-qLwNbGg"
-      },
-      "source": [
-        "Much better! Play around with the number of octaves, octave scale, and activated layers to change how your DeepDream-ed image looks.\n",
-        "\n",
-        "Readers might also be interested in [TensorFlow Lucid](https://github.com/tensorflow/lucid) which expands on ideas introduced in this tutorial to visualize and interpret neural networks."
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [],
-      "last_runtime": {
-        "build_target": "//research/colab/notebook:notebook_backend",
-        "kind": "private"
-      },
-      "name": "deepdream.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "1SgrstLXNbG_"
+   },
+   "source": [
+    "##### Copyright 2019 The TensorFlow Authors."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "cellView": "form",
+    "colab": {},
+    "colab_type": "code",
+    "id": "k7gifg92NbG9"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "dCMqzy7BNbG9"
+   },
+   "source": [
+    "# DeepDream"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "2yqCPS8SNbG8"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/generative/deepdream\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/generative/deepdream.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/generative/deepdream.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/generative/deepdream.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "XPDKhwPcNbG7"
+   },
+   "source": [
+    "This tutorial contains a minimal implementation of DeepDream, as described in this [blog post](https://ai.googleblog.com/2015/06/inceptionism-going-deeper-into-neural.html) by Alexander Mordvintsev.\n",
+    "\n",
+    "DeepDream is an experiment that visualizes the patterns learned by a neural network. Similar to when a child watches clouds and tries to interpret random shapes, DeepDream over-interprets and enhances the patterns it sees in an image.\n",
+    "\n",
+    "It does so by forwarding an image through the network, then calculating the gradient of the image with respect to the activations of a particular layer. The image is then modified to increase these activations, enhancing the patterns seen by the network, and resulting in a dream-like image. This process was dubbed \"Inceptionism\" (a reference to [InceptionNet](https://arxiv.org/pdf/1409.4842.pdf), and the [movie](https://en.wikipedia.org/wiki/Inception) Inception.\n",
+    "\n",
+    "Let's demonstrate how you can make a neural network \"dream\" and enhance the surreal patterns it sees in an image.\n",
+    "\n",
+    "![Dogception](images/dogception.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "GUSXlFNkxrqh"
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import absolute_import, division, print_function, unicode_literals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Sc5Yq_Rgxreb"
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "  # %tensorflow_version only exists in Colab.\n",
+    "  %tensorflow_version 2.x\n",
+    "except Exception:\n",
+    "  pass\n",
+    "import tensorflow as tf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "g_Qp173_NbG5"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "import matplotlib as mpl\n",
+    "\n",
+    "from IPython.display import clear_output\n",
+    "from matplotlib import pyplot as plt\n",
+    "from tensorflow.keras.preprocessing import image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "wgeIJg82NbG4"
+   },
+   "source": [
+    "## Choose an image to dream-ify"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "yt6zam_9NbG4"
+   },
+   "source": [
+    "For this tutorial, let's use an image of a [labrador](https://commons.wikimedia.org/wiki/File:YellowLabradorLooking_new.jpg)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "0lclzk9sNbG2"
+   },
+   "outputs": [],
+   "source": [
+    "url = 'https://storage.googleapis.com/download.tensorflow.org/example_images/YellowLabradorLooking_new.jpg'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Y5BPgc8NNbG0"
+   },
+   "outputs": [],
+   "source": [
+    "# Download an image and read it into a NumPy array.\n",
+    "def download(url, target_size=None):\n",
+    "  name = url.split('/')[-1]\n",
+    "  image_path = tf.keras.utils.get_file(name, origin=url)\n",
+    "  img = tf.keras.preprocessing.image.load_img(image_path, target_size=target_size)\n",
+    "  return img\n",
+    "\n",
+    "# Normalize an image\n",
+    "def deprocess(img):\n",
+    "  img = 255*(img + 1.0)/2.0\n",
+    "  return tf.cast(img, tf.uint8)\n",
+    "\n",
+    "\n",
+    "# Display an image\n",
+    "def show(img):\n",
+    "  plt.figure(figsize=(12,12))\n",
+    "  plt.grid(False)\n",
+    "  plt.axis('off')\n",
+    "  plt.imshow(img)\n",
+    "  plt.show()\n",
+    "\n",
+    "# Downsizing the image makes it easier to work with.\n",
+    "original_img = download(url, target_size=[225, 375])\n",
+    "original_img = np.array(original_img)\n",
+    "\n",
+    "show(original_img)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "F4RBFfIWNbG0"
+   },
+   "source": [
+    "## Prepare the feature extraction model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "cruNQmMDNbGz"
+   },
+   "source": [
+    "Download and prepare a pre-trained image classification model. You will use [InceptionV3](https://keras.io/applications/#inceptionv3) which is similar to the model originally used in DeepDream. Note that any [pre-trained model](https://keras.io/applications/#models-for-image-classification-with-weights-trained-on-imagenet) will work, although you will have to adjust the layer names below if you change this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "GlLi48GKNbGy"
+   },
+   "outputs": [],
+   "source": [
+    "base_model = tf.keras.applications.InceptionV3(include_top=False, weights='imagenet')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Bujb0jPNNbGx"
+   },
+   "source": [
+    "The idea in DeepDream is to choose a layer (or layers) and maximize the \"loss\" in a way that the image increasingly \"excites\" the layers. The complexity of the features incorporated depends on layers chosen by you, i.e, lower layers produce strokes or simple patterns, while deeper layers give sophisticated features in images, or even whole objects."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "qOVmDO4LNbGv"
+   },
+   "source": [
+    "The InceptionV3 architecture is quite large (for a graph of the model architecture see TensorFlow's [research repo](https://github.com/tensorflow/models/tree/master/research/inception)). For DeepDream, the layers of  interest are those where the convolutions are concatenated. There are 11 of these layers in InceptionV3, named 'mixed0' though 'mixed10'. Using different layers will result in different dream-like images. Deeper layers respond to higher-level features (such as eyes and faces), while earlier layers respond to simpler features (such as edges, shapes, and textures). Feel free to experiment with the layers selected below, but keep in mind that deeper layers (those with a higher index) will take longer to train on since the gradient computation is deeper."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "08KB502ONbGt"
+   },
+   "outputs": [],
+   "source": [
+    "# Maximize the activations of these layers\n",
+    "names = ['mixed3', 'mixed5']\n",
+    "\n",
+    "# Grab the outputs of the above layers\n",
+    "layers = [base_model.get_layer(name).output for name in names]\n",
+    "\n",
+    "# Create the feature extraction model\n",
+    "dream_model = tf.keras.Model(inputs=base_model.input, outputs=layers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "sb7u31B4NbGt"
+   },
+   "source": [
+    "## Calculate loss\n",
+    "\n",
+    "The loss is the sum of the activations in the chosen layers. The loss is normalizaed at each layer so the contribution from larger layers does not outweigh smaller layers. Normally, loss is a quantity you wish to minimize via gradient descent. In DeepDream, you will maximize this loss via gradient ascent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "8MhfSweXXiuq"
+   },
+   "outputs": [],
+   "source": [
+    "def calc_loss(img, model):\n",
+    "  # Pass forward the image through the model to retrieve the activations.\n",
+    "  # Add a batch dimension to the image\n",
+    "  img_batch = tf.expand_dims(img, axis=0)\n",
+    "\n",
+    "  layer_activations = model(img_batch)\n",
+    "\n",
+    "  losses = []\n",
+    "  for act in layer_activations:\n",
+    "    loss = tf.math.reduce_mean(act)\n",
+    "    losses.append(loss)\n",
+    "\n",
+    "  return  tf.reduce_sum(losses)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "k4TCNsAUO9kI"
+   },
+   "source": [
+    "## Gradient ascent\n",
+    "\n",
+    "Once you have calculated the loss for the chosen layers, all that is left is to calculate the gradients with respect to the image, and add them to the original image. \n",
+    "\n",
+    "Adding the gradients to the image enhances the patterns seen by the network. At each step, you will have created an image that increasingly excites the activations of certain layers in the network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "qRScWg_VNqvj"
+   },
+   "outputs": [],
+   "source": [
+    "@tf.function\n",
+    "def deepdream(model, img, step_size):\n",
+    "    with tf.GradientTape() as tape:\n",
+    "      # This needs gradients relative to `img`\n",
+    "      # `GradientTape` only watches `tf.Variable`s by default\n",
+    "      tape.watch(img)\n",
+    "      loss = calc_loss(img, model)\n",
+    "\n",
+    "    # Calculate the gradient of the loss with respect to the pixels of the input image.\n",
+    "    gradients = tape.gradient(loss, img)\n",
+    "\n",
+    "    # Normalize the gradients.\n",
+    "    gradients /= tf.math.reduce_std(gradients) + 1e-8 \n",
+    "    \n",
+    "    # In gradient ascent, the \"loss\" is maximized so that the input image increasingly \"excites\" the layers.\n",
+    "    # You can update the image by directly adding the gradients (because they're the same shape!)\n",
+    "    img = img + gradients*step_size\n",
+    "    img = tf.clip_by_value(img, -1, 1)\n",
+    "\n",
+    "    return loss, img"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "9vHEcy7dTysi"
+   },
+   "outputs": [],
+   "source": [
+    "def run_deep_dream_simple(model, img, steps=100, step_size=0.01):\n",
+    "  # Convert from uint8 to the range expected by the model.\n",
+    "  img = tf.keras.applications.inception_v3.preprocess_input(img)\n",
+    "\n",
+    "  for step in range(steps):\n",
+    "    loss, img = deepdream(model, img, step_size)\n",
+    "    \n",
+    "    # Logging\n",
+    "    if step % 100 == 0:\n",
+    "      clear_output(wait=True)\n",
+    "      show(deprocess(img))\n",
+    "      print (\"Step {}, loss {}\".format(step, loss))\n",
+    "\n",
+    "  result = deprocess(img)\n",
+    "  clear_output(wait=True)\n",
+    "  show(result)\n",
+    "\n",
+    "  return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "tEfd00rr0j8Z"
+   },
+   "outputs": [],
+   "source": [
+    "dream_img = run_deep_dream_simple(model=dream_model, img=original_img, \n",
+    "                                  steps=800, step_size=0.001)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "2PbfXEVFNbGp"
+   },
+   "source": [
+    "## Taking it up an octave\n",
+    "\n",
+    "Pretty good, but there are a few issues with this first attempt: \n",
+    "\n",
+    "  1. The output is noisy (this could be addressed with a `tf.image.total_variation` loss).\n",
+    "  1. The image is low resolution.\n",
+    "  1. The patterns appear like they're all happening at the same granularity.\n",
+    "  \n",
+    "One approach that addresses all these problems is applying gradient ascent at different scales. This will allow patterns generated at smaller scales to be incorporated into patterns at higher scales and filled in with additional detail.\n",
+    "\n",
+    "To do this you can perform the previous gradient ascent approach, then increase the size of the image (which is reffered to as an octave), and repeat this process for multiple octaves.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "0eGDSdatLT-8"
+   },
+   "outputs": [],
+   "source": [
+    "OCTAVE_SCALE = 1.3\n",
+    "\n",
+    "img = tf.constant(original_img)\n",
+    "base_shape = tf.cast(tf.shape(img)[:-1], tf.float32)\n",
+    "\n",
+    "for n in range(3):\n",
+    "  new_shape = tf.cast(base_shape*(OCTAVE_SCALE**n), tf.int32)\n",
+    "\n",
+    "  img = tf.image.resize(img, new_shape).numpy()\n",
+    "\n",
+    "  img = run_deep_dream_simple(model=dream_model, img=img, steps=200, step_size=0.001)\n",
+    "\n",
+    "clear_output(wait=True)\n",
+    "show(img)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "s9xqyeuwLZFy"
+   },
+   "source": [
+    "## Scaling up with tiles\n",
+    "\n",
+    "One thing to consider is that as the image increases in size, so will the time and memory necessary to perform the gradient calculation. The above octave implementation will not work on very large images, or many octaves.\n",
+    "\n",
+    "To avoid this issue you can split the image into tiles and compute the gradient for each tile.\n",
+    "\n",
+    "Applying random shifts to the image before each tiled computation prevents tile seams from appearing.\n",
+    "\n",
+    "Start by implementing the random shift:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "oGgLHk7o80ac"
+   },
+   "outputs": [],
+   "source": [
+    "def random_roll(img, maxroll):\n",
+    "  # Randomly shift the image to avoid tiled boundaries.\n",
+    "  shift = tf.random.uniform(shape=[2], minval=-maxroll, maxval=maxroll, dtype=tf.int32)\n",
+    "  shift_down, shift_right = shift[0],shift[1] \n",
+    "  img_rolled = tf.roll(tf.roll(img, shift_right, axis=1), shift_down, axis=0)\n",
+    "  return shift_down, shift_right, img_rolled"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "sKsiqWfA9H41"
+   },
+   "outputs": [],
+   "source": [
+    "shift_down, shift_right, img_rolled = random_roll(original_img, 512)\n",
+    "show(img_rolled)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "tGIjA3UhhAt8"
+   },
+   "source": [
+    "Here is a tiled equivalent of the `deepdream` function defined earlier:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "x__TZ0uqNbGm"
+   },
+   "outputs": [],
+   "source": [
+    "@tf.function\n",
+    "def get_tiled_gradients(model, img, tile_size=512):\n",
+    "  shift_down, shift_right, img_rolled = random_roll(img, tile_size)\n",
+    "\n",
+    "  # Initialize the image gradients to zero.\n",
+    "  gradients = tf.zeros_like(img_rolled)\n",
+    "\n",
+    "  for x in tf.range(0, img_rolled.shape[0], tile_size):\n",
+    "    for y in tf.range(0, img_rolled.shape[1], tile_size):\n",
+    "      # Calculate the gradients for this tile.\n",
+    "      with tf.GradientTape() as tape:\n",
+    "        # This needs gradients relative to `img_rolled`.\n",
+    "        # `GradientTape` only watches `tf.Variable`s by default.\n",
+    "        tape.watch(img_rolled)\n",
+    "\n",
+    "        # Extract a tile out of the image.\n",
+    "        img_tile = img_rolled[x:x+tile_size, y:y+tile_size]\n",
+    "        loss = calc_loss(img_tile, model)\n",
+    "\n",
+    "      # Update the image gradients for this tile.\n",
+    "      gradients = gradients + tape.gradient(loss, img_rolled)\n",
+    "\n",
+    "  # Undo the random shift applied to the image and its gradients.\n",
+    "  gradients = tf.roll(tf.roll(gradients, -shift_right, axis=1), -shift_down, axis=0)\n",
+    "\n",
+    "  # Normalize the gradients.\n",
+    "  gradients /= tf.math.reduce_std(gradients) + 1e-8 \n",
+    "\n",
+    "  return gradients "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "hYnTTs_qiaND"
+   },
+   "source": [
+    "Putting this together gives a scalable, octave-aware deepdream implementation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "gA-15DM4NbGk"
+   },
+   "outputs": [],
+   "source": [
+    "def run_deep_dream_with_octaves(model, img, steps_per_octave=100, step_size=0.01, \n",
+    "                                num_octaves=3, octave_scale=1.3):\n",
+    "  img = tf.keras.preprocessing.image.img_to_array(img)\n",
+    "  img = tf.keras.applications.inception_v3.preprocess_input(img)\n",
+    "\n",
+    "  for octave in range(num_octaves):\n",
+    "    # Scale the image based on the octave\n",
+    "    if octave>0:\n",
+    "      new_size = tf.cast(tf.convert_to_tensor(img.shape[:2]), tf.float32)*octave_scale\n",
+    "      img = tf.image.resize(img, tf.cast(new_size, tf.int32))\n",
+    "\n",
+    "    for step in range(steps_per_octave):\n",
+    "      gradients = get_tiled_gradients(model, img)\n",
+    "      img = img + gradients*step_size\n",
+    "      img = tf.clip_by_value(img, -1, 1)\n",
+    "\n",
+    "      if step % 10 == 0:\n",
+    "        clear_output(wait=True)\n",
+    "        show(deprocess(img))\n",
+    "        print (\"Octave {}, Step {}\".format(octave, step))\n",
+    "    \n",
+    "  clear_output(wait=True)\n",
+    "  result = deprocess(img)\n",
+    "  show(result)\n",
+    "\n",
+    "  return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "T7PbRLV74RrU"
+   },
+   "outputs": [],
+   "source": [
+    "dream_img = run_deep_dream_with_octaves(model=dream_model, img=original_img, step_size=0.01)\n",
+    "\n",
+    "clear_output()\n",
+    "show(original_img)\n",
+    "show(dream_img)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "0Og0-qLwNbGg"
+   },
+   "source": [
+    "Much better! Play around with the number of octaves, octave scale, and activated layers to change how your DeepDream-ed image looks.\n",
+    "\n",
+    "Readers might also be interested in [TensorFlow Lucid](https://github.com/tensorflow/lucid) which expands on ideas introduced in this tutorial to visualize and interpret neural networks."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "last_runtime": {
+    "build_target": "//research/colab/notebook:notebook_backend",
+    "kind": "private"
+   },
+   "name": "deepdream.ipynb",
+   "private_outputs": true,
+   "provenance": [],
+   "toc_visible": true,
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/site/en/tutorials/keras/save_and_load.ipynb
+++ b/site/en/tutorials/keras/save_and_load.ipynb
@@ -554,8 +554,9 @@
       },
       "source": [
         "The above code stores the weights to a collection of [checkpoint](https://www.tensorflow.org/guide/saved_model#save_and_restore_variables)-formatted files that contain only the trained weights in a binary format. Checkpoints contain:\n",
-        "* One or more shards that contain your model's weights.\n",
-        "* An index file that indicates which weights are stored in a which shard.\n",
+        "\n",
+        "- One or more shards that contain your model's weights.\n",
+        "- An index file that indicates which weights are stored in a which shard.\n",
         "\n",
         "If you are only training a model on a single machine, you'll have one shard with the suffix: `.data-00000-of-00001`"
       ]


### PR DESCRIPTION
Hi. 

I found [the tutorial on Deep Dream](https://www.tensorflow.org/tutorials/generative/deepdream) really interesting. It not only presents with the vanilla implementation but also introduces more complex topics like octaves, tiling very elegantly. 

However, I found two occurrences where I felt that the use of `np.array` is redundant. Towards the very beginning, while loading our image, we are already doing it. Also, I have removed some unnecessary spaces to keep it more compact. 