### PR TITLE
Err check for spelltest

### DIFF
--- a/tools/spelltest/spelltest.sh
+++ b/tools/spelltest/spelltest.sh
@@ -105,6 +105,12 @@ read_file_contents() {
     fi
 
     contents="$($NBCONVERT_BIN $opts --stdout $fp 2>/dev/null)"
+    # Check that nbconvert ran. Virtualenvs get hosed on Python upgrades, etc.
+    if [[ $? != 0 ]]; then
+      echo "[$(basename ${NBCONVERT_BIN})] Error: " >&2
+      $NBCONVERT_BIN $opts --stdout "$fp" >&2
+      exit 1
+    fi
 
   else
     echo "${LOG_NAME} Error: File format not supported: ${fp}" >&2


### PR DESCRIPTION
Check nbconvert ran as it's supposed to.
Virtualenvs can get hosed when upgrading Python.