### PR TITLE
Delete unnecessary max_length function

### DIFF
--- a/site/en/tutorials/text/nmt_with_attention.ipynb
+++ b/site/en/tutorials/text/nmt_with_attention.ipynb
@@ -273,20 +273,6 @@
       "metadata": {
         "colab": {},
         "colab_type": "code",
-        "id": "OmMZQpdO60dt"
-      },
-      "outputs": [],
-      "source": [
-        "def max_length(tensor):\n",
-        "  return max(len(t) for t in tensor)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "bIOn8RCNDJXG"
       },
       "outputs": [],
@@ -351,7 +337,7 @@
         "input_tensor, target_tensor, inp_lang, targ_lang = load_dataset(path_to_file, num_examples)\n",
         "\n",
         "# Calculate max_length of the target tensors\n",
-        "max_length_targ, max_length_inp = max_length(target_tensor), max_length(input_tensor)"
+        "max_length_targ, max_length_inp = target_tensor.shape[0], input_tensor.shape[0]"
       ]
     },
     {


### PR DESCRIPTION
As pointed out in tensorflow/tensorflow#28371, the `max_length` function is unnecessary since `tf.keras.preprocessing.sequence.pad_sequences` called within `tokenize` already pads sequences by `maxlen`, which defaults to the length of the longest sequence. Therefore, the maximum length can simply be obtained by examining its shape.