### PR TITLE
replace depreciated `dataset.output_shapes`

### DIFF
--- a/site/en/tutorials/text/text_classification_rnn.ipynb
+++ b/site/en/tutorials/text/text_classification_rnn.ipynb
@@ -306,9 +306,9 @@
       "outputs": [],
       "source": [
         "train_dataset = train_dataset.shuffle(BUFFER_SIZE)\n",
-        "train_dataset = train_dataset.padded_batch(BATCH_SIZE, train_dataset.output_shapes)\n",
+        "train_dataset = train_dataset.padded_batch(BATCH_SIZE, (train_dataset.element_spec[0].shape, train_dataset.element_spec[1].shape))\n",
         "\n",
-        "test_dataset = test_dataset.padded_batch(BATCH_SIZE, test_dataset.output_shapes)"
+        "test_dataset = test_dataset.padded_batch(BATCH_SIZE, (test_dataset.element_spec[0].shape, test_dataset.element_spec[1].shape))"
       ]
     },
     {


### PR DESCRIPTION
This tutorial doesn't work in Tensorflow 2.0.