### PR TITLE
A README.md Containing Information About Each Folder

### DIFF
--- a/site/en/README.md
+++ b/site/en/README.md
@@ -1,0 +1,30 @@
+# Information Regarding Each Directory
+---
+
+A file to give directions over where each file leads to.
+
+- **about :** Includes information about `Tensor White Papers` involving `Large-Scale Machine Learning on Heterogeneous Distributed Systems`and the white paper `TensorFlow: A System for Large-Scale Machine Learning` with its asbtract.
+
+- **api_docs :** Includes information about the different documentations and pages for APIs that it has for each programming language that Tensorflow currently supports - information is in the `index.md`.
+
+- **community :** Information for the different communities and chatting platforms for the sake of discusssing Tensorflow and related for the purpose of contribution and collaboration. Has a list for `General TensorFlow lists`, `Project-specific lists`, and `Special Interest Groups` exist in the file `forums.md`.
+
+- **datasets :** Contains a single .md file which provides the link to all datasets that can be imported from Tensorflow. A direct link for the aforementioned resource / for the docs is available as this [link](https://github.com/tensorflow/datasets/tree/master/docs).
+
+- **federated :** Guides for TensorFlow Federated ( TFF ), a direct link is [this](https://github.com/tensorflow/federated/tree/master/docs).
+
+- **graphics :** A README.md file containing the link for `tensorflow_graphics/g3doc`, which has this [direct link](https://github.com/tensorflow/graphics/tree/master/tensorflow_graphics/g3doc).
+
+- **guide :** ***FOR BEGINNERS*** A guide for new people to get started and have an idea about what TensorFlow really is.
+
+- **hub :** Contains a direct link for Tensorflow Hub - which is a place for "a repository and library for reusable machine learning.". Direct link is [this]https://github.com/tensorflow/hub/blob/master/docs/overview.md).
+
+- **install :** Information regarding how to quickly setup and et going with TensorFlow.
+
+- **js :** Contains information about integration of Tensorflow into JS - it is a README.md file which leads to https://github.com/tensorflow/tfjs-website/tree/master/docs , where you can find information regarding Tensorflow with Javacript ( JS ).
+
+- **lite :** Contains information about using Tensorflow Lite - has a single README.md which leads to https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/g3doc . Go here if you looking to implement TensorFlow for mobile or IoT devices.
+
+- **mlir :** Contains a README.md for the the link, [tensorflow/compiler/mlir/g3doc ](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/compiler/mlir/g3doc) which is the documentation for MLIR. The MLIR project defines a common intermediate representation (IR) that unifies the infrastructure required to execute high performance machine learning models in TensorFlow and similar ML frameworks, from https://www.tensorflow.org/mlir .
+
+- **neutral_structured_learning :** Contains a README.md with the link [tensorflow/neural-structured-learning](https://github.com/tensorflow/neural-structured-learning/tree/master/g3doc). "Neural Structured Learning (NSL) focuses on training deep neural networks by leveraging structured signals (when available) along with feature inputs.", from `The Neural Structured Learning Framework` at this [link](https://github.com/tensorflow/neural-structured-learning/blob/master/g3doc/framework.md). 


### PR DESCRIPTION
Contains information to serve as quick navigation as to what purpose each folder exists for. Intended to make navigation easier for new comers coming and taking a look at Tensorflow's documentations so that they can find relevant material quickly, especially `guide`, `lite`, `about`, `install`, and `community`.

Does not contain descriptions for the last few folders, so that is to be still done.