### PR TITLE
tensorflow-2.2.0 seems to work well with CUDA 10.2

### DIFF
--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -456,7 +456,7 @@ Success: TensorFlow is now installed.
 
 <table>
 <tr><th>Version</th><th>Python version</th><th>Compiler</th><th>Build tools</th><th>cuDNN</th><th>CUDA</th></tr>
-<tr><td>tensorflow-2.2.0</td><td>2.7, 3.5-3.8</td><td>GCC 7.3.1</td><td>Bazel 0.27.1</td><td>7.6</td><td>10.1</td></tr>
+<tr><td>tensorflow-2.2.0</td><td>2.7, 3.5-3.8</td><td>GCC 7.3.1</td><td>Bazel 0.27.1</td><td>7.6</td><td>10.2</td></tr>
 <tr><td>tensorflow-2.1.0</td><td>2.7, 3.5-3.7</td><td>GCC 7.3.1</td><td>Bazel 0.27.1</td><td>7.6</td><td>10.1</td></tr>
 <tr><td>tensorflow-2.0.0</td><td>2.7, 3.3-3.7</td><td>GCC 7.3.1</td><td>Bazel 0.26.1</td><td>7.4</td><td>10.0</td></tr>
 <tr><td>tensorflow_gpu-1.14.0</td><td>2.7, 3.3-3.7</td><td>GCC 4.8</td><td>Bazel 0.24.1</td><td>7.4</td><td>10.0</td></tr>


### PR DESCRIPTION
TF 2.2 seems to work well with CUDA 10.2 in my server.

Should we make that official by updating the docs?