### PR TITLE
Fix private outputs on notebooks with saved outputs

### DIFF
--- a/site/en/guide/gpu.ipynb
+++ b/site/en/guide/gpu.ipynb
@@ -5,7 +5,7 @@
       "name": "gpu.ipynb",
       "toc_visible": true,
       "version": "0.3.2",
-      "private_outputs": true,
+      "private_outputs": false,
       "provenance": []
     },
     "kernelspec": {

--- a/site/en/tutorials/estimator/boosted_trees.ipynb
+++ b/site/en/tutorials/estimator/boosted_trees.ipynb
@@ -5,7 +5,7 @@
       "name": "boosted_trees.ipynb",
       "provenance": [],
       "toc_visible": true,
-      "private_outputs": true
+      "private_outputs": false
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/site/en/tutorials/estimator/boosted_trees_model_understanding.ipynb
+++ b/site/en/tutorials/estimator/boosted_trees_model_understanding.ipynb
@@ -5,7 +5,7 @@
       "name": "boosted_trees_model_understanding.ipynb",
       "provenance": [],
       "toc_visible": true,
-      "private_outputs": true
+      "private_outputs": false
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION

```
./tools/nbfmt.py --ignore_warn --preserve_outputs \
  site/en/guide/gpu.ipynb   site/en/tutorials/estimator/boosted_trees.ipynb \
  site/en/tutorials/estimator/boosted_trees_model_understanding.ipynb
```