### PR TITLE
Resolve minor typo and punctuation issue

### DIFF
--- a/site/en/tutorials/generative/style_transfer.ipynb
+++ b/site/en/tutorials/generative/style_transfer.ipynb
@@ -429,7 +429,7 @@
       },
       "outputs": [],
       "source": [
-        "# Content layer where will pull our feature maps\n",
+        "# Content layer where we will pull our feature maps\n",
         "content_layers = ['block5_conv2'] \n",
         "\n",
         "# Style layer of interest\n",

--- a/site/en/tutorials/generative/style_transfer.ipynb
+++ b/site/en/tutorials/generative/style_transfer.ipynb
@@ -429,10 +429,8 @@
       },
       "outputs": [],
       "source": [
-        "# Content layer where we will pull our feature maps\n",
         "content_layers = ['block5_conv2'] \n",
         "\n",
-        "# Style layer of interest\n",
         "style_layers = ['block1_conv1',\n",
         "                'block2_conv1',\n",
         "                'block3_conv1', \n",

--- a/site/en/tutorials/generative/style_transfer.ipynb
+++ b/site/en/tutorials/generative/style_transfer.ipynb
@@ -310,7 +310,7 @@
       "source": [
         "## Fast Style Transfer using TF-Hub\n",
         "\n",
-        "This tutorial demonstrates the original style-transfer algorithm. Which optimizes the image content to a particular style. Before getting into the details let's see how the [TensorFlow Hub](https://tensorflow.org/hub) module does:"
+        "This tutorial demonstrates the original style-transfer algorithm, which optimizes the image content to a particular style. Before getting into the details, let's see how the [TensorFlow Hub](https://tensorflow.org/hub) module does:"
       ]
     },
     {


### PR DESCRIPTION
This PR resolves a very minor typo/punctuation error found in the `style_transfer.ipynb` tutorial.