### PR TITLE
fix save_and_serialize.ipynb

### DIFF
--- a/site/en/guide/keras/save_and_serialize.ipynb
+++ b/site/en/guide/keras/save_and_serialize.ipynb
@@ -74,7 +74,7 @@
         "id": "ZwiVWAQc9tk7"
       },
       "source": [
-        "The first part of this guide covers saving and serialization for Sequential models and models built using the Functional API and for Sequential models. The saving and serialization APIs are the exact same for both of these types of models.\n",
+        "The first part of this guide covers saving and serialization for Sequential models and models built using the Functional API. The saving and serialization APIs are the exact same for both of these types of models.\n",
         "\n",
         "Saving for custom subclasses of `Model` is covered in the section \"Saving Subclassed Models\". The APIs in this case are slightly different than for Sequential or Functional models."
       ]


### PR DESCRIPTION
duplicated word "for Sequential models" in sentence