### PR TITLE
guide/data.ipynb: Fix bug in parse_image example code.

### DIFF
--- a/site/en/guide/data.ipynb
+++ b/site/en/guide/data.ipynb
@@ -2045,7 +2045,7 @@
         "# Reads an image from a file, decodes it into a dense tensor, and resizes it\n",
         "# to a fixed shape.\n",
         "def parse_image(filename):\n",
-        "  parts = tf.strings.split(file_path, '/')\n",
+        "  parts = tf.strings.split(filename, '/')\n",
         "  label = parts[-2]\n",
         "\n",
         "  image = tf.io.read_file(filename)\n",


### PR DESCRIPTION
In the "preprocessing data" section, the "parse_image" method incorrectly reads from a variable called "file_path" instead of from the method parameter "filename".

This doesn't break anything too visibly, but it causes the "Map it over the dataset" example code two cells later to show incorrect labels for the examples it displays.