### PR TITLE
Update the beginner.ipynb file to add Installation instruction link

### DIFF
--- a/site/en/tutorials/quickstart/beginner.ipynb
+++ b/site/en/tutorials/quickstart/beginner.ipynb
@@ -101,7 +101,7 @@
         "id": "nnrWf3PCEzXL"
       },
       "source": [
-        "Download and install the TensorFlow 2 package. Import TensorFlow into your program:"
+        "Download and install the TensorFlow 2 package, being careful to follow the [Install Guide](https://www.tensorflow.org/install). Import TensorFlow into your program:"
       ]
     },
     {


### PR DESCRIPTION
Provide a link to the Install site so there is a clear(er) indication that the installation is non-standard and requires tool versions which are not available by default in some supported distributions.