### PR TITLE
Fixed typos and removed empty print() call

### DIFF
--- a/site/en/guide/saved_model.ipynb
+++ b/site/en/guide/saved_model.ipynb
@@ -186,7 +186,6 @@
       "source": [
         "pretrained_model = tf.keras.applications.MobileNet()\n",
         "result_before_save = pretrained_model(x)\n",
-        "print()\n",
         "\n",
         "decoded = imagenet_labels[np.argsort(result_before_save)[0,::-1][:5]+1]\n",
         "\n",
@@ -758,7 +757,7 @@
       "source": [
         "### Basic fine-tuning\n",
         "\n",
-        "Variable objects are available, and we can backprop through imported functions. That is enough to fine-tune (i.e, retrain) a SavedModel in simple cases."
+        "Variable objects are available, and we can backprop through imported functions. That is enough to fine-tune (i.e. retrain) a SavedModel in simple cases."
       ]
     },
     {


### PR DESCRIPTION
Fixed typos and removed empty `print()` call