### PR TITLE
PEP 8 fix in Quickstart for experts.

### DIFF
--- a/site/en/tutorials/quickstart/advanced.ipynb
+++ b/site/en/tutorials/quickstart/advanced.ipynb
@@ -355,11 +355,11 @@
         "    test_step(test_images, test_labels)\n",
         "\n",
         "  template = 'Epoch {}, Loss: {}, Accuracy: {}, Test Loss: {}, Test Accuracy: {}'\n",
-        "  print(template.format(epoch+1,\n",
+        "  print(template.format(epoch + 1,\n",
         "                        train_loss.result(),\n",
-        "                        train_accuracy.result()*100,\n",
+        "                        train_accuracy.result() * 100,\n",
         "                        test_loss.result(),\n",
-        "                        test_accuracy.result()*100))"
+        "                        test_accuracy.result() * 100))"
       ]
     },
     {


### PR DESCRIPTION
Surround binary operators with a single space on either side in the format string method of the [Quickstart for experts](https://github.com/tensorflow/docs/blob/master/site/en/tutorials/quickstart/advanced.ipynb) notebook.

Thanks !