### PR TITLE
Update parse_fn as per tf 2.0 apis

### DIFF
--- a/site/en/guide/data_performance.md
+++ b/site/en/guide/data_performance.md
@@ -49,11 +49,11 @@ image-label pairs suitable for training. The input pipeline is represented as a
 def parse_fn(example):
   "Parse TFExample records and perform simple data augmentation."
   example_fmt = {
-    "image": tf.FixedLengthFeature((), tf.string, ""),
-    "label": tf.FixedLengthFeature((), tf.int64, -1)
+    "image": tf.io.FixedLenFeature([], tf.string, ""),
+    "label": tf.io.FixedLenFeature([], tf.int64, -1)
   }
-  parsed = tf.parse_single_example(example, example_fmt)
-  image = tf.io.image.decode_image(parsed["image"])
+  parsed = tf.io.parse_single_example(example, example_fmt)
+  image = tf.io.decode_image(parsed["image"])
   image = _augment_helper(image)  # augments image using slice, reshape, resize_bilinear
   return image, parsed["label"]
 


### PR DESCRIPTION
Following changes will apply as per tf 2.0:
+  ```tf.FixedLengthFeature((), tf.string, "")``` to ```tf.io.FixedLenFeature([], tf.string, "")```
+  ```tf.parse_single_example(example, example_fmt)``` to ```tf.io.parse_single_example(example, example_fmt)```
+  ```tf.io.image.decode_image(parsed["image"])``` to ```tf.io.decode_image(parsed["image"])```

For reference, see here: 
+  https://www.tensorflow.org/api_docs/python/tf/io/parse_single_example
+  https://www.tensorflow.org/api_docs/python/tf/io/FixedLenFeature
+  https://www.tensorflow.org/api_docs/python/tf/io/decode_image