### PR TITLE
[MRG]Remove unnecessary rstrip

### DIFF
--- a/site/en/tutorials/text/nmt_with_attention.ipynb
+++ b/site/en/tutorials/text/nmt_with_attention.ipynb
@@ -191,7 +191,7 @@
         "  # replacing everything with space except (a-z, A-Z, \".\", \"?\", \"!\", \",\")\n",
         "  w = re.sub(r\"[^a-zA-Z?.!,¿]+\", \" \", w)\n",
         "\n",
-        "  w = w.rstrip().strip()\n",
+        "  w = w.strip()\n",
         "\n",
         "  # adding a start and an end token to the sentence\n",
         "  # so that the model know when to start and stop predicting.\n",


### PR DESCRIPTION
```python
w = w.rstrip().strip()
```
is equivalent to 

```python
w = w.strip()
```
It's better to use the simpler version.