### PR TITLE
Update gpu.md to fix non-existent package issue

### DIFF
--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -147,7 +147,7 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 </code>
 
 # Install TensorRT. Requires that libcudnn7 is installed above.
-<code class="devsite-terminal">sudo apt-get install -y --no-install-recommends libnvinfer5=6.0.1-1+cuda10.1 \
+<code class="devsite-terminal">sudo apt-get install -y --no-install-recommends libnvinfer6=6.0.1-1+cuda10.1 \
     libnvinfer-dev=6.0.1-1+cuda10.1
 </code>
 </pre>


### PR DESCRIPTION
Fix non-existent libnvinfer5 version by referring to libnvinfer6 which seems to match the intention.

Linked issue: tensorflow/tensorflow#35936