### PR TITLE
Fix minor typo

### DIFF
--- a/site/en/guide/keras/functional.ipynb
+++ b/site/en/guide/keras/functional.ipynb
@@ -428,7 +428,7 @@
       "source": [
         "## Save and serialize\n",
         "\n",
-        "Saving the model and serialization work the same way for models built using the functional API as they do for S`equential` models. To standard way to save a functional model is to call `model.save()` to save the entire model as a single file. You can later recreate the same model from this file, even if the code that built the model is no longer available.\n",
+        "Saving the model and serialization work the same way for models built using the functional API as they do for `Sequential` models. To standard way to save a functional model is to call `model.save()` to save the entire model as a single file. You can later recreate the same model from this file, even if the code that built the model is no longer available.\n",
         "\n",
         "This saved file includes the:\n",
         "- model architecture\n",


### PR DESCRIPTION
There is a minor formatting error where `Sequential` is formatted as S`equential`

