### PR TITLE
Fixing Oxford pets dataset download error in tutorials/images/segmentation.ipynb 

### DIFF
--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -1,4 +1,20 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "segmentation.ipynb",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -14,14 +30,12 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "JOgMcEajtkmg"
+        "id": "JOgMcEajtkmg",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -34,7 +48,9 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -96,40 +112,37 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "MQmKthrSBCld"
+        "id": "MQmKthrSBCld",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
-        "!pip install git+https://github.com/tensorflow/examples.git\n",
-        "!pip install git+https://github.com/tensorflow/datasets.git"
-      ]
+        "!pip install git+https://github.com/tensorflow/examples.git"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "YQX7R4bhZy5h"
+        "id": "YQX7R4bhZy5h",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "import tensorflow as tf"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "g87--n2AtyO_"
+        "id": "g87--n2AtyO_",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "from tensorflow_examples.models.pix2pix import pix2pix\n",
         "\n",
@@ -138,7 +151,9 @@
         "\n",
         "from IPython.display import clear_output\n",
         "import matplotlib.pyplot as plt"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -154,16 +169,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "40ITeStwDwZb"
+        "id": "40ITeStwDwZb",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
-        "dataset, info = tfds.load('oxford_iiit_pet:3.*.*', with_info=True)"
-      ]
+        "builder = tfds.builder('oxford_iiit_pet:3.*.*')\n",
+        "info = builder.info\n",
+        "# By setting register_checksums as True to pass the check.\n",
+        "config = tfds.download.DownloadConfig(register_checksums = True)\n",
+        "builder.download_and_prepare(download_config=config)\n",
+        "dataset = builder.as_dataset()"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -177,29 +197,27 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "FD60EbcAQqov"
+        "id": "FD60EbcAQqov",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def normalize(input_image, input_mask):\n",
         "  input_image = tf.cast(input_image, tf.float32) / 255.0\n",
         "  input_mask -= 1\n",
         "  return input_image, input_mask"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "2NPlCnBXQwb1"
+        "id": "2NPlCnBXQwb1",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "@tf.function\n",
         "def load_image_train(datapoint):\n",
@@ -213,17 +231,17 @@
         "  input_image, input_mask = normalize(input_image, input_mask)\n",
         "\n",
         "  return input_image, input_mask"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Zf0S67hJRp3D"
+        "id": "Zf0S67hJRp3D",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def load_image_test(datapoint):\n",
         "  input_image = tf.image.resize(datapoint['image'], (128, 128))\n",
@@ -232,7 +250,9 @@
         "  input_image, input_mask = normalize(input_image, input_mask)\n",
         "\n",
         "  return input_image, input_mask"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -246,48 +266,48 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "yHwj2-8SaQli"
+        "id": "yHwj2-8SaQli",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "TRAIN_LENGTH = info.splits['train'].num_examples\n",
         "BATCH_SIZE = 64\n",
         "BUFFER_SIZE = 1000\n",
         "STEPS_PER_EPOCH = TRAIN_LENGTH // BATCH_SIZE"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "39fYScNz9lmo"
+        "id": "39fYScNz9lmo",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "train = dataset['train'].map(load_image_train, num_parallel_calls=tf.data.experimental.AUTOTUNE)\n",
         "test = dataset['test'].map(load_image_test)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "DeFwFDN6EVoI"
+        "id": "DeFwFDN6EVoI",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "train_dataset = train.cache().shuffle(BUFFER_SIZE).batch(BATCH_SIZE).repeat()\n",
         "train_dataset = train_dataset.prefetch(buffer_size=tf.data.experimental.AUTOTUNE)\n",
         "test_dataset = test.batch(BATCH_SIZE)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -301,13 +321,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "3N2RPAAW9q4W"
+        "id": "3N2RPAAW9q4W",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def display(display_list):\n",
         "  plt.figure(figsize=(15, 15))\n",
@@ -320,22 +338,24 @@
         "    plt.imshow(tf.keras.preprocessing.image.array_to_img(display_list[i]))\n",
         "    plt.axis('off')\n",
         "  plt.show()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "a6u_Rblkteqb"
+        "id": "a6u_Rblkteqb",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "for image, mask in train.take(1):\n",
         "  sample_image, sample_mask = image, mask\n",
         "display([sample_image, sample_mask])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -352,16 +372,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "c6iB4iMvMkX9"
+        "id": "c6iB4iMvMkX9",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "OUTPUT_CHANNELS = 3"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -375,13 +395,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "liCeLH0ctjq7"
+        "id": "liCeLH0ctjq7",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "base_model = tf.keras.applications.MobileNetV2(input_shape=[128, 128, 3], include_top=False)\n",
         "\n",
@@ -399,7 +417,9 @@
         "down_stack = tf.keras.Model(inputs=base_model.input, outputs=layers)\n",
         "\n",
         "down_stack.trainable = False"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -413,13 +433,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "p0ZbfywEbZpJ"
+        "id": "p0ZbfywEbZpJ",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "up_stack = [\n",
         "    pix2pix.upsample(512, 3),  # 4x4 -> 8x8\n",
@@ -427,17 +445,17 @@
         "    pix2pix.upsample(128, 3),  # 16x16 -> 32x32\n",
         "    pix2pix.upsample(64, 3),   # 32x32 -> 64x64\n",
         "]"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "45HByxpVtrPF"
+        "id": "45HByxpVtrPF",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def unet_model(output_channels):\n",
         "  inputs = tf.keras.layers.Input(shape=[128, 128, 3])\n",
@@ -462,7 +480,9 @@
         "  x = last(x)\n",
         "\n",
         "  return tf.keras.Model(inputs=inputs, outputs=x)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -478,19 +498,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "6he36HK5uKAc"
+        "id": "6he36HK5uKAc",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "model = unet_model(OUTPUT_CHANNELS)\n",
         "model.compile(optimizer='adam',\n",
         "              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
         "              metrics=['accuracy'])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -504,16 +524,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "sw82qF1Gcovr"
+        "id": "sw82qF1Gcovr",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "tf.keras.utils.plot_model(model, show_shapes=True)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -527,29 +547,27 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "UwvIKLZPtxV_"
+        "id": "UwvIKLZPtxV_",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def create_mask(pred_mask):\n",
         "  pred_mask = tf.argmax(pred_mask, axis=-1)\n",
         "  pred_mask = pred_mask[..., tf.newaxis]\n",
         "  return pred_mask[0]"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "YLNsrynNtx4d"
+        "id": "YLNsrynNtx4d",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def show_predictions(dataset=None, num=1):\n",
         "  if dataset:\n",
@@ -559,20 +577,22 @@
         "  else:\n",
         "    display([sample_image, sample_mask,\n",
         "             create_mask(model.predict(sample_image[tf.newaxis, ...]))])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "X_1CC0T4dho3"
+        "id": "X_1CC0T4dho3",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "show_predictions()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -586,30 +606,28 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "wHrHsqijdmL6"
+        "id": "wHrHsqijdmL6",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "class DisplayCallback(tf.keras.callbacks.Callback):\n",
         "  def on_epoch_end(self, epoch, logs=None):\n",
         "    clear_output(wait=True)\n",
         "    show_predictions()\n",
         "    print ('\\nSample Prediction after epoch {}\\n'.format(epoch+1))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "StKDH_B9t4SD"
+        "id": "StKDH_B9t4SD",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "EPOCHS = 20\n",
         "VAL_SUBSPLITS = 5\n",
@@ -620,17 +638,17 @@
         "                          validation_steps=VALIDATION_STEPS,\n",
         "                          validation_data=test_dataset,\n",
         "                          callbacks=[DisplayCallback()])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "P_mu0SAbt40Q"
+        "id": "P_mu0SAbt40Q",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "loss = model_history.history['loss']\n",
         "val_loss = model_history.history['val_loss']\n",
@@ -646,7 +664,9 @@
         "plt.ylim([0, 1])\n",
         "plt.legend()\n",
         "plt.show()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -670,16 +690,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "ikrzoG24qwf5"
+        "id": "ikrzoG24qwf5",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "show_predictions(test_dataset, 3)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -694,21 +714,5 @@
         "You may also want to see the [Tensorflow Object Detection API](https://github.com/tensorflow/models/tree/master/research/object_detection) for another model you can retrain on your own data."
       ]
     }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [],
-      "name": "segmentation.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }

--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -1,4 +1,20 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "segmentation.ipynb",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -14,14 +30,12 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "JOgMcEajtkmg"
+        "id": "JOgMcEajtkmg",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -34,7 +48,9 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -96,39 +112,38 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "MQmKthrSBCld"
+        "id": "MQmKthrSBCld",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
-        "!pip install git+https://github.com/tensorflow/examples.git"
-      ]
+        "!pip install git+https://github.com/tensorflow/examples.git\n",
+        "!pip install git+https://github.com/tensorflow/datasets.git"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "YQX7R4bhZy5h"
+        "id": "YQX7R4bhZy5h",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "import tensorflow as tf"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "g87--n2AtyO_"
+        "id": "g87--n2AtyO_",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "from tensorflow_examples.models.pix2pix import pix2pix\n",
         "\n",
@@ -137,7 +152,9 @@
         "\n",
         "from IPython.display import clear_output\n",
         "import matplotlib.pyplot as plt"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -153,16 +170,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "40ITeStwDwZb"
+        "id": "40ITeStwDwZb",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "dataset, info = tfds.load('oxford_iiit_pet:3.*.*', with_info=True)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -176,29 +193,27 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "FD60EbcAQqov"
+        "id": "FD60EbcAQqov",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def normalize(input_image, input_mask):\n",
         "  input_image = tf.cast(input_image, tf.float32) / 255.0\n",
         "  input_mask -= 1\n",
         "  return input_image, input_mask"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "2NPlCnBXQwb1"
+        "id": "2NPlCnBXQwb1",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "@tf.function\n",
         "def load_image_train(datapoint):\n",
@@ -212,17 +227,17 @@
         "  input_image, input_mask = normalize(input_image, input_mask)\n",
         "\n",
         "  return input_image, input_mask"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Zf0S67hJRp3D"
+        "id": "Zf0S67hJRp3D",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def load_image_test(datapoint):\n",
         "  input_image = tf.image.resize(datapoint['image'], (128, 128))\n",
@@ -231,7 +246,9 @@
         "  input_image, input_mask = normalize(input_image, input_mask)\n",
         "\n",
         "  return input_image, input_mask"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -245,48 +262,48 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "yHwj2-8SaQli"
+        "id": "yHwj2-8SaQli",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "TRAIN_LENGTH = info.splits['train'].num_examples\n",
         "BATCH_SIZE = 64\n",
         "BUFFER_SIZE = 1000\n",
         "STEPS_PER_EPOCH = TRAIN_LENGTH // BATCH_SIZE"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "39fYScNz9lmo"
+        "id": "39fYScNz9lmo",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "train = dataset['train'].map(load_image_train, num_parallel_calls=tf.data.experimental.AUTOTUNE)\n",
         "test = dataset['test'].map(load_image_test)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "DeFwFDN6EVoI"
+        "id": "DeFwFDN6EVoI",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "train_dataset = train.cache().shuffle(BUFFER_SIZE).batch(BATCH_SIZE).repeat()\n",
         "train_dataset = train_dataset.prefetch(buffer_size=tf.data.experimental.AUTOTUNE)\n",
         "test_dataset = test.batch(BATCH_SIZE)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -300,13 +317,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "3N2RPAAW9q4W"
+        "id": "3N2RPAAW9q4W",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def display(display_list):\n",
         "  plt.figure(figsize=(15, 15))\n",
@@ -319,22 +334,24 @@
         "    plt.imshow(tf.keras.preprocessing.image.array_to_img(display_list[i]))\n",
         "    plt.axis('off')\n",
         "  plt.show()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "a6u_Rblkteqb"
+        "id": "a6u_Rblkteqb",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "for image, mask in train.take(1):\n",
         "  sample_image, sample_mask = image, mask\n",
         "display([sample_image, sample_mask])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -351,16 +368,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "c6iB4iMvMkX9"
+        "id": "c6iB4iMvMkX9",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "OUTPUT_CHANNELS = 3"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -374,13 +391,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "liCeLH0ctjq7"
+        "id": "liCeLH0ctjq7",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "base_model = tf.keras.applications.MobileNetV2(input_shape=[128, 128, 3], include_top=False)\n",
         "\n",
@@ -398,7 +413,9 @@
         "down_stack = tf.keras.Model(inputs=base_model.input, outputs=layers)\n",
         "\n",
         "down_stack.trainable = False"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -412,13 +429,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "p0ZbfywEbZpJ"
+        "id": "p0ZbfywEbZpJ",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "up_stack = [\n",
         "    pix2pix.upsample(512, 3),  # 4x4 -> 8x8\n",
@@ -426,17 +441,17 @@
         "    pix2pix.upsample(128, 3),  # 16x16 -> 32x32\n",
         "    pix2pix.upsample(64, 3),   # 32x32 -> 64x64\n",
         "]"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "45HByxpVtrPF"
+        "id": "45HByxpVtrPF",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def unet_model(output_channels):\n",
         "  inputs = tf.keras.layers.Input(shape=[128, 128, 3])\n",
@@ -461,7 +476,9 @@
         "  x = last(x)\n",
         "\n",
         "  return tf.keras.Model(inputs=inputs, outputs=x)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -477,19 +494,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "6he36HK5uKAc"
+        "id": "6he36HK5uKAc",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "model = unet_model(OUTPUT_CHANNELS)\n",
         "model.compile(optimizer='adam',\n",
         "              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
         "              metrics=['accuracy'])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -503,16 +520,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "sw82qF1Gcovr"
+        "id": "sw82qF1Gcovr",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "tf.keras.utils.plot_model(model, show_shapes=True)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -526,29 +543,27 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "UwvIKLZPtxV_"
+        "id": "UwvIKLZPtxV_",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def create_mask(pred_mask):\n",
         "  pred_mask = tf.argmax(pred_mask, axis=-1)\n",
         "  pred_mask = pred_mask[..., tf.newaxis]\n",
         "  return pred_mask[0]"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "YLNsrynNtx4d"
+        "id": "YLNsrynNtx4d",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def show_predictions(dataset=None, num=1):\n",
         "  if dataset:\n",
@@ -558,20 +573,22 @@
         "  else:\n",
         "    display([sample_image, sample_mask,\n",
         "             create_mask(model.predict(sample_image[tf.newaxis, ...]))])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "X_1CC0T4dho3"
+        "id": "X_1CC0T4dho3",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "show_predictions()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -585,30 +602,28 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "wHrHsqijdmL6"
+        "id": "wHrHsqijdmL6",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "class DisplayCallback(tf.keras.callbacks.Callback):\n",
         "  def on_epoch_end(self, epoch, logs=None):\n",
         "    clear_output(wait=True)\n",
         "    show_predictions()\n",
         "    print ('\\nSample Prediction after epoch {}\\n'.format(epoch+1))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "StKDH_B9t4SD"
+        "id": "StKDH_B9t4SD",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "EPOCHS = 20\n",
         "VAL_SUBSPLITS = 5\n",
@@ -619,17 +634,17 @@
         "                          validation_steps=VALIDATION_STEPS,\n",
         "                          validation_data=test_dataset,\n",
         "                          callbacks=[DisplayCallback()])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "P_mu0SAbt40Q"
+        "id": "P_mu0SAbt40Q",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "loss = model_history.history['loss']\n",
         "val_loss = model_history.history['val_loss']\n",
@@ -645,7 +660,9 @@
         "plt.ylim([0, 1])\n",
         "plt.legend()\n",
         "plt.show()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -669,16 +686,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "ikrzoG24qwf5"
+        "id": "ikrzoG24qwf5",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "show_predictions(test_dataset, 3)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -693,21 +710,5 @@
         "You may also want to see the [Tensorflow Object Detection API](https://github.com/tensorflow/models/tree/master/research/object_detection) for another model you can retrain on your own data."
       ]
     }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [],
-      "name": "segmentation.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }

--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -1,20 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "segmentation.ipynb",
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -30,12 +14,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
         "cellView": "form",
+        "colab": {},
         "colab_type": "code",
-        "id": "JOgMcEajtkmg",
-        "colab": {}
+        "id": "JOgMcEajtkmg"
       },
+      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -48,9 +34,7 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -112,37 +96,39 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "MQmKthrSBCld",
-        "colab": {}
+        "id": "MQmKthrSBCld"
       },
+      "outputs": [],
       "source": [
         "!pip install git+https://github.com/tensorflow/examples.git"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "YQX7R4bhZy5h",
-        "colab": {}
+        "id": "YQX7R4bhZy5h"
       },
+      "outputs": [],
       "source": [
         "import tensorflow as tf"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "g87--n2AtyO_",
-        "colab": {}
+        "id": "g87--n2AtyO_"
       },
+      "outputs": [],
       "source": [
         "from tensorflow_examples.models.pix2pix import pix2pix\n",
         "\n",
@@ -151,9 +137,7 @@
         "\n",
         "from IPython.display import clear_output\n",
         "import matplotlib.pyplot as plt"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -169,11 +153,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "40ITeStwDwZb",
-        "colab": {}
+        "id": "40ITeStwDwZb"
       },
+      "outputs": [],
       "source": [
         "builder = tfds.builder('oxford_iiit_pet:3.*.*')\n",
         "info = builder.info\n",
@@ -181,9 +167,7 @@
         "config = tfds.download.DownloadConfig(register_checksums = True)\n",
         "builder.download_and_prepare(download_config=config)\n",
         "dataset = builder.as_dataset()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -197,27 +181,29 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "FD60EbcAQqov",
-        "colab": {}
+        "id": "FD60EbcAQqov"
       },
+      "outputs": [],
       "source": [
         "def normalize(input_image, input_mask):\n",
         "  input_image = tf.cast(input_image, tf.float32) / 255.0\n",
         "  input_mask -= 1\n",
         "  return input_image, input_mask"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "2NPlCnBXQwb1",
-        "colab": {}
+        "id": "2NPlCnBXQwb1"
       },
+      "outputs": [],
       "source": [
         "@tf.function\n",
         "def load_image_train(datapoint):\n",
@@ -231,17 +217,17 @@
         "  input_image, input_mask = normalize(input_image, input_mask)\n",
         "\n",
         "  return input_image, input_mask"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "Zf0S67hJRp3D",
-        "colab": {}
+        "id": "Zf0S67hJRp3D"
       },
+      "outputs": [],
       "source": [
         "def load_image_test(datapoint):\n",
         "  input_image = tf.image.resize(datapoint['image'], (128, 128))\n",
@@ -250,9 +236,7 @@
         "  input_image, input_mask = normalize(input_image, input_mask)\n",
         "\n",
         "  return input_image, input_mask"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -266,48 +250,48 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "yHwj2-8SaQli",
-        "colab": {}
+        "id": "yHwj2-8SaQli"
       },
+      "outputs": [],
       "source": [
         "TRAIN_LENGTH = info.splits['train'].num_examples\n",
         "BATCH_SIZE = 64\n",
         "BUFFER_SIZE = 1000\n",
         "STEPS_PER_EPOCH = TRAIN_LENGTH // BATCH_SIZE"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "39fYScNz9lmo",
-        "colab": {}
+        "id": "39fYScNz9lmo"
       },
+      "outputs": [],
       "source": [
         "train = dataset['train'].map(load_image_train, num_parallel_calls=tf.data.experimental.AUTOTUNE)\n",
         "test = dataset['test'].map(load_image_test)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "DeFwFDN6EVoI",
-        "colab": {}
+        "id": "DeFwFDN6EVoI"
       },
+      "outputs": [],
       "source": [
         "train_dataset = train.cache().shuffle(BUFFER_SIZE).batch(BATCH_SIZE).repeat()\n",
         "train_dataset = train_dataset.prefetch(buffer_size=tf.data.experimental.AUTOTUNE)\n",
         "test_dataset = test.batch(BATCH_SIZE)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -321,11 +305,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "3N2RPAAW9q4W",
-        "colab": {}
+        "id": "3N2RPAAW9q4W"
       },
+      "outputs": [],
       "source": [
         "def display(display_list):\n",
         "  plt.figure(figsize=(15, 15))\n",
@@ -338,24 +324,22 @@
         "    plt.imshow(tf.keras.preprocessing.image.array_to_img(display_list[i]))\n",
         "    plt.axis('off')\n",
         "  plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "a6u_Rblkteqb",
-        "colab": {}
+        "id": "a6u_Rblkteqb"
       },
+      "outputs": [],
       "source": [
         "for image, mask in train.take(1):\n",
         "  sample_image, sample_mask = image, mask\n",
         "display([sample_image, sample_mask])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -372,16 +356,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "c6iB4iMvMkX9",
-        "colab": {}
+        "id": "c6iB4iMvMkX9"
       },
+      "outputs": [],
       "source": [
         "OUTPUT_CHANNELS = 3"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -395,11 +379,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "liCeLH0ctjq7",
-        "colab": {}
+        "id": "liCeLH0ctjq7"
       },
+      "outputs": [],
       "source": [
         "base_model = tf.keras.applications.MobileNetV2(input_shape=[128, 128, 3], include_top=False)\n",
         "\n",
@@ -417,9 +403,7 @@
         "down_stack = tf.keras.Model(inputs=base_model.input, outputs=layers)\n",
         "\n",
         "down_stack.trainable = False"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -433,11 +417,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "p0ZbfywEbZpJ",
-        "colab": {}
+        "id": "p0ZbfywEbZpJ"
       },
+      "outputs": [],
       "source": [
         "up_stack = [\n",
         "    pix2pix.upsample(512, 3),  # 4x4 -> 8x8\n",
@@ -445,17 +431,17 @@
         "    pix2pix.upsample(128, 3),  # 16x16 -> 32x32\n",
         "    pix2pix.upsample(64, 3),   # 32x32 -> 64x64\n",
         "]"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "45HByxpVtrPF",
-        "colab": {}
+        "id": "45HByxpVtrPF"
       },
+      "outputs": [],
       "source": [
         "def unet_model(output_channels):\n",
         "  inputs = tf.keras.layers.Input(shape=[128, 128, 3])\n",
@@ -480,9 +466,7 @@
         "  x = last(x)\n",
         "\n",
         "  return tf.keras.Model(inputs=inputs, outputs=x)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -498,19 +482,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "6he36HK5uKAc",
-        "colab": {}
+        "id": "6he36HK5uKAc"
       },
+      "outputs": [],
       "source": [
         "model = unet_model(OUTPUT_CHANNELS)\n",
         "model.compile(optimizer='adam',\n",
         "              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
         "              metrics=['accuracy'])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -524,16 +508,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "sw82qF1Gcovr",
-        "colab": {}
+        "id": "sw82qF1Gcovr"
       },
+      "outputs": [],
       "source": [
         "tf.keras.utils.plot_model(model, show_shapes=True)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -547,27 +531,29 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "UwvIKLZPtxV_",
-        "colab": {}
+        "id": "UwvIKLZPtxV_"
       },
+      "outputs": [],
       "source": [
         "def create_mask(pred_mask):\n",
         "  pred_mask = tf.argmax(pred_mask, axis=-1)\n",
         "  pred_mask = pred_mask[..., tf.newaxis]\n",
         "  return pred_mask[0]"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "YLNsrynNtx4d",
-        "colab": {}
+        "id": "YLNsrynNtx4d"
       },
+      "outputs": [],
       "source": [
         "def show_predictions(dataset=None, num=1):\n",
         "  if dataset:\n",
@@ -577,22 +563,20 @@
         "  else:\n",
         "    display([sample_image, sample_mask,\n",
         "             create_mask(model.predict(sample_image[tf.newaxis, ...]))])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "X_1CC0T4dho3",
-        "colab": {}
+        "id": "X_1CC0T4dho3"
       },
+      "outputs": [],
       "source": [
         "show_predictions()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -606,28 +590,30 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "wHrHsqijdmL6",
-        "colab": {}
+        "id": "wHrHsqijdmL6"
       },
+      "outputs": [],
       "source": [
         "class DisplayCallback(tf.keras.callbacks.Callback):\n",
         "  def on_epoch_end(self, epoch, logs=None):\n",
         "    clear_output(wait=True)\n",
         "    show_predictions()\n",
         "    print ('\\nSample Prediction after epoch {}\\n'.format(epoch+1))"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "StKDH_B9t4SD",
-        "colab": {}
+        "id": "StKDH_B9t4SD"
       },
+      "outputs": [],
       "source": [
         "EPOCHS = 20\n",
         "VAL_SUBSPLITS = 5\n",
@@ -638,17 +624,17 @@
         "                          validation_steps=VALIDATION_STEPS,\n",
         "                          validation_data=test_dataset,\n",
         "                          callbacks=[DisplayCallback()])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "P_mu0SAbt40Q",
-        "colab": {}
+        "id": "P_mu0SAbt40Q"
       },
+      "outputs": [],
       "source": [
         "loss = model_history.history['loss']\n",
         "val_loss = model_history.history['val_loss']\n",
@@ -664,9 +650,7 @@
         "plt.ylim([0, 1])\n",
         "plt.legend()\n",
         "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -690,16 +674,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "ikrzoG24qwf5",
-        "colab": {}
+        "id": "ikrzoG24qwf5"
       },
+      "outputs": [],
       "source": [
         "show_predictions(test_dataset, 3)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -714,5 +698,21 @@
         "You may also want to see the [Tensorflow Object Detection API](https://github.com/tensorflow/models/tree/master/research/object_detection) for another model you can retrain on your own data."
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "segmentation.ipynb",
+      "private_outputs": true,
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -1,20 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "segmentation.ipynb",
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -30,12 +14,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
         "cellView": "form",
+        "colab": {},
         "colab_type": "code",
-        "id": "JOgMcEajtkmg",
-        "colab": {}
+        "id": "JOgMcEajtkmg"
       },
+      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -48,9 +34,7 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -112,38 +96,40 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "MQmKthrSBCld",
-        "colab": {}
+        "id": "MQmKthrSBCld"
       },
+      "outputs": [],
       "source": [
         "!pip install git+https://github.com/tensorflow/examples.git\n",
         "!pip install git+https://github.com/tensorflow/datasets.git"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "YQX7R4bhZy5h",
-        "colab": {}
+        "id": "YQX7R4bhZy5h"
       },
+      "outputs": [],
       "source": [
         "import tensorflow as tf"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "g87--n2AtyO_",
-        "colab": {}
+        "id": "g87--n2AtyO_"
       },
+      "outputs": [],
       "source": [
         "from tensorflow_examples.models.pix2pix import pix2pix\n",
         "\n",
@@ -152,9 +138,7 @@
         "\n",
         "from IPython.display import clear_output\n",
         "import matplotlib.pyplot as plt"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -170,16 +154,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "40ITeStwDwZb",
-        "colab": {}
+        "id": "40ITeStwDwZb"
       },
+      "outputs": [],
       "source": [
         "dataset, info = tfds.load('oxford_iiit_pet:3.*.*', with_info=True)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -193,27 +177,29 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "FD60EbcAQqov",
-        "colab": {}
+        "id": "FD60EbcAQqov"
       },
+      "outputs": [],
       "source": [
         "def normalize(input_image, input_mask):\n",
         "  input_image = tf.cast(input_image, tf.float32) / 255.0\n",
         "  input_mask -= 1\n",
         "  return input_image, input_mask"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "2NPlCnBXQwb1",
-        "colab": {}
+        "id": "2NPlCnBXQwb1"
       },
+      "outputs": [],
       "source": [
         "@tf.function\n",
         "def load_image_train(datapoint):\n",
@@ -227,17 +213,17 @@
         "  input_image, input_mask = normalize(input_image, input_mask)\n",
         "\n",
         "  return input_image, input_mask"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "Zf0S67hJRp3D",
-        "colab": {}
+        "id": "Zf0S67hJRp3D"
       },
+      "outputs": [],
       "source": [
         "def load_image_test(datapoint):\n",
         "  input_image = tf.image.resize(datapoint['image'], (128, 128))\n",
@@ -246,9 +232,7 @@
         "  input_image, input_mask = normalize(input_image, input_mask)\n",
         "\n",
         "  return input_image, input_mask"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -262,48 +246,48 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "yHwj2-8SaQli",
-        "colab": {}
+        "id": "yHwj2-8SaQli"
       },
+      "outputs": [],
       "source": [
         "TRAIN_LENGTH = info.splits['train'].num_examples\n",
         "BATCH_SIZE = 64\n",
         "BUFFER_SIZE = 1000\n",
         "STEPS_PER_EPOCH = TRAIN_LENGTH // BATCH_SIZE"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "39fYScNz9lmo",
-        "colab": {}
+        "id": "39fYScNz9lmo"
       },
+      "outputs": [],
       "source": [
         "train = dataset['train'].map(load_image_train, num_parallel_calls=tf.data.experimental.AUTOTUNE)\n",
         "test = dataset['test'].map(load_image_test)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "DeFwFDN6EVoI",
-        "colab": {}
+        "id": "DeFwFDN6EVoI"
       },
+      "outputs": [],
       "source": [
         "train_dataset = train.cache().shuffle(BUFFER_SIZE).batch(BATCH_SIZE).repeat()\n",
         "train_dataset = train_dataset.prefetch(buffer_size=tf.data.experimental.AUTOTUNE)\n",
         "test_dataset = test.batch(BATCH_SIZE)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -317,11 +301,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "3N2RPAAW9q4W",
-        "colab": {}
+        "id": "3N2RPAAW9q4W"
       },
+      "outputs": [],
       "source": [
         "def display(display_list):\n",
         "  plt.figure(figsize=(15, 15))\n",
@@ -334,24 +320,22 @@
         "    plt.imshow(tf.keras.preprocessing.image.array_to_img(display_list[i]))\n",
         "    plt.axis('off')\n",
         "  plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "a6u_Rblkteqb",
-        "colab": {}
+        "id": "a6u_Rblkteqb"
       },
+      "outputs": [],
       "source": [
         "for image, mask in train.take(1):\n",
         "  sample_image, sample_mask = image, mask\n",
         "display([sample_image, sample_mask])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -368,16 +352,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "c6iB4iMvMkX9",
-        "colab": {}
+        "id": "c6iB4iMvMkX9"
       },
+      "outputs": [],
       "source": [
         "OUTPUT_CHANNELS = 3"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -391,11 +375,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "liCeLH0ctjq7",
-        "colab": {}
+        "id": "liCeLH0ctjq7"
       },
+      "outputs": [],
       "source": [
         "base_model = tf.keras.applications.MobileNetV2(input_shape=[128, 128, 3], include_top=False)\n",
         "\n",
@@ -413,9 +399,7 @@
         "down_stack = tf.keras.Model(inputs=base_model.input, outputs=layers)\n",
         "\n",
         "down_stack.trainable = False"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -429,11 +413,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "p0ZbfywEbZpJ",
-        "colab": {}
+        "id": "p0ZbfywEbZpJ"
       },
+      "outputs": [],
       "source": [
         "up_stack = [\n",
         "    pix2pix.upsample(512, 3),  # 4x4 -> 8x8\n",
@@ -441,17 +427,17 @@
         "    pix2pix.upsample(128, 3),  # 16x16 -> 32x32\n",
         "    pix2pix.upsample(64, 3),   # 32x32 -> 64x64\n",
         "]"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "45HByxpVtrPF",
-        "colab": {}
+        "id": "45HByxpVtrPF"
       },
+      "outputs": [],
       "source": [
         "def unet_model(output_channels):\n",
         "  inputs = tf.keras.layers.Input(shape=[128, 128, 3])\n",
@@ -476,9 +462,7 @@
         "  x = last(x)\n",
         "\n",
         "  return tf.keras.Model(inputs=inputs, outputs=x)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -494,19 +478,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "6he36HK5uKAc",
-        "colab": {}
+        "id": "6he36HK5uKAc"
       },
+      "outputs": [],
       "source": [
         "model = unet_model(OUTPUT_CHANNELS)\n",
         "model.compile(optimizer='adam',\n",
         "              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
         "              metrics=['accuracy'])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -520,16 +504,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "sw82qF1Gcovr",
-        "colab": {}
+        "id": "sw82qF1Gcovr"
       },
+      "outputs": [],
       "source": [
         "tf.keras.utils.plot_model(model, show_shapes=True)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -543,27 +527,29 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "UwvIKLZPtxV_",
-        "colab": {}
+        "id": "UwvIKLZPtxV_"
       },
+      "outputs": [],
       "source": [
         "def create_mask(pred_mask):\n",
         "  pred_mask = tf.argmax(pred_mask, axis=-1)\n",
         "  pred_mask = pred_mask[..., tf.newaxis]\n",
         "  return pred_mask[0]"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "YLNsrynNtx4d",
-        "colab": {}
+        "id": "YLNsrynNtx4d"
       },
+      "outputs": [],
       "source": [
         "def show_predictions(dataset=None, num=1):\n",
         "  if dataset:\n",
@@ -573,22 +559,20 @@
         "  else:\n",
         "    display([sample_image, sample_mask,\n",
         "             create_mask(model.predict(sample_image[tf.newaxis, ...]))])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "X_1CC0T4dho3",
-        "colab": {}
+        "id": "X_1CC0T4dho3"
       },
+      "outputs": [],
       "source": [
         "show_predictions()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -602,28 +586,30 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "wHrHsqijdmL6",
-        "colab": {}
+        "id": "wHrHsqijdmL6"
       },
+      "outputs": [],
       "source": [
         "class DisplayCallback(tf.keras.callbacks.Callback):\n",
         "  def on_epoch_end(self, epoch, logs=None):\n",
         "    clear_output(wait=True)\n",
         "    show_predictions()\n",
         "    print ('\\nSample Prediction after epoch {}\\n'.format(epoch+1))"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "StKDH_B9t4SD",
-        "colab": {}
+        "id": "StKDH_B9t4SD"
       },
+      "outputs": [],
       "source": [
         "EPOCHS = 20\n",
         "VAL_SUBSPLITS = 5\n",
@@ -634,17 +620,17 @@
         "                          validation_steps=VALIDATION_STEPS,\n",
         "                          validation_data=test_dataset,\n",
         "                          callbacks=[DisplayCallback()])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "P_mu0SAbt40Q",
-        "colab": {}
+        "id": "P_mu0SAbt40Q"
       },
+      "outputs": [],
       "source": [
         "loss = model_history.history['loss']\n",
         "val_loss = model_history.history['val_loss']\n",
@@ -660,9 +646,7 @@
         "plt.ylim([0, 1])\n",
         "plt.legend()\n",
         "plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -686,16 +670,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "ikrzoG24qwf5",
-        "colab": {}
+        "id": "ikrzoG24qwf5"
       },
+      "outputs": [],
       "source": [
         "show_predictions(test_dataset, 3)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -710,5 +694,21 @@
         "You may also want to see the [Tensorflow Object Detection API](https://github.com/tensorflow/models/tree/master/research/object_detection) for another model you can retrain on your own data."
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "segmentation.ipynb",
+      "private_outputs": true,
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
There is a checksum error when running `tutorials/images/segmentation.ipynb` in Colab.

The latest tensorflow_datasets patch seems unable to solve this issue, see: https://github.com/tensorflow/datasets/issues/1978

As an alternative, I've updated the `tfds.load` function into the first method mentioned in https://github.com/tensorflow/tensorflow/issues/31171#issuecomment-619580795

Although this seems a bit complicated, it solves the checksum error.