### PR TITLE
Update to avoid error from function iter

### DIFF
--- a/site/en/tutorials/keras/text_classification_with_hub.ipynb
+++ b/site/en/tutorials/keras/text_classification_with_hub.ipynb
@@ -138,6 +138,7 @@
         "except Exception:\n",
         "  pass\n",
         "import tensorflow as tf\n",
+        "tf.enable_eager_execution()\n",
         "\n",
         "!pip install tensorflow-hub\n",
         "!pip install tfds-nightly\n",


### PR DESCRIPTION
To fix the error due to function 'iter' in the cell: https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/keras/text_classification_with_hub.ipynb#scrollTo=QtTS4kpEpjbi

Error was: RuntimeError: __iter__() is only supported inside of tf.function or when eager execution is enabled.
To fix it: Use the command 'tf.enable_eager_execution()' while calling the liberary at start