### PR TITLE
Fix installation docker command error

### DIFF
--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -65,8 +65,8 @@ landing_page:
           support</a>.
         </p>
         <pre class="prettyprint lang-bsh">
-        <code class="devsite-terminal">docker pull tensorflow/tensorflow:latest-jupyter                  # Download latest image</code><br/>
-        <code class="devsite-terminal">docker run -it -p 8888:8888 tensorflow/tensorflow:latest-jupyter  # Start a Jupyter notebook server</code>
+        <code class="devsite-terminal">docker pull tensorflow/tensorflow  # Download latest stable image</code><br/>
+        <code class="devsite-terminal">docker run -it -p 8888:8888 tensorflow/tensorflow:latest-gpu-jupyter  # Start Jupyter server</code>
         </pre>
       buttons:
       - label: Read the Docker install guide

--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -65,8 +65,8 @@ landing_page:
           support</a>.
         </p>
         <pre class="prettyprint lang-bsh">
-        <code class="devsite-terminal">docker pull tensorflow/tensorflow                  # Download latest image</code><br/>
-        <code class="devsite-terminal">docker run -it -p 8888:8888 tensorflow/tensorflow  # Start a Jupyter notebook server</code>
+        <code class="devsite-terminal">docker pull tensorflow/tensorflow:latest-jupyter                  # Download latest image</code><br/>
+        <code class="devsite-terminal">docker run -it -p 8888:8888 tensorflow/tensorflow:latest-jupyter  # Start a Jupyter notebook server</code>
         </pre>
       buttons:
       - label: Read the Docker install guide


### PR DESCRIPTION
When you arrive to https://www.tensorflow.org/install.
The command said you would run a Jupyter notebook on the container start, but you need to have the `-jupyter`image tag to do it. I was confused when I wanted to follow the instructions.