### PR TITLE
Fix driver version to install CUDA on ubuntu 18.04

### DIFF
--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -95,7 +95,7 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 <code class="devsite-terminal">sudo apt-get update</code>
 
 # Install NVIDIA driver
-<code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-driver-418</code>
+<code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-driver-430</code>
 # Reboot. Check that GPUs are visible using the command: nvidia-smi
 
 # Install development and runtime libraries (~4GB)


### PR DESCRIPTION
The issue seems to appear while running line 102 of this doc to install CUDA on Ubuntu 18.04. When I run the following script as it's written in the documentation, I ran to an error.


<code class="devsite-terminal">sudo apt-get install --no-install-recommends \
    cuda-10-1 \
    libcudnn7=7.6.4.38-1+cuda10.1  \
    libcudnn7-dev=7.6.4.38-1+cuda10.1
</code>


The error is as follows: 
```
cuda-10-1 : Depends: cuda-runtime-10-1 (>= 10.1.243) but it is not going to be installed
            Depends: cuda-demo-suite-10-1 (>= 10.1.243) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

After trying different ways to overcome this issue, it seems like it can be solved by explicitly determining the driver version as version 430. I cleaned the whole previously installed CUDA or NVIDIA driver as it's written in [NVIDIA's documentation](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html). And then attempt to re-install it as it's written in the instruction with the mentioned change. 

This fixed my issue.