### PR TITLE
[MRG] Rephrase to remove redundant word "available"

### DIFF
--- a/site/en/tutorials/images/data_augmentation.ipynb
+++ b/site/en/tutorials/images/data_augmentation.ipynb
@@ -410,7 +410,7 @@
         "id": "8W5E_c7o-H96"
       },
       "source": [
-        "See the `tf.image` reference for more details on available augmentation options."
+        "See the `tf.image` reference for details about available augmentation options."
       ]
     },
     {

--- a/site/en/tutorials/images/data_augmentation.ipynb
+++ b/site/en/tutorials/images/data_augmentation.ipynb
@@ -410,7 +410,7 @@
         "id": "8W5E_c7o-H96"
       },
       "source": [
-        "See the `tf.image` reference for available augmentation options available."
+        "See the `tf.image` reference for more details on available augmentation options."
       ]
     },
     {


### PR DESCRIPTION
There is a redundancy is the use of "available" in the following sentence: 

```
        "See the `tf.image` reference for available augmentation options available."
```

This PR proposes a correction. 