### PR TITLE
JA: add lite/guide/build_arm64.md

### DIFF
--- a/site/ja/lite/guide/build_arm64.md
+++ b/site/ja/lite/guide/build_arm64.md
@@ -1,0 +1,78 @@
+# Build TensorFlow Lite for ARM64 boards
+
+This page describes how to build the TensorFlow Lite static library for
+ARM64-based computers. If you just want to start using TensorFlow Lite to
+execute your models, the fastest option is to install the TensorFlow Lite
+runtime package as shown in the [Python quickstart](python.md).
+
+Note: This page shows how to compile only the C++ static library for
+TensorFlow Lite. Alternative install options include: [install just the Python
+interpreter API](python.md) (for inferencing only); [install the full
+TensorFlow package from pip](https://www.tensorflow.org/install/pip);
+or [build the full TensorFlow package](
+https://www.tensorflow.org/install/source).
+
+## Cross-compile for ARM64
+
+To ensure the proper build environment, we recommend using one of our TensorFlow
+Docker images such as [tensorflow/tensorflow:nightly-devel](
+https://hub.docker.com/r/tensorflow/tensorflow/tags/).
+
+To get started, install the toolchain and libs:
+
+```bash
+sudo apt-get update
+sudo apt-get install crossbuild-essential-arm64
+```
+
+If you are using Docker, you may not use `sudo`.
+
+Now git-clone the TensorFlow repository
+(`https://github.com/tensorflow/tensorflow`)—if you're using the TensorFlow
+Docker image, the repo is already provided in `/tensorflow_src/`—and then run
+this script at the root of the TensorFlow repository to download all the
+build dependencies:
+
+```bash
+./tensorflow/lite/tools/make/download_dependencies.sh
+```
+
+Note that you only need to do this once.
+
+Then compile:
+
+```bash
+./tensorflow/lite/tools/make/build_aarch64_lib.sh
+```
+
+This should compile a static library in:
+`tensorflow/lite/tools/make/gen/aarch64_armv8-a/lib/libtensorflow-lite.a`.
+
+## Compile natively on ARM64
+
+These steps were tested on HardKernel Odroid C2, gcc version 5.4.0.
+
+Log in to your board and install the toolchain:
+
+```bash
+sudo apt-get install build-essential
+```
+
+Now git-clone the TensorFlow repository
+(`https://github.com/tensorflow/tensorflow`) and run this at the root of
+the repository:
+
+```bash
+./tensorflow/lite/tools/make/download_dependencies.sh
+```
+
+Note that you only need to do this once.
+
+Then compile:
+
+```bash
+./tensorflow/lite/tools/make/build_aarch64_lib.sh
+```
+
+This should compile a static library in:
+`tensorflow/lite/tools/make/gen/aarch64_armv8-a/lib/libtensorflow-lite.a`.

--- a/site/ja/lite/guide/build_arm64.md
+++ b/site/ja/lite/guide/build_arm64.md
@@ -1,78 +1,82 @@
-# Build TensorFlow Lite for ARM64 boards
+# TensorFlow LiteをARM64基板用にビルドする
 
-This page describes how to build the TensorFlow Lite static library for
-ARM64-based computers. If you just want to start using TensorFlow Lite to
-execute your models, the fastest option is to install the TensorFlow Lite
-runtime package as shown in the [Python quickstart](python.md).
+このページではTensorFlow Liteの静的ライブラリを
+ARM64ベースのコンピュータ用にビルドする方法を説明します。
+あなたが単にTensorFlow Liteを使ってあなたのモデルを実行したいのでしたら、
+一番早いのはTensorFlow Lite実行時パッケージを
+[Python quickstart](python.md)に
+示したようにインストールすることです。
 
-Note: This page shows how to compile only the C++ static library for
-TensorFlow Lite. Alternative install options include: [install just the Python
-interpreter API](python.md) (for inferencing only); [install the full
-TensorFlow package from pip](https://www.tensorflow.org/install/pip);
-or [build the full TensorFlow package](
-https://www.tensorflow.org/install/source).
+付記: このページで示すのは、TensorFlow Lite用のC++静的ライブラリの
+コンパイル方法のみです。
+代わりのインストールの選択肢としては:
+(推論のためだけに)[PythonインタープリタAPIのみをインストールする](python.md);
+[pipからフルのTensorFlowパッケージをインストールする](https://www.tensorflow.org/install/pip);
+または[フルのTensorFlowパッケージをビルドする](
+https://www.tensorflow.org/install/source)などです。
 
-## Cross-compile for ARM64
+## ARM64用にクロスコンパイルする
 
-To ensure the proper build environment, we recommend using one of our TensorFlow
-Docker images such as [tensorflow/tensorflow:nightly-devel](
-https://hub.docker.com/r/tensorflow/tensorflow/tags/).
+ビルド環境が適切であることを確かめるために、私たちのTensorFlowの
+Dockerイメージのうちのどれか、例えば[tensorflow/tensorflow:nightly-devel](
+https://hub.docker.com/r/tensorflow/tensorflow/tags/)をお勧めします。
 
-To get started, install the toolchain and libs:
+始めるためには、ツールチェインとライブラリ群をインストールします:
 
 ```bash
 sudo apt-get update
 sudo apt-get install crossbuild-essential-arm64
 ```
 
-If you are using Docker, you may not use `sudo`.
+Dockerを使っている場合は、`sudo`は使えません。
 
-Now git-clone the TensorFlow repository
-(`https://github.com/tensorflow/tensorflow`)—if you're using the TensorFlow
-Docker image, the repo is already provided in `/tensorflow_src/`—and then run
-this script at the root of the TensorFlow repository to download all the
-build dependencies:
+そしてthe TensorFlowリポジトリ
+(`https://github.com/tensorflow/tensorflow`)をgit-cloneしてください
+—あなたがTensorFlowの
+Dockerイメージを使っているときは、リポジトリはすでに`/tensorflow_src/`に提供されています—
+そして、このスクリプトをTensorFlowリポジトリのルートで実行して
+ビルドが依存するものをすべてダウンロードしてください:
 
 ```bash
 ./tensorflow/lite/tools/make/download_dependencies.sh
 ```
 
-Note that you only need to do this once.
+これは一回だけ行えばいいことに注意してください。
 
-Then compile:
+そしてコンパイルします:
 
 ```bash
 ./tensorflow/lite/tools/make/build_aarch64_lib.sh
 ```
 
-This should compile a static library in:
+これにより次にある静的ライブラリがコンパイルされます:
 `tensorflow/lite/tools/make/gen/aarch64_armv8-a/lib/libtensorflow-lite.a`.
 
-## Compile natively on ARM64
+## ARM64上でネイティブコンパイルをする
 
-These steps were tested on HardKernel Odroid C2, gcc version 5.4.0.
+これらのステップはHardKernelのOdroid C2上で、gcc version 5.4.0で確認しました。
 
-Log in to your board and install the toolchain:
+基板にログインしてツールチェインをインストールします:
 
 ```bash
 sudo apt-get install build-essential
 ```
 
-Now git-clone the TensorFlow repository
-(`https://github.com/tensorflow/tensorflow`) and run this at the root of
-the repository:
+そしてTensorFlowのリポジトリ
+(`https://github.com/tensorflow/tensorflow`)をgit-cloneして次を
+リポジトリのルートで走らせます:
 
 ```bash
 ./tensorflow/lite/tools/make/download_dependencies.sh
 ```
 
-Note that you only need to do this once.
+これは一回だけ行えばいいことに注意してください。
 
-Then compile:
+そしてコンパイルします:
 
 ```bash
 ./tensorflow/lite/tools/make/build_aarch64_lib.sh
 ```
 
-This should compile a static library in:
+これにより次にある静的ライブラリがコンパイルされます:
 `tensorflow/lite/tools/make/gen/aarch64_armv8-a/lib/libtensorflow-lite.a`.


### PR DESCRIPTION
Originally from:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/guide/build_arm64.md