### PR TITLE
Update Go documentation links to pkg.go.dev

### DIFF
--- a/site/en/api_docs/_book.yaml
+++ b/site/en/api_docs/_book.yaml
@@ -18,7 +18,7 @@ upper_tabs:
       - title: "Swift"
         path: /swift/api_docs/
       - title: "Go"
-        path: https://godoc.org/github.com/tensorflow/tensorflow/tensorflow/go
+        path: https://pkg.go.dev/github.com/tensorflow/tensorflow/tensorflow/go
         status: external
       - title: "Haskell"
         path: https://github.com/tensorflow/haskell

--- a/site/en/api_docs/index.md
+++ b/site/en/api_docs/index.md
@@ -12,7 +12,7 @@ covered by the [API stability promises](https://www.tensorflow.org/guide/version
 * [JavaScript](https://js.tensorflow.org/api/latest/)
 * [C++](https://www.tensorflow.org/api_docs/cc/)
 * [Java](https://www.tensorflow.org/api_docs/java/reference/org/tensorflow/package-summary)
-* [Go](https://godoc.org/github.com/tensorflow/tensorflow/tensorflow/go)
+* [Go](https://pkg.go.dev/github.com/tensorflow/tensorflow/tensorflow/go)
 * [Swift (Early Release)](https://www.tensorflow.org/swift)
 
 

--- a/site/en/install/lang_go.md
+++ b/site/en/install/lang_go.md
@@ -1,7 +1,7 @@
 # Install TensorFlow for Go
 
 TensorFlow provides a
-[Go API](https://godoc.org/github.com/tensorflow/tensorflow/tensorflow/go){:.external}—
+[Go API](https://pkg.go.dev/github.com/tensorflow/tensorflow/tensorflow/go){:.external}—
 particularly useful for loading models created with Python and running them
 within a Go application.
 

--- a/site/en/r1/guide/version_compat.md
+++ b/site/en/r1/guide/version_compat.md
@@ -81,7 +81,7 @@ backward incompatible ways between minor releases. These include:
   - [C++](./extend/cc.md) (exposed through header files in
     [`tensorflow/cc`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/cc)).
   - [Java](../api_docs/java/reference/org/tensorflow/package-summary),
-  - [Go](https://godoc.org/github.com/tensorflow/tensorflow/tensorflow/go)
+  - [Go](https://pkg.go.dev/github.com/tensorflow/tensorflow/tensorflow/go)
   - [JavaScript](https://js.tensorflow.org)
 
 *   **Details of composite ops:** Many public functions in Python expand to


### PR DESCRIPTION
Since [Pkg.go.dev](https://pkg.go.dev) is now the officially suggested documentation and discovery resource for open-source projects, the TensorFlow docs should automatically point there instead of [GoDoc.org](https://godoc.org/).

This PR updates all relevant links.