### PR TITLE
estimator/linear.pynb: Fix typo with duplicate 'take'

### DIFF
--- a/site/en/tutorials/estimator/linear.ipynb
+++ b/site/en/tutorials/estimator/linear.ipynb
@@ -380,7 +380,7 @@
         "id": "Gt8HMtwOh9lJ"
       },
       "source": [
-        "The `input_function` specifies how data is converted to a `tf.data.Dataset` that feeds the input pipeline in a streaming fashion. `tf.data.Dataset` take take in multiple sources such as a dataframe, a csv-formatted file, and more."
+        "The `input_function` specifies how data is converted to a `tf.data.Dataset` that feeds the input pipeline in a streaming fashion. `tf.data.Dataset` can take in multiple sources such as a dataframe, a csv-formatted file, and more."
       ]
     },
     {


### PR DESCRIPTION
This tiny change fixes a comment I noticed while reading docs.