### PR TITLE
Fix typo in custom metric name

### DIFF
--- a/site/en/guide/keras/train_and_evaluate.ipynb
+++ b/site/en/guide/keras/train_and_evaluate.ipynb
@@ -482,7 +482,7 @@
         "\n",
         "State update and results computation are kept separate (in `update_state()` and `result()`, respectively) because in some cases, results computation might be very expensive, and would only be done periodically.\n",
         "\n",
-        "Here's a simple example showing how to implement a `CatgoricalTruePositives` metric, that counts how many samples where correctly classified as belonging to a given class:"
+        "Here's a simple example showing how to implement a `CategoricalTruePositives` metric, that counts how many samples where correctly classified as belonging to a given class:"
       ]
     },
     {
@@ -495,10 +495,10 @@
       },
       "outputs": [],
       "source": [
-        "class CatgoricalTruePositives(keras.metrics.Metric):\n",
+        "class CategoricalTruePositives(keras.metrics.Metric):\n",
         "\n",
         "    def __init__(self, name='categorical_true_positives', **kwargs):\n",
-        "      super(CatgoricalTruePositives, self).__init__(name=name, **kwargs)\n",
+        "      super(CategoricalTruePositives, self).__init__(name=name, **kwargs)\n",
         "      self.true_positives = self.add_weight(name='tp', initializer='zeros')\n",
         "\n",
         "    def update_state(self, y_true, y_pred, sample_weight=None):\n",
@@ -520,7 +520,7 @@
         "\n",
         "model.compile(optimizer=keras.optimizers.RMSprop(learning_rate=1e-3),\n",
         "              loss=keras.losses.SparseCategoricalCrossentropy(),\n",
-        "              metrics=[CatgoricalTruePositives()])\n",
+        "              metrics=[CategoricalTruePositives()])\n",
         "model.fit(x_train, y_train,\n",
         "          batch_size=64,\n",
         "          epochs=3)\n"


### PR DESCRIPTION
I've spotted this (probably unintended) typo on https://www.tensorflow.org/guide/keras/train_and_evaluate