### PR TITLE
Fixed docker install verification script, to work with TF 2.0

### DIFF
--- a/site/en/install/docker.md
+++ b/site/en/install/docker.md
@@ -75,7 +75,7 @@ downloads a new TensorFlow image the first time it is run:
 
 <pre class="devsite-terminal devsite-click-to-copy prettyprint lang-bsh">
 docker run -it --rm tensorflow/tensorflow \
-   python -c "import tensorflow as tf; print(tf.reduce_sum(tf.random_normal([1000, 1000])))"
+   python -c "import tensorflow as tf; print(tf.reduce_sum(tf.random.normal([1000, 1000])))"
 </pre>
 
 Success: TensorFlow is now installed. Read the [tutorials](../tutorials) to get started.
@@ -144,7 +144,7 @@ Download and run a GPU-enabled TensorFlow image (may take a few minutes):
 
 <pre class="devsite-terminal devsite-click-to-copy prettyprint lang-bsh">
 docker run --gpus all -it --rm tensorflow/tensorflow:latest-gpu \
-   python -c "import tensorflow as tf; print(tf.reduce_sum(tf.random_normal([1000, 1000])))"
+   python -c "import tensorflow as tf; print(tf.reduce_sum(tf.random.normal([1000, 1000])))"
 </pre>
 
 It can take a while to set up the GPU-enabled image. If repeatably running


### PR DESCRIPTION
I noticed that the python code used to verify the installation on the Docker install page is still using a Tensorflow 1.x API call and therefore always fails. This PR updates tf.random_normal to tf.random.normal so this code and succeeds with a correctly installed TF2.0 environment.