### PR TITLE
Simplify creating image_features_extract_model

### DIFF
--- a/site/en/tutorials/text/image_captioning.ipynb
+++ b/site/en/tutorials/text/image_captioning.ipynb
@@ -301,12 +301,8 @@
       },
       "outputs": [],
       "source": [
-        "image_model = tf.keras.applications.InceptionV3(include_top=False,\n",
+        "image_features_extract_model = tf.keras.applications.InceptionV3(include_top=False,\n",
         "                                                weights='imagenet')\n",
-        "new_input = image_model.input\n",
-        "hidden_layer = image_model.layers[-1].output\n",
-        "\n",
-        "image_features_extract_model = tf.keras.Model(new_input, hidden_layer)"
       ]
     },
     {


### PR DESCRIPTION
Currently `image_features_extract_model` is created like this:

```
image_model = tf.keras.applications.InceptionV3(include_top=False,
                                                weights='imagenet')
new_input = image_model.input
hidden_layer = image_model.layers[-1].output

image_features_extract_model = tf.keras.Model(new_input, hidden_layer)
```

There is no difference between `image_features_extract_model` and `image_model`. Therefore the following line achieves the same as the above four lines:

```
image_features_extract_model = tf.keras.applications.InceptionV3(include_top=False,
                                                weights='imagenet')
```
