### PR TITLE
Update groups.md

### DIFF
--- a/site/en/community/groups.md
+++ b/site/en/community/groups.md
@@ -26,6 +26,7 @@ TensorFlow has communities around the world. [Add your community!](https://githu
 ## Asia
 
 * [TensorFlow China community](https://www.tensorflowers.cn)
+* [TensorFlow India ](https://www.facebook.com/groups/tensorflowindia/)
 * [TensorFlow User Group Beijing](https://mp.weixin.qq.com/s/IftQLGI9qHM5zvlxSD756Q)
 * [TensorFlow User Group Hangzhou](https://mp.weixin.qq.com/s/EIyGkk5ctE-gVsdYoqVEww)
 * [TensorFlow User Group Shanghai](https://mp.weixin.qq.com/s/9iQ0vzYjZdZXyi3LGN5fRQ)


### PR DESCRIPTION
Add Tensorflow India group. 
Created on 29 April 2017
Current tf Members :  4,261
Group link : https://www.facebook.com/groups/tensorflowindia/

The current Mumbai group link  (TensorFlow UserGroup Mumbai) is not active, please remove it 