### PR TITLE
Replaced deprecated function

### DIFF
--- a/site/en/tutorials/customization/custom_layers.ipynb
+++ b/site/en/tutorials/customization/custom_layers.ipynb
@@ -222,9 +222,9 @@
       "source": [
         "## Implementing custom layers\n",
         "The best way to implement your own layer is extending the tf.keras.Layer class and implementing:\n",
-        "  *  `__init__` , where you can do all input-independent initialization\n",
-        "  * `build`, where you know the shapes of the input tensors and can do the rest of the initialization\n",
-        "  * `call`, where you do the forward computation\n",
+        "*  `__init__` , where you can do all input-independent initialization\n",
+        "* `build`, where you know the shapes of the input tensors and can do the rest of the initialization\n",
+        "* `call`, where you do the forward computation\n",
         "\n",
         "Note that you don't have to wait until `build` is called to create your variables, you can also create them in `__init__`. However, the advantage of creating them in `build` is that it enables late variable creation based on the shape of the inputs the layer will operate on. On the other hand, creating variables in `__init__` would mean that shapes required to create the variables will need to be explicitly specified."
       ]
@@ -245,9 +245,9 @@
         "    self.num_outputs = num_outputs\n",
         "\n",
         "  def build(self, input_shape):\n",
-        "    self.kernel = self.add_variable(\"kernel\",\n",
-        "                                    shape=[int(input_shape[-1]),\n",
-        "                                           self.num_outputs])\n",
+        "    self.kernel = self.add_weight(\"kernel\",\n",
+        "                                  shape=[int(input_shape[-1]),\n",
+        "                                         self.num_outputs])\n",
         "\n",
         "  def call(self, input):\n",
         "    return tf.matmul(input, self.kernel)\n",

--- a/site/en/tutorials/customization/custom_layers.ipynb
+++ b/site/en/tutorials/customization/custom_layers.ipynb
@@ -222,9 +222,10 @@
       "source": [
         "## Implementing custom layers\n",
         "The best way to implement your own layer is extending the tf.keras.Layer class and implementing:\n",
-        "*  `__init__` , where you can do all input-independent initialization\n",
-        "* `build`, where you know the shapes of the input tensors and can do the rest of the initialization\n",
-        "* `call`, where you do the forward computation\n",
+        "\n",
+        "1. `__init__` , where you can do all input-independent initialization\n",
+        "2. `build`, where you know the shapes of the input tensors and can do the rest of the initialization\n",
+        "3. `call`, where you do the forward computation\n",
         "\n",
         "Note that you don't have to wait until `build` is called to create your variables, you can also create them in `__init__`. However, the advantage of creating them in `build` is that it enables late variable creation based on the shape of the inputs the layer will operate on. On the other hand, creating variables in `__init__` would mean that shapes required to create the variables will need to be explicitly specified."
       ]


### PR DESCRIPTION
This tutorial uses `add_variable`, which is a deprecated function for newer versions of TensorFlow. Replaced this function with `add_weights` to keep the tutorial up-to-date with TF API. 