### PR TITLE
Remove deprecated tf.data.Dataset.output_shapes

### DIFF
--- a/site/en/tutorials/text/text_classification_rnn.ipynb
+++ b/site/en/tutorials/text/text_classification_rnn.ipynb
@@ -278,7 +278,7 @@
         "id": "z2qVJzcEluH_"
       },
       "source": [
-        "Next create batches of these encoded strings. Use the `padded_batch` method to zero-pad the sequences to the length of the longest string n the batch:"
+        "Next create batches of these encoded strings. Use the [`padded_batch`](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#padded_batch) method to zero-pad the sequences to the length of the longest string in the batch:"
       ]
     },
     {
@@ -306,9 +306,9 @@
       "outputs": [],
       "source": [
         "train_dataset = train_dataset.shuffle(BUFFER_SIZE)\n",
-        "train_dataset = train_dataset.padded_batch(BATCH_SIZE, train_dataset.output_shapes)\n",
+        "train_dataset = train_dataset.padded_batch(BATCH_SIZE, padded_shapes=([None,], []))\n",
         "\n",
-        "test_dataset = test_dataset.padded_batch(BATCH_SIZE, test_dataset.output_shapes)"
+        "test_dataset = test_dataset.padded_batch(BATCH_SIZE, padded_shapes=([None,], []))"
       ]
     },
     {


### PR DESCRIPTION
Remove deprecated tf.data.Dataset.output_shapes
https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/data/Dataset#output_shapes

Convert output_shapes into None which will be padded to the maximum size of that dimension in each
batch.

Also added links for padded_batch and fixed typo.

(Running in Google Colab gives the error below)
<img width="816" alt="Screen Shot 2019-12-15 at 12 38 33 AM" src="https://user-images.githubusercontent.com/40487883/70860964-ca116f00-1edc-11ea-823b-f7671a188452.png">