### PR TITLE
Corrected order of params of loss fn in custom_training.ipynb

### DIFF
--- a/site/en/tutorials/customization/custom_training.ipynb
+++ b/site/en/tutorials/customization/custom_training.ipynb
@@ -257,8 +257,8 @@
       },
       "outputs": [],
       "source": [
-        "def loss(predicted_y, target_y):\n",
-        "  return tf.reduce_mean(tf.square(predicted_y - target_y))"
+        "def loss(target_y, predicted_y):\n",
+        "  return tf.reduce_mean(tf.square(target_y - predicted_y))"
       ]
     },
     {

--- a/site/en/tutorials/customization/custom_training.ipynb
+++ b/site/en/tutorials/customization/custom_training.ipynb
@@ -345,7 +345,7 @@
       "source": [
         "def train(model, inputs, outputs, learning_rate):\n",
         "  with tf.GradientTape() as t:\n",
-        "    current_loss = loss(model(inputs), outputs)\n",
+        "    current_loss = loss(outputs, model(inputs))\n",
         "  dW, db = t.gradient(current_loss, [model.W, model.b])\n",
         "  model.W.assign_sub(learning_rate * dW)\n",
         "  model.b.assign_sub(learning_rate * db)"
@@ -379,7 +379,7 @@
         "for epoch in epochs:\n",
         "  Ws.append(model.W.numpy())\n",
         "  bs.append(model.b.numpy())\n",
-        "  current_loss = loss(model(inputs), outputs)\n",
+        "  current_loss = loss(outputs, model(inputs))\n",
         "\n",
         "  train(model, inputs, outputs, learning_rate=0.1)\n",
         "  print('Epoch %2d: W=%1.2f b=%1.2f, loss=%2.5f' %\n",


### PR DESCRIPTION
Fixes [#38067](https://github.com/tensorflow/tensorflow/issues/38067).  
I agree with @Arktius that even if the loss here given is MSE and it is not affected by order of params, it is good to follow the convention of every loss function that `y_true` should be first and then `y_pred`.  
@MarkDaoust and @mihaimaruseac , Please review.