### PR TITLE
fix: resolve minor typo

### DIFF
--- a/site/en/tutorials/load_data/csv.ipynb
+++ b/site/en/tutorials/load_data/csv.ipynb
@@ -420,7 +420,7 @@
       "outputs": [],
       "source": [
         "def pack(features, label):\n",
-        "  return tf.stack(list(features.values()), axis=-1), label"
+        "  return tf.stack(list(features.values()), axis=-1), labels"
       ]
     },
     {


### PR DESCRIPTION
Hello!
I just found a typo during tutorial :)

It can cause NameError.
because name 'label' is not defined!