### PR TITLE
Changed tense which confused me

### DIFF
--- a/site/en/tutorials/load_data/tfrecord.ipynb
+++ b/site/en/tutorials/load_data/tfrecord.ipynb
@@ -553,7 +553,7 @@
         "id": "f-q0VKyZvcad"
       },
       "source": [
-        "Applies to a tuple of arrays, it returns a dataset of tuples:"
+        "Applied to a tuple of arrays, it returns a dataset of tuples:"
       ]
     },
     {


### PR DESCRIPTION
The phrase was:
`Applies to a tuple of arrays, it returns a dataset of tuples`
, where it should be Applied, which is more correct and matches the phrase above (line 533)


Yes, I've signed the CLA