### PR TITLE
Correct Docker Build with GPU

### DIFF
--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -392,8 +392,10 @@ is configured to build a Python 3 *pip* package with GPU support:
 
 <pre class="prettyprint lang-bsh">
 <code class="devsite-terminal">docker pull tensorflow/tensorflow<var>:devel-gpu-py3</var></code>
-<code class="devsite-terminal">docker run --runtime=nvidia -it -w /tensorflow -v $PWD:/mnt -e HOST_PERMS="$(id -u):$(id -g)" \
+<code class="devsite-terminal">docker run --gpus all -it -w /tensorflow -v $PWD:/mnt -e HOST_PERMS="$(id -u):$(id -g)" \
     tensorflow/tensorflow<var>:devel-gpu-py3</var> bash</code>
+    
+<code class="devsite-terminal tfo-terminal-root">git pull  # within the container, download the latest source code</code>
 </pre>
 
 Then, within the container's virtual environment, build the TensorFlow package

--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -394,7 +394,6 @@ is configured to build a Python 3 *pip* package with GPU support:
 <code class="devsite-terminal">docker pull tensorflow/tensorflow<var>:devel-gpu-py3</var></code>
 <code class="devsite-terminal">docker run --gpus all -it -w /tensorflow -v $PWD:/mnt -e HOST_PERMS="$(id -u):$(id -g)" \
     tensorflow/tensorflow<var>:devel-gpu-py3</var> bash</code>
-    
 <code class="devsite-terminal tfo-terminal-root">git pull  # within the container, download the latest source code</code>
 </pre>
 


### PR DESCRIPTION
Changed command-line option to "--gpus all" as "--runtime=nvidia" kept returning an error.

Added note to do a: git pull as well much like the CPU instructions to make this clear.