### PR TITLE
Fix install instructions for TensorRT

### DIFF
--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -113,7 +113,8 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 
 # Install TensorRT. Requires that libcudnn7 is installed above.
 <code class="devsite-terminal">sudo apt-get install -y --no-install-recommends libnvinfer6=6.0.1-1+cuda10.1 \
-    libnvinfer-dev=6.0.1-1+cuda10.1
+    libnvinfer-dev=6.0.1-1+cuda10.1 \
+    libnvinfer-plugin6=6.0.1-1+cuda10.1
 </code>
 </pre>
 


### PR DESCRIPTION
Without the `libnvinfer-plugin6` package, Tensorflow apparently fails to load TensorRT with the following error:

W tensorflow/stream_executor/platform/default/dso_loader.cc:55] Could not load dynamic library 'libnvinfer_plugin.so.6'; dlerror: libnvinfer_plugin.so.6: cannot open shared object file: No such file or directory
W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:30] Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.

Adding the package solves the issue