### PR TITLE
fix vocabulary size based on all unique word count

### DIFF
--- a/site/en/tutorials/text/image_captioning.ipynb
+++ b/site/en/tutorials/text/image_captioning.ipynb
@@ -552,7 +552,7 @@
         "BUFFER_SIZE = 1000\n",
         "embedding_dim = 256\n",
         "units = 512\n",
-        "vocab_size = len(tokenizer.word_index) + 1\n",
+        "vocab_size = top_k + 1\n",
         "num_steps = len(img_name_train) // BATCH_SIZE\n",
         "# Shape of the vector extracted from InceptionV3 is (64, 2048)\n",
         "# These two variables represent that vector shape\n",


### PR DESCRIPTION
```len(tokenizer.word_index)``` return all unfiltered vocab size. You filtered this vocabulary while building **_Tokenizer_**.

For example:
```

import tensorflow as tf
tk = tf.keras.preprocessing.text.Tokenizer(num_words=2)
texts = ["AAA BBB", "CCC DDD", "AAA DDD"]
tk.fit_on_texts(texts)

print(tk.word_index)  
## ---> prints {'aaa': 1, 'ddd': 2, 'bbb': 3, 'ccc': 4}

print(len(tk.word_index))
## ---> prints 4
```