### PR TITLE
Clarify that CUDA Ubuntu 16.04 Install is for version 10.1

### DIFF
--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -119,7 +119,7 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 </pre>
 
 
-#### Ubuntu 16.04 (CUDA 10)
+#### Ubuntu 16.04 (CUDA 10.1)
 
 <pre class="prettyprint lang-bsh">
 # Add NVIDIA package repositories
@@ -141,7 +141,7 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 
 # Install development and runtime libraries (~4GB)
 <code class="devsite-terminal">sudo apt-get install --no-install-recommends \
-    cuda-10-0 \
+    cuda-10-1 \
     libcudnn7=7.6.4.38-1+cuda10.1  \
     libcudnn7-dev=7.6.4.38-1+cuda10.1
 </code>


### PR DESCRIPTION
Currently, the CUDA 10 Ubuntu 16.04 install instructions are vague about what version of CUDA 10 is being installed. The title of this installation guide is changed to show that CUDA 10.1 is being installed and the guide now indicates that the `cuda-10-1` package is to be installed, rather than the `cuda-10-0` package.