### PR TITLE
Update data.ipynb string split to work on windows

### DIFF
--- a/site/en/guide/data.ipynb
+++ b/site/en/guide/data.ipynb
@@ -2045,7 +2045,7 @@
         "# Reads an image from a file, decodes it into a dense tensor, and resizes it\n",
         "# to a fixed shape.\n",
         "def parse_image(filename):\n",
-        "  parts = tf.strings.split(filename, '/')\n",
+        "  parts = tf.strings.split(filename, pathlib.os.sep)\n",
         "  label = parts[-2]\n",
         "\n",
         "  image = tf.io.read_file(filename)\n",

--- a/site/en/guide/data.ipynb
+++ b/site/en/guide/data.ipynb
@@ -1496,7 +1496,7 @@
       "outputs": [],
       "source": [
         "def process_path(file_path):\n",
-        "  label = tf.strings.split(file_path, '/')[-2]\n",
+        "  label = tf.strings.split(file_path, pathlib.os.sep)[-2]\n",
         "  return tf.io.read_file(file_path), label\n",
         "\n",
         "labeled_ds = list_ds.map(process_path)"


### PR DESCRIPTION
I'm not sure whether it's intended for the documentation to run on every platform. I think this change slightly decreases the readability.

Note that `pathlib` does not explicitly provide the `pathlib.os` variable, it's simply available because it imports `os` internally. It could be cleaner to explicitly `import os` and change this to `os.sep` instead of `pathlib.os.sep`.
