### PR TITLE
Removing "another" from the first option

### DIFF
--- a/site/en/tutorials/keras/save_and_load.ipynb
+++ b/site/en/tutorials/keras/save_and_load.ipynb
@@ -607,7 +607,7 @@
         "id": "LtcN4VIb7JkK"
       },
       "source": [
-        "The SavedModel format is another way to serialize models. Models saved in this format can be restored using `tf.keras.models.load_model` and are compatible with TensorFlow Serving. The [SavedModel guide](https://www.tensorflow.org/guide/saved_model) goes into detail about how to serve/inspect the SavedModel. The section below illustrates the steps to saving and restoring the model."
+        "The SavedModel format is one of the ways to serialize models. Models saved in this format can be restored using `tf.keras.models.load_model` and are compatible with TensorFlow Serving. The [SavedModel guide](https://www.tensorflow.org/guide/saved_model) goes into detail about how to serve/inspect the SavedModel. The section below illustrates the steps to saving and restoring the model."
       ]
     },
     {


### PR DESCRIPTION
The SavedModel solution comes first, but starts with "The SavedModel format is another way to serialize models". 

My guess is that there used to be an option before this one, but as it's the first it's odd to have an "another" in the sentence.