### PR TITLE
[MRG] Rephrase subsection title for clarity in tutorials/text/nmt

### DIFF
--- a/site/en/tutorials/text/nmt_with_attention.ipynb
+++ b/site/en/tutorials/text/nmt_with_attention.ipynb
@@ -395,7 +395,7 @@
         "id": "rgCLkfv5uO3d"
       },
       "source": [
-        "### Create a tf.data dataset"
+        "### Use tf.data to create batches and shuffle the dataset"
       ]
     },
     {


### PR DESCRIPTION
It is not clear in this subsection title: [Create a tf.data dataset](https://www.tensorflow.org/tutorials/text/nmt_with_attention#create_a_tfdata_dataset), whether the author wants to ask the reader to:

* "Create a tf.data.Dataset" : in that case there is a missing dot and capital D
* or say what is written: "Create a tf.data dataset".

The subtle difference makes the translation of this subsection title hard to convey a clear meaning. Therefore, I suggest using the clearer subsection title: *Use tf.data to create batches and shuffle the dataset* that is used in [Convolutional Variational Autoencoder](https://www.tensorflow.org/tutorials/generative/cvae#use_tfdata_to_create_batches_and_shuffle_the_dataset) tutorial.