### PR TITLE
Updated notes on Dense layer using `linear` instead `sigmoid` and tf 2.1.0 compatible args

### DIFF
--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -1,10 +1,12 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "collapsed_sections": [],
       "name": "text_classification.ipynb",
-      "private_outputs": true,
       "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
       "toc_visible": true
     },
     "kernelspec": {
@@ -12,8 +14,6 @@
       "name": "python3"
     }
   },
-  "nbformat": 4,
-  "nbformat_minor": 0,
   "cells": [
     {
       "cell_type": "markdown",
@@ -27,14 +27,12 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "ioaprt5q5US7"
+        "id": "ioaprt5q5US7",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -47,18 +45,18 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "yCl0eTNH5RS3"
+        "id": "yCl0eTNH5RS3",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title MIT License\n",
         "#\n",
@@ -81,7 +79,9 @@
         "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
         "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
         "# DEALINGS IN THE SOFTWARE."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -143,26 +143,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Nh0KjNGMWNlL"
+        "id": "Nh0KjNGMWNlL",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "from __future__ import absolute_import, division, print_function, unicode_literals"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "8RZOuS9LWQvv"
+        "id": "8RZOuS9LWQvv",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "try:\n",
         "  # %tensorflow_version only exists in Colab.\n",
@@ -170,17 +168,17 @@
         "except Exception:\n",
         "  pass\n",
         "import tensorflow as tf"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "2ew7HTbPpCJH"
+        "id": "2ew7HTbPpCJH",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "from tensorflow import keras\n",
         "\n",
@@ -191,7 +189,9 @@
         "import numpy as np\n",
         "\n",
         "print(tf.__version__)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -213,13 +213,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "wbIQ2wSeXSme"
+        "id": "wbIQ2wSeXSme",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "(train_data, test_data), info = tfds.load(\n",
         "    # Use the version pre-encoded with an ~8k vocabulary.\n",
@@ -230,7 +228,9 @@
         "    as_supervised=True,\n",
         "    # Also return the `info` structure. \n",
         "    with_info=True)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -248,29 +248,29 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "EplYp5pNnW1S"
+        "id": "EplYp5pNnW1S",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "encoder = info.features['text'].encoder"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "e7ACuHM5hFp3"
+        "id": "e7ACuHM5hFp3",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "print ('Vocabulary size: {}'.format(encoder.vocab_size))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -284,13 +284,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Bq6xDmf2SAs-"
+        "id": "Bq6xDmf2SAs-",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "sample_string = 'Hello TensorFlow.'\n",
         "\n",
@@ -301,7 +299,9 @@
         "print ('The original string: \"{}\"'.format(original_string))\n",
         "\n",
         "assert original_string == sample_string"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -315,17 +315,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "GUIRWSO8yxT5"
+        "id": "GUIRWSO8yxT5",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "for ts in encoded_string:\n",
         "  print ('{} ----> {}'.format(ts, encoder.decode([ts])))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -347,18 +347,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "cxnWQJijdGA1"
+        "id": "cxnWQJijdGA1",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "for train_example, train_label in train_data.take(1):\n",
         "  print('Encoded text:', train_example[:10].numpy())\n",
         "  print('Label:', train_label.numpy())"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -372,16 +372,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "34VUXtgxsVpf"
+        "id": "34VUXtgxsVpf",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "encoder.decode(train_example)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -397,25 +397,25 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "SDRI_s_tX1Hk"
+        "id": "SDRI_s_tX1Hk",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "BUFFER_SIZE = 1000\n",
         "\n",
         "train_batches = (\n",
         "    train_data\n",
         "    .shuffle(BUFFER_SIZE)\n",
-        "    .padded_batch(32))\n",
+        "    .padded_batch(32, padded_shapes=([None],[])))\n",
         "\n",
         "test_batches = (\n",
         "    test_data\n",
-        "    .padded_batch(32))"
-      ]
+        "    .padded_batch(32, padded_shapes=([None],[])))"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -429,19 +429,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "sXXne4DreQfv"
+        "id": "sXXne4DreQfv",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "for example_batch, label_batch in train_batches.take(2):\n",
         "  print(\"Batch shape:\", example_batch.shape)\n",
         "  print(\"label shape:\", label_batch.shape)\n",
         "  "
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -464,13 +464,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "xpKOoWgu-llD"
+        "id": "xpKOoWgu-llD",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "model = keras.Sequential([\n",
         "  keras.layers.Embedding(encoder.vocab_size, 16),\n",
@@ -478,7 +476,9 @@
         "  keras.layers.Dense(1)])\n",
         "\n",
         "model.summary()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -492,7 +492,7 @@
         "1. The first layer is an `Embedding` layer. This layer takes the integer-encoded vocabulary and looks up the embedding vector for each word-index. These vectors are learned as the model trains. The vectors add a dimension to the output array. The resulting dimensions are: `(batch, sequence, embedding)`.\n",
         "2. Next, a `GlobalAveragePooling1D` layer returns a fixed-length output vector for each example by averaging over the sequence dimension. This allows the model to handle input of variable length, in the simplest way possible.\n",
         "3. This fixed-length output vector is piped through a fully-connected (`Dense`) layer with 16 hidden units.\n",
-        "4. The last layer is densely connected with a single output node. Using the `sigmoid` activation function, this value is a float between 0 and 1, representing a probability, or confidence level."
+        "4. The last layer is densely connected with a single output node. If we use the `sigmoid` activation function, this value will be a float between 0 and 1, representing a probability, or confidence level. For numerical stability, we use the `linear` activation function instead, which represents the [logits](https://en.wikipedia.org/wiki/Logit)."
       ]
     },
     {
@@ -529,18 +529,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Mr0GP-cQ-llN"
+        "id": "Mr0GP-cQ-llN",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "model.compile(optimizer='adam',\n",
         "              loss=tf.losses.BinaryCrossentropy(from_logits=True),\n",
         "              metrics=['accuracy'])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -556,19 +556,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "tXSGrjWZ-llW"
+        "id": "tXSGrjWZ-llW",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "history = model.fit(train_batches,\n",
         "                    epochs=10,\n",
         "                    validation_data=test_batches,\n",
         "                    validation_steps=30)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -584,19 +584,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "zOMKywn4zReN"
+        "id": "zOMKywn4zReN",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "loss, accuracy = model.evaluate(test_batches)\n",
         "\n",
         "print(\"Loss: \", loss)\n",
         "print(\"Accuracy: \", accuracy)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -622,17 +622,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "VcvSXvhp-llb"
+        "id": "VcvSXvhp-llb",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "history_dict = history.history\n",
         "history_dict.keys()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -646,13 +646,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "nGoYf2Js-lle"
+        "id": "nGoYf2Js-lle",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "import matplotlib.pyplot as plt\n",
         "\n",
@@ -673,17 +671,17 @@
         "plt.legend()\n",
         "\n",
         "plt.show()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "6hXx-xOv-llh"
+        "id": "6hXx-xOv-llh",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "plt.clf()   # clear figure\n",
         "\n",
@@ -695,7 +693,9 @@
         "plt.legend(loc='lower right')\n",
         "\n",
         "plt.show()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",

--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -408,7 +408,7 @@
         "train_batches = (\n",
         "    train_data\n",
         "    .shuffle(BUFFER_SIZE)\n",
-        "    .padded_batch(32, padded_shapes=([None],[])))\n",
+        "    .padded_batch(32))\n",
         "\n",
         "test_batches = (\n",
         "    test_data\n",

--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -1,6 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
   "metadata": {
     "colab": {
       "name": "text_classification.ipynb",
@@ -14,6 +12,8 @@
       "name": "python3"
     }
   },
+  "nbformat": 4,
+  "nbformat_minor": 0,
   "cells": [
     {
       "cell_type": "markdown",

--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -492,7 +492,7 @@
         "1. The first layer is an `Embedding` layer. This layer takes the integer-encoded vocabulary and looks up the embedding vector for each word-index. These vectors are learned as the model trains. The vectors add a dimension to the output array. The resulting dimensions are: `(batch, sequence, embedding)`.\n",
         "2. Next, a `GlobalAveragePooling1D` layer returns a fixed-length output vector for each example by averaging over the sequence dimension. This allows the model to handle input of variable length, in the simplest way possible.\n",
         "3. This fixed-length output vector is piped through a fully-connected (`Dense`) layer with 16 hidden units.\n",
-        "4. The last layer is densely connected with a single output node. If we use the `sigmoid` activation function, this value will be a float between 0 and 1, representing a probability, or confidence level. For numerical stability, we use the `linear` activation function instead, which represents the [logits](https://en.wikipedia.org/wiki/Logit)."
+        "4. The last layer is densely connected with a single output node. Using the `sigmoid` activation function, this value is a float between 0 and 1, representing a probability, or confidence level. For numerical stability, use the `linear` activation function that represents the logits."
       ]
     },
     {


### PR DESCRIPTION
1) Updated the notes on Dense layer using `sigmoid` activation, when it is actually using `linear` + `BinaryCrossentropy`'s  "from_logits" option.

2) The notebook installs TF 2.2.0 dev. However, for TF 2.1.0, "padded_shapes" is a mandatory agurment for the `padded_batch()` function. Of course, this change is subjective as it may affect readability of the tutorial.