### PR TITLE
Fix typo

### DIFF
--- a/site/en/guide/data.ipynb
+++ b/site/en/guide/data.ipynb
@@ -2929,7 +2929,7 @@
       },
       "source": [
         "One problem with the above `experimental.sample_from_datasets` approach is that\n",
-        "is that it needs a separate `tf.data.Dataset` per class. Using `Dataset.filter`\n",
+        "it needs a separate `tf.data.Dataset` per class. Using `Dataset.filter`\n",
         "works, but results in all the data being loaded twice.\n",
         "\n",
         "The `data.experimental.rejection_resample` function can be applied to a dataset to rebalance it, while only loading it once. Elements will be dropped from the dataset to achieve balance.\n",


### PR DESCRIPTION
Repetition of `is that` in the sentence "One problem with the above experimental.sample_from_datasets approach is that is that it needs a separate tf.data.Dataset per class."