### PR TITLE
Minor typo and punctuation fix

### DIFF
--- a/site/en/tutorials/generative/adversarial_fgsm.ipynb
+++ b/site/en/tutorials/generative/adversarial_fgsm.ipynb
@@ -197,7 +197,7 @@
       },
       "source": [
         "## Original image\n",
-        "Let's use a sample image of a [Labrador Retriever](https://commons.wikimedia.org/wiki/File:YellowLabradorLooking_new.jpg) by Mirko       [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) from Wikimedia Common and create adversarial examples from it. The first step is to preprocess it so that it can be fed as an input to the MobileNetV2 model."
+        "Let's use a sample image of a [Labrador Retriever](https://commons.wikimedia.org/wiki/File:YellowLabradorLooking_new.jpg) by Mirko [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) from Wikimedia Common and create adversarial examples from it. The first step is to preprocess it so that it can be fed as an input to the MobileNetV2 model."
       ]
     },
     {

--- a/site/en/tutorials/generative/adversarial_fgsm.ipynb
+++ b/site/en/tutorials/generative/adversarial_fgsm.ipynb
@@ -108,7 +108,7 @@
         "*   $\\theta$ : Model parameters.\n",
         "*   $J$ : Loss.\n",
         "\n",
-        "An intriguing property here, is the fact that the gradients are taken with respect to the input image. This is done because the objective is to create an image that maximises the loss. A method to accomplish this is to find how much each pixel in the image contributes to the loss value, and add a perturbation accordingly. This works pretty fast because it is easy find how each input pixel contributes to the loss, by using the chain rule, and finding the required gradients. Hence, the gradients are used with respect to the image. In addition, since the model is no longer being trained (thus the gradient is not taken with respect to the trainable variables, i.e., the model parameters), and so the model parameters remain constant. The only goal is to fool an already trained model.\n",
+        "An intriguing property here, is the fact that the gradients are taken with respect to the input image. This is done because the objective is to create an image that maximises the loss. A method to accomplish this is to find how much each pixel in the image contributes to the loss value, and add a perturbation accordingly. This works pretty fast because it is easy to find how each input pixel contributes to the loss by using the chain rule and finding the required gradients. Hence, the gradients are taken with respect to the image. In addition, since the model is no longer being trained (thus the gradient is not taken with respect to the trainable variables, i.e., the model parameters), and so the model parameters remain constant. The only goal is to fool an already trained model.\n",
         "\n",
         "So let's try and fool a pretrained model. In this tutorial, the model is [MobileNetV2](https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/keras/applications/MobileNetV2) model, pretrained on [ImageNet](http://www.image-net.org/)."
       ]
@@ -145,7 +145,7 @@
         "id": "wiTHY8dqxzx7"
       },
       "source": [
-        "Let's load the pretained MobileNetV2 model and the ImageNet class names."
+        "Let's load the pretrained MobileNetV2 model and the ImageNet class names."
       ]
     },
     {
@@ -197,7 +197,7 @@
       },
       "source": [
         "## Original image\n",
-        "Let's use a sample image of a [Labrador Retriever](https://commons.wikimedia.org/wiki/File:YellowLabradorLooking_new.jpg) -by Mirko       [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) from Wikimedia Common and create adversarial examples from it. The first step is to preprocess it so that it can be fed as an input to the MobileNetV2 model."
+        "Let's use a sample image of a [Labrador Retriever](https://commons.wikimedia.org/wiki/File:YellowLabradorLooking_new.jpg) by Mirko       [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) from Wikimedia Common and create adversarial examples from it. The first step is to preprocess it so that it can be fed as an input to the MobileNetV2 model."
       ]
     },
     {
@@ -319,7 +319,7 @@
         "id": "DKKSFHjwCyQH"
       },
       "source": [
-        "Let's try this out for different values of epsilon and observe the resultant image. You'll notice that as the value of epsilon is increased, it becomes easier to fool the network, however, this comes as a trade-off which results in the perturbations becoming more identifiable."
+        "Let's try this out for different values of epsilon and observe the resultant image. You'll notice that as the value of epsilon is increased, it becomes easier to fool the network. However, this comes as a trade-off which results in the perturbations becoming more identifiable."
       ]
     },
     {


### PR DESCRIPTION
Minor edits to fix typo, punctuation, and ambiguous expression (changed "gradients are used with respect to..." to "gradients are taken with respect to...") to improve readability