### PR TITLE
Update rnn.ipynb

### DIFF
--- a/site/en/guide/keras/rnn.ipynb
+++ b/site/en/guide/keras/rnn.ipynb
@@ -473,7 +473,7 @@
       "source": [
         "Under the hood, `Bidirectional` will copy the RNN layer passed in, and flip the `go_backwards` field of the newly copied layer, so that it will process the inputs in reverse order.\n",
         "\n",
-        "The output of the `Bidirectional` RNN will be, by default, the sum of the forward layer output and the backward layer output. If you need a different merging behavior, e.g. concatenation, change the `merge_mode` parameter in the `Bidirectional` wrapper constructor. For more details about `Bidirectional`, please check [the API docs](https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/keras/layers/Bidirectional)."
+        "The output of the `Bidirectional` RNN will be, by default, the concatenation of the forward layer output and the backward layer output. If you need a different merging behavior, e.g. sum, change the `merge_mode` parameter in the `Bidirectional` wrapper constructor. For more details about `Bidirectional`, please check [the API docs](https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/keras/layers/Bidirectional)."
       ]
     },
     {


### PR DESCRIPTION
The default `merge_mode` for `tf.keras.layers.Bidirectional` in v2.1.0 is `concate`, according to https://www.tensorflow.org/api_docs/python/tf/keras/layers/Bidirectional