### PR TITLE
Nvidia doesn't enable installs of driver 418 Linux Ubuntu 18.04

### DIFF
--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -95,7 +95,7 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 <code class="devsite-terminal">sudo apt-get update</code>
 
 # Install NVIDIA driver
-<code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-driver-418</code>
+<code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-driver-430</code>
 # Reboot. Check that GPUs are visible using the command: nvidia-smi
 
 # Install development and runtime libraries (~4GB)


### PR DESCRIPTION
When trying to install the dependencies:
```
sudo apt-get install --no-install-recommends \
    cuda-10-1 \
    libcudnn7=7.6.4.38-1+cuda10.1  \
    libcudnn7-dev=7.6.4.38-1+cuda10.1
```
Apt complains there are broken packages. To install the dependencies it prompts to install driver 430 instead.
After installing nvidia driver 430 installation works and Tensorflow works as well.

Tested on a clean Ubuntu 18.04 image without prior changes.