### PR TITLE
Typo in site/en/tutorials/keras/overfit_and_underfit.ipynb 

### DIFF
--- a/site/en/tutorials/keras/overfit_and_underfit.ipynb
+++ b/site/en/tutorials/keras/overfit_and_underfit.ipynb
@@ -545,7 +545,7 @@
       "source": [
         "Each model in this tutorial will use the same training configuration. So set these up in a reusable way, starting with the list of callbacks.\n",
         "\n",
-        "The training for this tutorial runs for many short epochs. To reduce the logging noise use the `tfdocs.EpochDots` which simply a `.` for each epoch and, and a full set of metrics every 100 epochs.\n",
+        "The training for this tutorial runs for many short epochs. To reduce the logging noise use the `tfdocs.EpochDots` which simply prints a `.` for each epoch, and a full set of metrics every 100 epochs.\n",
         "\n",
         "Next include `callbacks.EarlyStopping` to avoid long and unnecessary training times. Note that this callback is set to monitor the `val_binary_crossentropy`, not the `val_loss`. This difference will be important later.\n",
         "\n",


### PR DESCRIPTION
The original sentence seemed ambiguous, with missing words potentially. Here's a suggestion to make it easier to understand. 