### PR TITLE
fix broken link to tf.keras.callbacks.EarlySopping

### DIFF
--- a/site/en/tutorials/keras/regression.ipynb
+++ b/site/en/tutorials/keras/regression.ipynb
@@ -702,7 +702,7 @@
       "source": [
         "This graph shows little improvement, or even degradation in the validation error after about 100 epochs. Let's update the `model.fit` call to automatically stop training when the validation score doesn't improve. We'll use an *EarlyStopping callback* that tests a training condition for  every epoch. If a set amount of epochs elapses without showing improvement, then automatically stop the training.\n",
         "\n",
-        "You can learn more about this callback [here](https://www.tensorflow.org/versions/master/api_docs/python/tf/keras/callbacks/EarlyStopping)."
+        "You can learn more about this callback [here](https://www.tensorflow.org/api_docs/python/tf/keras/callbacks/EarlyStopping)."
       ]
     },
     {


### PR DESCRIPTION
Only fix the URL of [tf.keras.callbacks.EarlyStopping](https://www.tensorflow.org/api_docs/python/tf/keras/callbacks/EarlyStopping) 