### PR TITLE
Disabled input shuffle when loading CSVs

### DIFF
--- a/site/en/tutorials/load_data/csv.ipynb
+++ b/site/en/tutorials/load_data/csv.ipynb
@@ -244,6 +244,7 @@
         "      na_value=\"?\",\n",
         "      num_epochs=1,\n",
         "      ignore_errors=True, \n",
+        "      shuffle=False, \n",
         "      **kwargs)\n",
         "  return dataset\n",
         "\n",


### PR DESCRIPTION
In the function `tf.data.experimental.make_csv_dataset`, the `shuffle` argument is set to True by default. This will affect the final step in the notebook where predictions are compared with labels. Setting `shuffle` to False ensures the predictions and labels being compared are the same instances.