### PR TITLE
Update time_series.ipynb - scaling methods 

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -328,7 +328,8 @@
     "id": "-eFckdUUHWmT"
    },
    "source": [
-    "It is important to normalize features before training a neural network. A common way to do so is by subtracting the mean and dividing by the standard deviation of each feature."
+    "It is important to scale features before training a neural network. Standardization is a common way of doing this scaling by subtracting the mean and dividing by the standard deviation of each feature.",
+    "You could also use a [normalization method](https://www.tensorflow.org/api_docs/python/tf/keras/utils/normalize) that rescales the values into a range of [0,1]."
    ]
   },
   {
@@ -362,7 +363,7 @@
     "id": "8Gob1YJYH0cH"
    },
    "source": [
-    "Let's normalize the data."
+    "Let's standardize the data."
    ]
   },
   {
@@ -799,7 +800,7 @@
     "id": "cqStgZ-O1b3_"
    },
    "source": [
-    "As mentioned, the first step will be to normalize the dataset using the mean and standard deviation of the training data."
+    "As mentioned, the first step will be to standardize the dataset using the mean and standard deviation of the training data."
    ]
   },
   {

--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -329,7 +329,7 @@
    },
    "source": [
     "It is important to scale features before training a neural network. Standardization is a common way of doing this scaling by subtracting the mean and dividing by the standard deviation of each feature.",
-    "You could also use a [normalization method](https://www.tensorflow.org/api_docs/python/tf/keras/utils/normalize) that rescales the values into a range of [0,1]."
+    "You could also use a `tf.keras.utils.normalize` method that rescales the values into a range of [0,1]."
    ]
   },
   {


### PR DESCRIPTION
**Note : This is a reapplying of my Pull Request as asked by @MarkDaoust in Pull Request #946** 

**Page concerned :** [Time series forecasting guide](https://www.tensorflow.org/beta/tutorials/text/time_series)


I noticed that the name of the method used for scaling data did not match its description.

#### Here are two methods for scaling data : 

- **Normalization** typically means rescales the values into a range of [0,1]. 
- **Standardization** typically means rescales data to have a mean of 0 and a standard deviation of 1 (unit variance).

This can be confusing when you observe data and notice that the values are not between [0,1]. 

[Source](https://towardsdatascience.com/normalization-vs-standardization-quantitative-analysis-a91e8a79cebf)