### PR TITLE
change download url for dataset

### DIFF
--- a/site/en/r1/tutorials/sequences/audio_recognition.md
+++ b/site/en/r1/tutorials/sequences/audio_recognition.md
@@ -402,7 +402,7 @@ change to customize the results for your own requirements.
 ### Custom Training Data
 
 By default the script will download the [Speech Commands
-dataset](https://storage.googleapis.com/download.tensorflow.org/data/speech_commands_v0.01.tar.gz), but
+dataset](https://storage.googleapis.com/download.tensorflow.org/data/speech_commands_v0.02.tar.gz), but
 you can also supply your own training data. To train on your own data, you
 should make sure that you have at least several hundred recordings of each sound
 you would like to recognize, and arrange them into folders by class. For

--- a/site/en/r1/tutorials/sequences/audio_recognition.md
+++ b/site/en/r1/tutorials/sequences/audio_recognition.md
@@ -402,7 +402,7 @@ change to customize the results for your own requirements.
 ### Custom Training Data
 
 By default the script will download the [Speech Commands
-dataset](https://storage.googleapis.com/download.tensorflow.org/data/speech_commands_v0.02.tar.gz), but
+dataset](https://storage.googleapis.com/download.tensorflow.org/data/speech_commands_v0.01.tar.gz), but
 you can also supply your own training data. To train on your own data, you
 should make sure that you have at least several hundred recordings of each sound
 you would like to recognize, and arrange them into folders by class. For

--- a/site/en/r1/tutorials/sequences/audio_recognition.md
+++ b/site/en/r1/tutorials/sequences/audio_recognition.md
@@ -402,7 +402,7 @@ change to customize the results for your own requirements.
 ### Custom Training Data
 
 By default the script will download the [Speech Commands
-dataset](https://download.tensorflow.org/data/speech_commands_v0.01.tar.gz), but
+dataset](https://storage.googleapis.com/download.tensorflow.org/data/speech_commands_v0.02.tar.gz), but
 you can also supply your own training data. To train on your own data, you
 should make sure that you have at least several hundred recordings of each sound
 you would like to recognize, and arrange them into folders by class. For


### PR DESCRIPTION
closes https://github.com/tensorflow/tensorflow/issues/34460
Changed the url according to the script `tensorflow/examples/speech_commands/train.py` .
Also, the previous url has some certification error