### PR TITLE
Update text_classification.ipynb

### DIFF
--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -455,7 +455,7 @@
         "\n",
         "In this example, the input data consists of an array of word-indices. The labels to predict are either 0 or 1. Let's build a \"Continuous bag of words\" style model for this problem:\n",
         "\n",
-        "Caution: This model doesn't use masking, so the zero-padding is used as part of the input, so the padding length may affect the output.  To fix this, see the [masking and padding guide](../../guide/keras/masking_and_padding)."
+        "Caution: This model doesn't use masking, so the zero-padding is used as part of the input, so the padding length may affect the output.  To fix this, see the [masking and padding guide](../../guide/keras/masking_and_padding.ipynb)."
       ]
     },
     {


### PR DESCRIPTION
masking and padding guide pointing to URL not found is fixed.