### PR TITLE
Python version corrected in doc

### DIFF
--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -15,6 +15,7 @@ landing_page:
         <table class="columns">
           <tr><td>
             <ul>
+              <li>Python 3.4–3.7</li>
               <li>Ubuntu 16.04 or later</li>
               <li>Windows 7 or later</li>
             </ul>

--- a/site/en/install/pip.html
+++ b/site/en/install/pip.html
@@ -70,7 +70,7 @@
 <code class="devsite-terminal">virtualenv --version</code>
 </pre>
 {% dynamic else %}<!-- python3 -->
-<aside class="note">Requires Python &gt;= 3.4 and Python &lt;=3.7 and pip &gt;= 19.0</aside>
+<aside class="note">Requires Python &gt;= 3.4 and Python &lt;= 3.7 and pip &gt;= 19.0</aside>
 
 <pre class="prettyprint lang-bsh">
 <code class="devsite-terminal">python3 --version</code>

--- a/site/en/install/pip.html
+++ b/site/en/install/pip.html
@@ -70,7 +70,7 @@
 <code class="devsite-terminal">virtualenv --version</code>
 </pre>
 {% dynamic else %}<!-- python3 -->
-<aside class="note">Requires Python &gt; 3.4 and pip &gt;= 19.0</aside>
+<aside class="note">Requires Python &gt;= 3.4 and Python &lt;=3.7 and pip &gt;= 19.0</aside>
 
 <pre class="prettyprint lang-bsh">
 <code class="devsite-terminal">python3 --version</code>

--- a/site/en/install/pip.html
+++ b/site/en/install/pip.html
@@ -70,7 +70,7 @@
 <code class="devsite-terminal">virtualenv --version</code>
 </pre>
 {% dynamic else %}<!-- python3 -->
-<aside class="note">Requires Python &gt;= 3.4 and Python &lt;= 3.7 and pip &gt;= 19.0</aside>
+<aside class="note">Requires Python 3.4–3.7 and pip &gt;= 19.0</aside>
 
 <pre class="prettyprint lang-bsh">
 <code class="devsite-terminal">python3 --version</code>


### PR DESCRIPTION
There are issues like [#33374](https://github.com/tensorflow/tensorflow/issues/33374) which asks for installing tf in python 3.8 but as of now, it is not supporting. Also, there are many issues being made everyday about the same problem. So, this is the correction in the doc to illustrate that tf supports python version 3.4 to 3.7.