### PR TITLE
Replace nightly with TF 2.x

### DIFF
--- a/site/en/tutorials/load_data/images.ipynb
+++ b/site/en/tutorials/load_data/images.ipynb
@@ -95,11 +95,15 @@
       "metadata": {
         "colab": {},
         "colab_type": "code",
-        "id": "3vhAMaIOBIee"
+        "id": "QGXxBuPyKJw1"
       },
       "outputs": [],
       "source": [
-        "from __future__ import absolute_import, division, print_function, unicode_literals"
+        "try:\n",
+        "  # %tensorflow_version only exists in Colab.\n",
+        "  %tensorflow_version 2.x\n",
+        "except Exception:\n",
+        "  pass"
       ]
     },
     {
@@ -108,15 +112,12 @@
       "metadata": {
         "colab": {},
         "colab_type": "code",
-        "id": "QGXxBuPyKJw1"
+        "id": "3vhAMaIOBIee"
       },
       "outputs": [],
       "source": [
-        "try:\n",
-        "  # %tensorflow_version only exists in Colab.\n",
-        "  !pip install tf-nightly\n",
-        "except Exception:\n",
-        "  pass\n",
+        "from __future__ import absolute_import, division, print_function, unicode_literals\n",
+        " \n",
         "import tensorflow as tf"
       ]
     },


### PR DESCRIPTION
The current [images tutorial](https://www.tensorflow.org/tutorials/load_data/images) displays the following error: `ERROR: tensorflow 2.1.0 has requirement gast==0.2.2, but you'll have gast 0.3.3 which is incompatible.`. This is presumably caused by the use of TF nightly, and can easily be resolved by using TF 2.X (2.1) instead. I have verified that the notebook runs fine with this setting on Colab. Thanks for reviewing!