### PR TITLE
Edit string shortcut for model compilation

### DIFF
--- a/site/en/guide/keras/train_and_evaluate.ipynb
+++ b/site/en/guide/keras/train_and_evaluate.ipynb
@@ -362,7 +362,7 @@
         "If your model has multiple outputs, your can specify  different losses and metrics for each output,\n",
         "and you can modulate the contribution of each output to the total loss of the model. You will find more details about this in the section \"**Passing data to multi-input, multi-output models**\".\n",
         "\n",
-        "Note that in many cases, the optimizer, loss, and metrics can also be specified via string identifiers as a shortcut:\n"
+        "Note that if you're satisfied with the default settings, in many cases the optimizer, loss, and metrics can be specified via string identifiers as a shortcut:\n"
       ]
     },
     {

--- a/site/en/guide/keras/train_and_evaluate.ipynb
+++ b/site/en/guide/keras/train_and_evaluate.ipynb
@@ -347,7 +347,7 @@
       "source": [
         "model.compile(optimizer=keras.optimizers.RMSprop(learning_rate=1e-3),\n",
         "              loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
-        "              metrics=['sparse_categorical_accuracy'])"
+        "              metrics=[keras.metrics.sparse_categorical_accuracy])"
       ]
     },
     {
@@ -362,7 +362,7 @@
         "If your model has multiple outputs, your can specify  different losses and metrics for each output,\n",
         "and you can modulate the contribution of each output to the total loss of the model. You will find more details about this in the section \"**Passing data to multi-input, multi-output models**\".\n",
         "\n",
-        "Note that in many cases, the loss and metrics are specified via string identifiers, as a shortcut:\n"
+        "Note that in many cases, the optimizer, loss, and metrics can also be specified via string identifiers as a shortcut:\n"
       ]
     },
     {
@@ -375,8 +375,8 @@
       },
       "outputs": [],
       "source": [
-        "model.compile(optimizer=keras.optimizers.RMSprop(learning_rate=1e-3),\n",
-        "              loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+        "model.compile(optimizer='rmsprop',\n",
+        "              loss='sparse_categorical_crossentropy',\n",
         "              metrics=['sparse_categorical_accuracy'])"
       ]
     },

--- a/site/en/guide/keras/train_and_evaluate.ipynb
+++ b/site/en/guide/keras/train_and_evaluate.ipynb
@@ -376,7 +376,7 @@
       "outputs": [],
       "source": [
         "model.compile(optimizer='rmsprop',\n",
-        "              loss='sparse_categorical_crossentropy',\n",
+        "              loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
         "              metrics=['sparse_categorical_accuracy'])"
       ]
     },


### PR DESCRIPTION
The document states that string identifiers can be used as shortcut, yet the example given is no different from the compilation method shown in the code block above (presumably without strings identifiers, which is also confusing given that the metric was defined with a string identifier). The edit adds clarity by demonstrating how models can be compiled with and without string identifiers.