### PR TITLE
Fixbug #37927: Added code block for TF 1.x

### DIFF
--- a/site/en/r1/tutorials/keras/save_and_restore_models.ipynb
+++ b/site/en/r1/tutorials/keras/save_and_restore_models.ipynb
@@ -165,12 +165,32 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "7Nm7Tyb-gRt-"
-      },
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# The below line changes the tensorflow to be \n",
+        "# imported from Google Colab to 1.x\n",
+        "# Without it, TF 2.x is imported instead\n",
+        "%tensorflow_version 1.x"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Confirm that tensorflow 1.x is loaded\n",
+        "import tensorflow\n",
+        "\n",
+        "print(tensorflow.__version__)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
       "outputs": [],
       "source": [
         "import os\n",


### PR DESCRIPTION
Added a code block to switch TF version from 2.x to 1.x, as per issue #37972 [Tensorflow 2.x version is used in 1.x Tutorials](https://github.com/tensorflow/tensorflow/issues/37972) . The solution was found at '[The %tensorflow_version magic](https://colab.research.google.com/notebooks/tensorflow_version.ipynb)' .

All the change was adding the following code block
```
%tensorflow_version 1.x
```
Just before tensorflow was imported