### PR TITLE
time_series.ipynb: simplify create_time_steps

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -457,10 +457,7 @@
    "outputs": [],
    "source": [
     "def create_time_steps(length):\n",
-    "  time_steps = []\n",
-    "  for i in range(-length, 0, 1):\n",
-    "    time_steps.append(i)\n",
-    "  return time_steps"
+    "  return list(range(-length, 0))"
    ]
   },
   {


### PR DESCRIPTION
This change is compatible Python 2/3.
Tested with length < 0, == 0 and > 0.