### PR TITLE
Fix typos in overfit_and_underfit.ipynb tutorial

### DIFF
--- a/site/en/tutorials/keras/overfit_and_underfit.ipynb
+++ b/site/en/tutorials/keras/overfit_and_underfit.ipynb
@@ -118,7 +118,7 @@
         "\n",
         "If you train for too long though, the model will start to overfit and learn patterns from the training data that don't generalize to the test data. We need to strike a balance. Understanding how to train for an appropriate number of epochs as we'll explore below is a useful skill.\n",
         "\n",
-        "To prevent overfitting, the best solution is to use more complete training data. The dataset should cover the full range of inputs that the model is expected to handle. Additional data may only be useful if it covers new and and interesting cases.\n",
+        "To prevent overfitting, the best solution is to use more complete training data. The dataset should cover the full range of inputs that the model is expected to handle. Additional data may only be useful if it covers new and interesting cases.\n",
         "\n",
         "A model trained on more complete data will naturally generalize better. When that is no longer possible, the next best solution is to use techniques like regularization. These place constraints on the quantity and type of information your model can store.  If a network can only afford to memorize a small number of patterns, the optimization process will force it to focus on the most prominent patterns, which have a better chance of generalizing well.\n",
         "\n",
@@ -551,7 +551,7 @@
         "id": "ya7x7gr9UjU0"
       },
       "source": [
-        "Each model in this tutorial will use the same training configuration. So set these up in a resuable way, starting with the list of callbacks.\n",
+        "Each model in this tutorial will use the same training configuration. So set these up in a reusable way, starting with the list of callbacks.\n",
         "\n",
         "The training for this tutorial runs for many short epochs. To reduce the logging noise use the `tfdocs.EpochDots` which simply a `.` for each epoch and, and a full set of metrics every 100 epochs.\n",
         "\n",
@@ -902,7 +902,7 @@
       "source": [
         "While building a larger model gives it more power, if this power is not constrained somehow it can easily overfit to the training set.\n",
         "\n",
-        "In this example, typically, only the `\"Tiny\"` model manages to avoid overfitting alltogether, and each of the larger models overfit the data more quickly. This becomes so sever for the `\"large\"` model that you need to switch the plot to a log-scale to really see what's happening.\n",
+        "In this example, typically, only the `\"Tiny\"` model manages to avoid overfitting altogether, and each of the larger models overfit the data more quickly. This becomes so severe for the `\"large\"` model that you need to switch the plot to a log-scale to really see what's happening.\n",
         "\n",
         "This is apparent if you plot and compare the validation metrics to the training metrics.\n",
         "\n",
@@ -968,7 +968,7 @@
         "\n",
         "TensorBoard.dev is a managed experience for hosting, tracking, and sharing ML experiments with everyone.\n",
         "\n",
-        "It's also included in an `\u003ciframe\u003e` for convienience:"
+        "It's also included in an `\u003ciframe\u003e` for convenience:"
       ]
     },
     {
@@ -1021,7 +1021,7 @@
         "id": "YN512ksslaxJ"
       },
       "source": [
-        "Before getting into the content of this section copy the training logs from the `\"Tiny\"` model above, to use as a beseline for comparison."
+        "Before getting into the content of this section copy the training logs from the `\"Tiny\"` model above, to use as a baseline for comparison."
       ]
     },
     {
@@ -1145,7 +1145,7 @@
         "id": "Kx1YHMsVxWjP"
       },
       "source": [
-        "As you can see, the `\"L2\"` regularized model is now much more competitive with the the `\"Tiny\"` model. This `\"L2\"` model is also much more resistant to overfitting than the `\"Large\"` model it was based on despite having a the same number of parameters."
+        "As you can see, the `\"L2\"` regularized model is now much more competitive with the the `\"Tiny\"` model. This `\"L2\"` model is also much more resistant to overfitting than the `\"Large\"` model it was based on despite having the same number of parameters."
       ]
     },
     {
@@ -1199,7 +1199,7 @@
         "\n",
         "Dropout is one of the most effective and most commonly used regularization techniques for neural networks, developed by Hinton and his students at the University of Toronto.\n",
         "\n",
-        "The intuitive explaination for dropout is that because individual nodes in the network cannot rely on the output of the others, each node must output features that are useful on their own.\n",
+        "The intuitive explanation for dropout is that because individual nodes in the network cannot rely on the output of the others, each node must output features that are useful on their own.\n",
         "\n",
         "Dropout, applied to a layer, consists of randomly \"dropping out\" (i.e. set to zero) a number of output features of the layer during training. Let's say a given layer would normally have returned a vector [0.2, 0.5, 1.3, 0.8, 1.1] for a given input sample during training; after applying dropout, this vector will have a few zero entries distributed at random, e.g. [0, 0.5,\n",
         "1.3, 0, 1.1].\n",
@@ -1257,7 +1257,7 @@
         "id": "4zlHr4iaI1U6"
       },
       "source": [
-        "It's clear from this plot that both of these regularization approaches improve teh behavior of the `\"Large\"` model. But this still doesn't beat even the `\"Tiny\"` baseline.\n",
+        "It's clear from this plot that both of these regularization approaches improve the behavior of the `\"Large\"` model. But this still doesn't beat even the `\"Tiny\"` baseline.\n",
         "\n",
         "Next try them both, together, and see if that does better."
       ]
@@ -1352,7 +1352,7 @@
       "source": [
         "You can view the [results of a previous run](https://tensorboard.dev/experiment/fGInKDo8TXes1z7HQku9mw/#scalars\u0026_smoothingWeight=0.97) of this notebook on [TensorDoard.dev](https://tensorboard.dev/).\n",
         "\n",
-        "It's also included in an `\u003ciframe\u003e` for convienience:"
+        "It's also included in an `\u003ciframe\u003e` for convenience:"
       ]
     },
     {


### PR DESCRIPTION
Fixed several spelling and grammatical errors in the tutorial.