### PR TITLE
add `tf.` for prediction_layer in `/tutorials/images/transfer_learning`

### DIFF
--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -168,8 +168,7 @@
         "except Exception:\n",
         "  pass\n",
         "import tensorflow as tf\n",
-        "\n",
-        "keras = tf.keras"
+        "\n"
       ]
     },
     {
@@ -588,7 +587,7 @@
       },
       "outputs": [],
       "source": [
-        "prediction_layer = keras.layers.Dense(1)\n",
+        "prediction_layer = tf.keras.layers.Dense(1)\n",
         "prediction_batch = prediction_layer(feature_batch_average)\n",
         "print(prediction_batch.shape)"
       ]


### PR DESCRIPTION
To avoid confusion, add tf. that are not written in code.

And as mentioned in [#1447 ](https://github.com/tensorflow/docs/pull/1447#issuecomment-583231323) I checked all files and edit which contains `kreas = tf.keras` on top.