### PR TITLE
Fix 'output_shape' error in Text classification tutorial

### DIFF
--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -408,11 +408,11 @@
         "train_batches = (\n",
         "    train_data\n",
         "    .shuffle(BUFFER_SIZE)\n",
-        "    .padded_batch(32, train_data.output_shapes))\n",
+        "    .padded_batch(32, tf.compat.v1.data.get_output_shapes(train_data)))\n",
         "\n",
         "test_batches = (\n",
         "    test_data\n",
-        "    .padded_batch(32, train_data.output_shapes))"
+        "    .padded_batch(32, tf.compat.v1.data.get_output_shapes(train_data)))"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
AttributeError: '_OptionsDataset' object has no attribute 'output_shapes'.

Following recommendations here:
https://github.com/tensorflow/datasets/issues/102
https://github.com/tensorflow/tensorflow/issues/28669