### PR TITLE
Fixed typos. Fixed and enhanced conflicting instructions.

### DIFF
--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -52,7 +52,7 @@ file under `REQUIRED_PACKAGES`.
 [Install Bazel](https://docs.bazel.build/versions/master/install.html){:.external},
 the build tool used to compile TensorFlow.
 
-To avoid errors, [check out](#tested_build_configurations) which version of bazel has been tested with the tensorflow version and your gpu cnofiguration. 
+To avoid errors, [check out](#tested_build_configurations) which version of bazel has been tested with the tensorflow version and your gpu cnofiguration.
 
 Add the location of the Bazel executable to your `PATH` environment variable.
 
@@ -228,7 +228,7 @@ tensorflow:master repo has been updated to build 2.x by default.
 bazel build //tensorflow/tools/pip_package:build_pip_package
 </pre>
 
-Note: For GPU support, enable CUDA during the `./configure` stage.
+Note: For GPU support, enable CUDA with `cuda=Y` during the `./configure` stage.
 
 ### TensorFlow 1.x
 

--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -52,7 +52,7 @@ file under `REQUIRED_PACKAGES`.
 [Install Bazel](https://docs.bazel.build/versions/master/install.html){:.external},
 the build tool used to compile TensorFlow.
 
-To avoid errors, [check out](#tested_build_configurations) which version of bazel has been tested with the tensorflow version and your gpu cnofiguration.
+Refer to this [table](#tested_build_configurations) to know which versions of Bazel have been tested with your TensorFlow version and system configuration.
 
 Add the location of the Bazel executable to your `PATH` environment variable.
 
@@ -420,7 +420,8 @@ Install and verify the package within the container and check for a GPU:
 Success: TensorFlow is now installed.
 
 
-##<a name="tested_build_configurations"></a> Tested build configurations
+<a name="tested_build_configurations"></a>
+## Tested build configurations
 
 ### Linux
 

--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -52,6 +52,8 @@ file under `REQUIRED_PACKAGES`.
 [Install Bazel](https://docs.bazel.build/versions/master/install.html){:.external},
 the build tool used to compile TensorFlow.
 
+To avoid errors, [check out](#tested_build_configurations) which version of bazel has been tested with the tensorflow version and your gpu cnofiguration. 
+
 Add the location of the Bazel executable to your `PATH` environment variable.
 
 Note: To build TensorFlow, the Bazel version must conform to the minimum and maximum
@@ -418,7 +420,7 @@ Install and verify the package within the container and check for a GPU:
 Success: TensorFlow is now installed.
 
 
-## Tested build configurations
+##<a name="tested_build_configurations"></a> Tested build configurations
 
 ### Linux
 

--- a/site/en/install/source_rpi.md
+++ b/site/en/install/source_rpi.md
@@ -89,4 +89,4 @@ Raspberry Pi and install with `pip`:
 pip install tensorflow-<var>version</var>-cp34-none-linux_armv7l.whl
 </pre>
 
-Success: TensorFlow is now installed on Raspian.
+Success: TensorFlow is now installed on Raspbian.

--- a/site/en/install/source_windows.md
+++ b/site/en/install/source_windows.md
@@ -274,7 +274,9 @@ For GPU support, add the CUDA and cuDNN bin directories to your `$PATH`:
 <code class="devsite-terminal">export PATH="/c/tools/cuda/bin:$PATH"</code>
 </pre>
 
+
 ##<a name=tested_build_configurations></a> Tested build configurations
+
 ### CPU
 
 <table>

--- a/site/en/install/source_windows.md
+++ b/site/en/install/source_windows.md
@@ -36,7 +36,7 @@ the build tool used to compile TensorFlow. Set up Bazel to
 
 Add the location of the Bazel executable to your `%PATH%` environment variable.
 
-Ensure that your version of Bazel is tested with the TensorFlow version [here.](#tested_build_configurations)
+Ensure that your version of Bazel uses a [tested build configuration](#tested_build_configurations) of TensorFlow.
 
 ### Install MSYS2
 

--- a/site/en/install/source_windows.md
+++ b/site/en/install/source_windows.md
@@ -275,7 +275,7 @@ For GPU support, add the CUDA and cuDNN bin directories to your `$PATH`:
 </pre>
 
 
-<a name=tested_build_configurations></a>
+<a name="tested_build_configurations"></a>
 ## Tested build configurations
 
 ### CPU

--- a/site/en/install/source_windows.md
+++ b/site/en/install/source_windows.md
@@ -36,7 +36,7 @@ the build tool used to compile TensorFlow. Set up Bazel to
 
 Add the location of the Bazel executable to your `%PATH%` environment variable.
 
-Ensure that your version of Bazel is tested with the tensorflow version [here.](#tested_build_configurations)
+Ensure that your version of Bazel is tested with the TensorFlow version [here.](#tested_build_configurations)
 
 ### Install MSYS2
 
@@ -275,7 +275,8 @@ For GPU support, add the CUDA and cuDNN bin directories to your `$PATH`:
 </pre>
 
 
-##<a name=tested_build_configurations></a> Tested build configurations
+<a name=tested_build_configurations></a>
+## Tested build configurations
 
 ### CPU
 

--- a/site/en/install/source_windows.md
+++ b/site/en/install/source_windows.md
@@ -36,7 +36,7 @@ the build tool used to compile TensorFlow. Set up Bazel to
 
 Add the location of the Bazel executable to your `%PATH%` environment variable.
 
-Ensure you install Bazel 0.23.0 or lower.
+Ensure that your version of Bazel is tested with the tensorflow version [here.](#tested_build_configurations)
 
 ### Install MSYS2
 
@@ -112,7 +112,7 @@ python ./configure.py
 Starting local Bazel server and connecting to it...
 ................
 You have bazel 0.15.0 installed.
-Please specify the location of python. [Default is C:\python36\python.exe]: 
+Please specify the location of python. [Default is C:\python36\python.exe]:
 
 Found possible Python library paths:
   C:\python36\lib\site-packages
@@ -133,7 +133,7 @@ Please specify a list of comma-separated Cuda compute capabilities you want to b
 You can find the compute capability of your device at: https://developer.nvidia.com/cuda-gpus.
 Please note that each additional compute capability significantly increases your build time and binary size. [Default is: 3.5,7.0]: <b>3.7</b>
 
-Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is /arch:AVX]: 
+Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is /arch:AVX]:
 
 Would you like to override eigen strong inline for some C++ compilation to reduce the compilation time? [Y/n]:
 Eigen strong inline overridden.
@@ -195,7 +195,7 @@ bazel build --config=opt --config=cuda --define=no_tensorflow_py_deps=true //ten
 #### Bazel build options
 
 Use this option when building to avoid issue with package creation:
-https://github.com/tensorflow/tensorflow/issues/22390
+[tensorflow:issue#22390](https://github.com/tensorflow/tensorflow/issues/22390)
 
 <pre class="devsite-terminal tfo-terminal-windows devsite-click-to-copy">
 --define=no_tensorflow_py_deps=true
@@ -274,9 +274,7 @@ For GPU support, add the CUDA and cuDNN bin directories to your `$PATH`:
 <code class="devsite-terminal">export PATH="/c/tools/cuda/bin:$PATH"</code>
 </pre>
 
-
-## Tested build configurations
-
+##<a name=tested_build_configurations></a> Tested build configurations
 ### CPU
 
 <table>


### PR DESCRIPTION
Fixed typos and updated instructions in source, source_windows source_rpi. 
Fixed typo: Raspian -> Raspbian (source_rpi)
Fixed conflicting instruction in source_windows regarding bazel installation version, (link provided was 0.24.1 while the instructions said the build version should be 0.23.0 or lower) 
Added links to the tested configurations to see compatible bazel versions in source_windows.md and source.md . 