### PR TITLE
fix missing positional argument to padded_batch

### DIFF
--- a/site/en/tutorials/load_data/text.ipynb
+++ b/site/en/tutorials/load_data/text.ipynb
@@ -451,10 +451,10 @@
       "outputs": [],
       "source": [
         "train_data = all_encoded_data.skip(TAKE_SIZE).shuffle(BUFFER_SIZE)\n",
-        "train_data = train_data.padded_batch(BATCH_SIZE)\n",
+        "train_data = train_data.padded_batch(BATCH_SIZE, padded_shapes=([None], []))\n",
         "\n",
         "test_data = all_encoded_data.take(TAKE_SIZE)\n",
-        "test_data = test_data.padded_batch(BATCH_SIZE)"
+        "test_data = test_data.padded_batch(BATCH_SIZE, padded_shapes=([None], []))"
       ]
     },
     {


### PR DESCRIPTION
When running tutorial `load_data/text.ipynb` with tensorflow 2.1 - the following line fails:

```
train_data = train_data.padded_batch(BATCH_SIZE)
```

with the error message:
```
TypeError: padded_batch() missing 1 required positional argument: 'padded_shapes'
```

And the document actually mentions this argument: https://www.tensorflow.org/api_docs/python/tf/data/Dataset#padded_batch.

The proposed patch adds the expected parameters with default value to pad on the text sequence. 

