### PR TITLE
Fix tutorials/keras/overfit and underfit: failed to open TensorBoard

### DIFF
--- a/site/en/tutorials/keras/overfit_and_underfit.ipynb
+++ b/site/en/tutorials/keras/overfit_and_underfit.ipynb
@@ -1,21 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "overfit_and_underfit.ipynb のコピー",
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [],
-      "toc_visible": true,
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -29,12 +12,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
         "cellView": "form",
+        "colab": {},
         "colab_type": "code",
-        "id": "lzyBOpYMdp3F",
-        "colab": {}
+        "id": "lzyBOpYMdp3F"
       },
+      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -47,18 +32,18 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
         "cellView": "form",
+        "colab": {},
         "colab_type": "code",
-        "id": "m_x4KfSJ7Vt7",
-        "colab": {}
+        "id": "m_x4KfSJ7Vt7"
       },
+      "outputs": [],
       "source": [
         "#@title MIT License\n",
         "#\n",
@@ -81,9 +66,7 @@
         "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
         "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
         "# DEALINGS IN THE SOFTWARE."
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -164,11 +147,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "5pZ8A2liqvgk",
-        "colab": {}
+        "id": "5pZ8A2liqvgk"
       },
+      "outputs": [],
       "source": [
         "import tensorflow as tf\n",
         "\n",
@@ -176,34 +161,34 @@
         "from tensorflow.keras import regularizers\n",
         "\n",
         "print(tf.__version__)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "QnAtAjqRYVXe",
-        "colab": {}
+        "id": "QnAtAjqRYVXe"
       },
+      "outputs": [],
       "source": [
         "!pip install git+https://github.com/tensorflow/docs\n",
         "\n",
         "import tensorflow_docs as tfdocs\n",
         "import tensorflow_docs.modeling\n",
         "import tensorflow_docs.plots"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "-pnOU-ctX27Q",
-        "colab": {}
+        "id": "-pnOU-ctX27Q"
       },
+      "outputs": [],
       "source": [
         "from  IPython import display\n",
         "from matplotlib import pyplot as plt\n",
@@ -213,23 +198,21 @@
         "import pathlib\n",
         "import shutil\n",
         "import tempfile\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "jj6I4dvTtbUe",
-        "colab": {}
+        "id": "jj6I4dvTtbUe"
       },
+      "outputs": [],
       "source": [
         "logdir = pathlib.Path(tempfile.mkdtemp())/\"tensorboard_logs\"\n",
         "shutil.rmtree(logdir, ignore_errors=True)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -245,29 +228,29 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "YPjAvwb-6dFd",
-        "colab": {}
+        "id": "YPjAvwb-6dFd"
       },
+      "outputs": [],
       "source": [
         "gz = tf.keras.utils.get_file('HIGGS.csv.gz', 'http://mlphysics.ics.uci.edu/data/higgs/HIGGS.csv.gz')"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "AkiyUdaWIrww",
-        "colab": {}
+        "id": "AkiyUdaWIrww"
       },
+      "outputs": [],
       "source": [
         "FEATURES = 28"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -281,16 +264,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "QHz4sLVQEVIU",
-        "colab": {}
+        "id": "QHz4sLVQEVIU"
       },
+      "outputs": [],
       "source": [
         "ds = tf.data.experimental.CsvDataset(gz,[float(),]*(FEATURES+1), compression_type=\"GZIP\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -304,19 +287,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "zPD6ICDlF6Wf",
-        "colab": {}
+        "id": "zPD6ICDlF6Wf"
       },
+      "outputs": [],
       "source": [
         "def pack_row(*row):\n",
         "  label = row[0]\n",
         "  features = tf.stack(row[1:],1)\n",
         "  return features, label"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -332,16 +315,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "-w-VHTwwGVoZ",
-        "colab": {}
+        "id": "-w-VHTwwGVoZ"
       },
+      "outputs": [],
       "source": [
         "packed_ds = ds.batch(10000).map(pack_row).unbatch()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -357,18 +340,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "TfcXuv33Fvka",
-        "colab": {}
+        "id": "TfcXuv33Fvka"
       },
+      "outputs": [],
       "source": [
         "for features,label in packed_ds.batch(1000).take(1):\n",
         "  print(features[0])\n",
         "  plt.hist(features.numpy().flatten(), bins = 101)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -382,20 +365,20 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "hmk49OqZIFZP",
-        "colab": {}
+        "id": "hmk49OqZIFZP"
       },
+      "outputs": [],
       "source": [
         "N_VALIDATION = int(1e3)\n",
         "N_TRAIN = int(1e4)\n",
         "BUFFER_SIZE = int(1e4)\n",
         "BATCH_SIZE = 500\n",
         "STEPS_PER_EPOCH = N_TRAIN//BATCH_SIZE"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -411,30 +394,30 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "H8H_ZzpBOOk-",
-        "colab": {}
+        "id": "H8H_ZzpBOOk-"
       },
+      "outputs": [],
       "source": [
         "validate_ds = packed_ds.take(N_VALIDATION).cache()\n",
         "train_ds = packed_ds.skip(N_VALIDATION).take(N_TRAIN).cache()"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "9zAOqk2_Px7K",
-        "colab": {}
+        "id": "9zAOqk2_Px7K"
       },
+      "outputs": [],
       "source": [
         "train_ds"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -448,17 +431,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "Y7I4J355O223",
-        "colab": {}
+        "id": "Y7I4J355O223"
       },
+      "outputs": [],
       "source": [
         "validate_ds = validate_ds.batch(BATCH_SIZE)\n",
         "train_ds = train_ds.shuffle(BUFFER_SIZE).repeat().batch(BATCH_SIZE)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -506,11 +489,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "LwQp-ERhAD6F",
-        "colab": {}
+        "id": "LwQp-ERhAD6F"
       },
+      "outputs": [],
       "source": [
         "lr_schedule = tf.keras.optimizers.schedules.InverseTimeDecay(\n",
         "  0.001,\n",
@@ -520,9 +505,7 @@
         "\n",
         "def get_optimizer():\n",
         "  return tf.keras.optimizers.Adam(lr_schedule)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -536,11 +519,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "HIo_yPjEAFgn",
-        "colab": {}
+        "id": "HIo_yPjEAFgn"
       },
+      "outputs": [],
       "source": [
         "step = np.linspace(0,100000)\n",
         "lr = lr_schedule(step)\n",
@@ -549,9 +534,7 @@
         "plt.ylim([0,max(plt.ylim())])\n",
         "plt.xlabel('Epoch')\n",
         "_ = plt.ylabel('Learning Rate')\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -571,11 +554,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "vSv8rfw_T85n",
-        "colab": {}
+        "id": "vSv8rfw_T85n"
       },
+      "outputs": [],
       "source": [
         "def get_callbacks(name):\n",
         "  return [\n",
@@ -583,9 +568,7 @@
         "    tf.keras.callbacks.EarlyStopping(monitor='val_binary_crossentropy', patience=200),\n",
         "    tf.keras.callbacks.TensorBoard(logdir/name),\n",
         "  ]"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -599,11 +582,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "xRCGwU3YH5sT",
-        "colab": {}
+        "id": "xRCGwU3YH5sT"
       },
+      "outputs": [],
       "source": [
         "def compile_and_fit(model, name, optimizer=None, max_epochs=10000):\n",
         "  if optimizer is None:\n",
@@ -625,9 +610,7 @@
         "    callbacks=get_callbacks(name),\n",
         "    verbose=0)\n",
         "  return history"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -651,45 +634,45 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "EZh-QFjKHb70",
-        "colab": {}
+        "id": "EZh-QFjKHb70"
       },
+      "outputs": [],
       "source": [
         "tiny_model = tf.keras.Sequential([\n",
         "    layers.Dense(16, activation='elu', input_shape=(FEATURES,)),\n",
         "    layers.Dense(1)\n",
         "])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "X72IUdWYipIS",
-        "colab": {}
+        "id": "X72IUdWYipIS"
       },
+      "outputs": [],
       "source": [
         "size_histories = {}"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "bdOcJtPGHhJ5",
-        "colab": {}
+        "id": "bdOcJtPGHhJ5"
       },
+      "outputs": [],
       "source": [
         "size_histories['Tiny'] = compile_and_fit(tiny_model, 'sizes/Tiny')"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -703,18 +686,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "dkEvb2x5XsjE",
-        "colab": {}
+        "id": "dkEvb2x5XsjE"
       },
+      "outputs": [],
       "source": [
         "plotter = tfdocs.plots.HistoryPlotter(metric = 'binary_crossentropy', smoothing_std=10)\n",
         "plotter.plot(size_histories)\n",
         "plt.ylim([0.5, 0.7])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -740,11 +723,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "QKgdXPx9usBa",
-        "colab": {}
+        "id": "QKgdXPx9usBa"
       },
+      "outputs": [],
       "source": [
         "small_model = tf.keras.Sequential([\n",
         "    # `input_shape` is only required here so that `.summary` works.\n",
@@ -752,22 +737,20 @@
         "    layers.Dense(16, activation='elu'),\n",
         "    layers.Dense(1)\n",
         "])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "LqG3MXF5xSjR",
-        "colab": {}
+        "id": "LqG3MXF5xSjR"
       },
+      "outputs": [],
       "source": [
         "size_histories['Small'] = compile_and_fit(small_model, 'sizes/Small')"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -791,11 +774,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "jksi-XtaxDAh",
-        "colab": {}
+        "id": "jksi-XtaxDAh"
       },
+      "outputs": [],
       "source": [
         "medium_model = tf.keras.Sequential([\n",
         "    layers.Dense(64, activation='elu', input_shape=(FEATURES,)),\n",
@@ -803,9 +788,7 @@
         "    layers.Dense(64, activation='elu'),\n",
         "    layers.Dense(1)\n",
         "])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -819,16 +802,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "Ofn1AwDhx-Fe",
-        "colab": {}
+        "id": "Ofn1AwDhx-Fe"
       },
+      "outputs": [],
       "source": [
         "size_histories['Medium']  = compile_and_fit(medium_model, \"sizes/Medium\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -844,11 +827,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "ghQwwqwqvQM9",
-        "colab": {}
+        "id": "ghQwwqwqvQM9"
       },
+      "outputs": [],
       "source": [
         "large_model = tf.keras.Sequential([\n",
         "    layers.Dense(512, activation='elu', input_shape=(FEATURES,)),\n",
@@ -857,9 +842,7 @@
         "    layers.Dense(512, activation='elu'),\n",
         "    layers.Dense(1)\n",
         "])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -873,16 +856,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "U1A99dhqvepf",
-        "colab": {}
+        "id": "U1A99dhqvepf"
       },
+      "outputs": [],
       "source": [
         "size_histories['large'] = compile_and_fit(large_model, \"sizes/large\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -925,20 +908,20 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "0XmKDtOWzOpk",
-        "colab": {}
+        "id": "0XmKDtOWzOpk"
       },
+      "outputs": [],
       "source": [
         "plotter.plot(size_histories)\n",
         "a = plt.xscale('log')\n",
         "plt.xlim([5, max(plt.xlim())])\n",
         "plt.ylim([0.5, 0.7])\n",
         "plt.xlabel(\"Epochs [Log Scale]\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -966,11 +949,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "6oa1lkJddZ-m",
-        "colab": {}
+        "id": "6oa1lkJddZ-m"
       },
+      "outputs": [],
       "source": [
         "#docs_infra: no_execute\n",
         "\n",
@@ -979,9 +964,7 @@
         "\n",
         "# Open an embedded TensorBoard viewer\n",
         "%tensorboard --logdir {logdir}/sizes"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -999,18 +982,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "dX5fcgrADwym",
-        "colab": {}
+        "id": "dX5fcgrADwym"
       },
+      "outputs": [],
       "source": [
         "display.IFrame(\n",
         "    src=\"https://tensorboard.dev/experiment/vW7jmmF9TmKmy3rbheMQpw/#scalars&_smoothingWeight=0.97\",\n",
         "    width=\"100%\", height=\"800px\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1052,31 +1035,31 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "40k1eBtnQzNo",
-        "colab": {}
+        "id": "40k1eBtnQzNo"
       },
+      "outputs": [],
       "source": [
         "shutil.rmtree(logdir/'regularizers/Tiny', ignore_errors=True)\n",
         "shutil.copytree(logdir/'sizes/Tiny', logdir/'regularizers/Tiny')"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "vFWMeFo7jLpN",
-        "colab": {}
+        "id": "vFWMeFo7jLpN"
       },
+      "outputs": [],
       "source": [
         "regularizer_histories = {}\n",
         "regularizer_histories['Tiny'] = size_histories['Tiny']"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1110,11 +1093,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "HFGmcwduwVyQ",
-        "colab": {}
+        "id": "HFGmcwduwVyQ"
       },
+      "outputs": [],
       "source": [
         "l2_model = tf.keras.Sequential([\n",
         "    layers.Dense(512, activation='elu',\n",
@@ -1130,9 +1115,7 @@
         "])\n",
         "\n",
         "regularizer_histories['l2'] = compile_and_fit(l2_model, \"regularizers/l2\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1150,17 +1133,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "7wkfLyxBZdh_",
-        "colab": {}
+        "id": "7wkfLyxBZdh_"
       },
+      "outputs": [],
       "source": [
         "plotter.plot(regularizer_histories)\n",
         "plt.ylim([0.5, 0.7])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1188,17 +1171,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "apDHQNybjaML",
-        "colab": {}
+        "id": "apDHQNybjaML"
       },
+      "outputs": [],
       "source": [
         "result = l2_model(features)\n",
         "regularization_loss=tf.add_n(l2_model.losses)"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1237,11 +1220,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "OFEYvtrHxSWS",
-        "colab": {}
+        "id": "OFEYvtrHxSWS"
       },
+      "outputs": [],
       "source": [
         "dropout_model = tf.keras.Sequential([\n",
         "    layers.Dense(512, activation='elu', input_shape=(FEATURES,)),\n",
@@ -1256,23 +1241,21 @@
         "])\n",
         "\n",
         "regularizer_histories['dropout'] = compile_and_fit(dropout_model, \"regularizers/dropout\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "SPZqwVchx5xp",
-        "colab": {}
+        "id": "SPZqwVchx5xp"
       },
+      "outputs": [],
       "source": [
         "plotter.plot(regularizer_histories)\n",
         "plt.ylim([0.5, 0.7])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1298,11 +1281,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "7zfs_qQIw1cz",
-        "colab": {}
+        "id": "7zfs_qQIw1cz"
       },
+      "outputs": [],
       "source": [
         "combined_model = tf.keras.Sequential([\n",
         "    layers.Dense(512, kernel_regularizer=regularizers.l2(0.0001),\n",
@@ -1321,23 +1306,21 @@
         "])\n",
         "\n",
         "regularizer_histories['combined'] = compile_and_fit(combined_model, \"regularizers/combined\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "qDqBBxfI0Yd8",
-        "colab": {}
+        "id": "qDqBBxfI0Yd8"
       },
+      "outputs": [],
       "source": [
         "plotter.plot(regularizer_histories)\n",
         "plt.ylim([0.5, 0.7])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1381,19 +1364,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
+        "colab": {},
         "colab_type": "code",
-        "id": "doMtyYoqFEO5",
-        "colab": {}
+        "id": "doMtyYoqFEO5"
       },
+      "outputs": [],
       "source": [
         "display.IFrame(\n",
         "    src=\"https://tensorboard.dev/experiment/fGInKDo8TXes1z7HQku9mw/#scalars&_smoothingWeight=0.97\",\n",
         "    width = \"100%\",\n",
         "    height=\"800px\")\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1441,5 +1424,22 @@
         "Remember that each method can help on its own, but often combining them can be even more effective."
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "machine_shape": "hm",
+      "name": "overfit_and_underfit.ipynb",
+      "private_outputs": true,
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/site/en/tutorials/keras/overfit_and_underfit.ipynb
+++ b/site/en/tutorials/keras/overfit_and_underfit.ipynb
@@ -1,4 +1,21 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "overfit_and_underfit.ipynb のコピー",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true,
+      "machine_shape": "hm"
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -12,14 +29,12 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "lzyBOpYMdp3F"
+        "id": "lzyBOpYMdp3F",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -32,18 +47,18 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "m_x4KfSJ7Vt7"
+        "id": "m_x4KfSJ7Vt7",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title MIT License\n",
         "#\n",
@@ -66,7 +81,9 @@
         "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
         "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
         "# DEALINGS IN THE SOFTWARE."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -147,13 +164,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "5pZ8A2liqvgk"
+        "id": "5pZ8A2liqvgk",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "import tensorflow as tf\n",
         "\n",
@@ -161,34 +176,34 @@
         "from tensorflow.keras import regularizers\n",
         "\n",
         "print(tf.__version__)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "QnAtAjqRYVXe"
+        "id": "QnAtAjqRYVXe",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "!pip install git+https://github.com/tensorflow/docs\n",
         "\n",
         "import tensorflow_docs as tfdocs\n",
         "import tensorflow_docs.modeling\n",
         "import tensorflow_docs.plots"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "-pnOU-ctX27Q"
+        "id": "-pnOU-ctX27Q",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "from  IPython import display\n",
         "from matplotlib import pyplot as plt\n",
@@ -198,21 +213,23 @@
         "import pathlib\n",
         "import shutil\n",
         "import tempfile\n"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "jj6I4dvTtbUe"
+        "id": "jj6I4dvTtbUe",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "logdir = pathlib.Path(tempfile.mkdtemp())/\"tensorboard_logs\"\n",
         "shutil.rmtree(logdir, ignore_errors=True)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -228,29 +245,29 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "YPjAvwb-6dFd"
+        "id": "YPjAvwb-6dFd",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "gz = tf.keras.utils.get_file('HIGGS.csv.gz', 'http://mlphysics.ics.uci.edu/data/higgs/HIGGS.csv.gz')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "AkiyUdaWIrww"
+        "id": "AkiyUdaWIrww",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "FEATURES = 28"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -264,16 +281,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "QHz4sLVQEVIU"
+        "id": "QHz4sLVQEVIU",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "ds = tf.data.experimental.CsvDataset(gz,[float(),]*(FEATURES+1), compression_type=\"GZIP\")"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -287,19 +304,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "zPD6ICDlF6Wf"
+        "id": "zPD6ICDlF6Wf",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def pack_row(*row):\n",
         "  label = row[0]\n",
         "  features = tf.stack(row[1:],1)\n",
         "  return features, label"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -315,16 +332,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "-w-VHTwwGVoZ"
+        "id": "-w-VHTwwGVoZ",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "packed_ds = ds.batch(10000).map(pack_row).unbatch()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -340,18 +357,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "TfcXuv33Fvka"
+        "id": "TfcXuv33Fvka",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "for features,label in packed_ds.batch(1000).take(1):\n",
         "  print(features[0])\n",
         "  plt.hist(features.numpy().flatten(), bins = 101)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -365,20 +382,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "hmk49OqZIFZP"
+        "id": "hmk49OqZIFZP",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "N_VALIDATION = int(1e3)\n",
         "N_TRAIN = int(1e4)\n",
         "BUFFER_SIZE = int(1e4)\n",
         "BATCH_SIZE = 500\n",
         "STEPS_PER_EPOCH = N_TRAIN//BATCH_SIZE"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -394,30 +411,30 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "H8H_ZzpBOOk-"
+        "id": "H8H_ZzpBOOk-",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "validate_ds = packed_ds.take(N_VALIDATION).cache()\n",
         "train_ds = packed_ds.skip(N_VALIDATION).take(N_TRAIN).cache()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "9zAOqk2_Px7K"
+        "id": "9zAOqk2_Px7K",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "train_ds"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -431,17 +448,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Y7I4J355O223"
+        "id": "Y7I4J355O223",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "validate_ds = validate_ds.batch(BATCH_SIZE)\n",
         "train_ds = train_ds.shuffle(BUFFER_SIZE).repeat().batch(BATCH_SIZE)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -489,13 +506,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "LwQp-ERhAD6F"
+        "id": "LwQp-ERhAD6F",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "lr_schedule = tf.keras.optimizers.schedules.InverseTimeDecay(\n",
         "  0.001,\n",
@@ -505,7 +520,9 @@
         "\n",
         "def get_optimizer():\n",
         "  return tf.keras.optimizers.Adam(lr_schedule)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -519,13 +536,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "HIo_yPjEAFgn"
+        "id": "HIo_yPjEAFgn",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "step = np.linspace(0,100000)\n",
         "lr = lr_schedule(step)\n",
@@ -534,7 +549,9 @@
         "plt.ylim([0,max(plt.ylim())])\n",
         "plt.xlabel('Epoch')\n",
         "_ = plt.ylabel('Learning Rate')\n"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -554,13 +571,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "vSv8rfw_T85n"
+        "id": "vSv8rfw_T85n",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def get_callbacks(name):\n",
         "  return [\n",
@@ -568,7 +583,9 @@
         "    tf.keras.callbacks.EarlyStopping(monitor='val_binary_crossentropy', patience=200),\n",
         "    tf.keras.callbacks.TensorBoard(logdir/name),\n",
         "  ]"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -582,13 +599,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "xRCGwU3YH5sT"
+        "id": "xRCGwU3YH5sT",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def compile_and_fit(model, name, optimizer=None, max_epochs=10000):\n",
         "  if optimizer is None:\n",
@@ -610,7 +625,9 @@
         "    callbacks=get_callbacks(name),\n",
         "    verbose=0)\n",
         "  return history"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -634,45 +651,45 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "EZh-QFjKHb70"
+        "id": "EZh-QFjKHb70",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "tiny_model = tf.keras.Sequential([\n",
         "    layers.Dense(16, activation='elu', input_shape=(FEATURES,)),\n",
         "    layers.Dense(1)\n",
         "])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "X72IUdWYipIS"
+        "id": "X72IUdWYipIS",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "size_histories = {}"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "bdOcJtPGHhJ5"
+        "id": "bdOcJtPGHhJ5",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "size_histories['Tiny'] = compile_and_fit(tiny_model, 'sizes/Tiny')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -686,18 +703,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "dkEvb2x5XsjE"
+        "id": "dkEvb2x5XsjE",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "plotter = tfdocs.plots.HistoryPlotter(metric = 'binary_crossentropy', smoothing_std=10)\n",
         "plotter.plot(size_histories)\n",
         "plt.ylim([0.5, 0.7])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -723,13 +740,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "QKgdXPx9usBa"
+        "id": "QKgdXPx9usBa",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "small_model = tf.keras.Sequential([\n",
         "    # `input_shape` is only required here so that `.summary` works.\n",
@@ -737,20 +752,22 @@
         "    layers.Dense(16, activation='elu'),\n",
         "    layers.Dense(1)\n",
         "])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "LqG3MXF5xSjR"
+        "id": "LqG3MXF5xSjR",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "size_histories['Small'] = compile_and_fit(small_model, 'sizes/Small')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -774,13 +791,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "jksi-XtaxDAh"
+        "id": "jksi-XtaxDAh",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "medium_model = tf.keras.Sequential([\n",
         "    layers.Dense(64, activation='elu', input_shape=(FEATURES,)),\n",
@@ -788,7 +803,9 @@
         "    layers.Dense(64, activation='elu'),\n",
         "    layers.Dense(1)\n",
         "])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -802,16 +819,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Ofn1AwDhx-Fe"
+        "id": "Ofn1AwDhx-Fe",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "size_histories['Medium']  = compile_and_fit(medium_model, \"sizes/Medium\")"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -827,13 +844,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "ghQwwqwqvQM9"
+        "id": "ghQwwqwqvQM9",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "large_model = tf.keras.Sequential([\n",
         "    layers.Dense(512, activation='elu', input_shape=(FEATURES,)),\n",
@@ -842,7 +857,9 @@
         "    layers.Dense(512, activation='elu'),\n",
         "    layers.Dense(1)\n",
         "])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -856,16 +873,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "U1A99dhqvepf"
+        "id": "U1A99dhqvepf",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "size_histories['large'] = compile_and_fit(large_model, \"sizes/large\")"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -908,20 +925,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "0XmKDtOWzOpk"
+        "id": "0XmKDtOWzOpk",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "plotter.plot(size_histories)\n",
         "a = plt.xscale('log')\n",
         "plt.xlim([5, max(plt.xlim())])\n",
         "plt.ylim([0.5, 0.7])\n",
         "plt.xlabel(\"Epochs [Log Scale]\")"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -949,17 +966,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "6oa1lkJddZ-m"
+        "id": "6oa1lkJddZ-m",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#docs_infra: no_execute\n",
+        "\n",
+        "# Load the TensorBoard notebook extension\n",
+        "%load_ext tensorboard\n",
+        "\n",
+        "# Open an embedded TensorBoard viewer\n",
         "%tensorboard --logdir {logdir}/sizes"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -977,18 +999,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "dX5fcgrADwym"
+        "id": "dX5fcgrADwym",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "display.IFrame(\n",
         "    src=\"https://tensorboard.dev/experiment/vW7jmmF9TmKmy3rbheMQpw/#scalars&_smoothingWeight=0.97\",\n",
         "    width=\"100%\", height=\"800px\")"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1030,31 +1052,31 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "40k1eBtnQzNo"
+        "id": "40k1eBtnQzNo",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "shutil.rmtree(logdir/'regularizers/Tiny', ignore_errors=True)\n",
         "shutil.copytree(logdir/'sizes/Tiny', logdir/'regularizers/Tiny')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "vFWMeFo7jLpN"
+        "id": "vFWMeFo7jLpN",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "regularizer_histories = {}\n",
         "regularizer_histories['Tiny'] = size_histories['Tiny']"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1088,13 +1110,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "HFGmcwduwVyQ"
+        "id": "HFGmcwduwVyQ",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "l2_model = tf.keras.Sequential([\n",
         "    layers.Dense(512, activation='elu',\n",
@@ -1110,7 +1130,9 @@
         "])\n",
         "\n",
         "regularizer_histories['l2'] = compile_and_fit(l2_model, \"regularizers/l2\")"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1128,17 +1150,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "7wkfLyxBZdh_"
+        "id": "7wkfLyxBZdh_",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "plotter.plot(regularizer_histories)\n",
         "plt.ylim([0.5, 0.7])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1166,17 +1188,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "apDHQNybjaML"
+        "id": "apDHQNybjaML",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "result = l2_model(features)\n",
         "regularization_loss=tf.add_n(l2_model.losses)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1215,13 +1237,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "OFEYvtrHxSWS"
+        "id": "OFEYvtrHxSWS",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "dropout_model = tf.keras.Sequential([\n",
         "    layers.Dense(512, activation='elu', input_shape=(FEATURES,)),\n",
@@ -1236,21 +1256,23 @@
         "])\n",
         "\n",
         "regularizer_histories['dropout'] = compile_and_fit(dropout_model, \"regularizers/dropout\")"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "SPZqwVchx5xp"
+        "id": "SPZqwVchx5xp",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "plotter.plot(regularizer_histories)\n",
         "plt.ylim([0.5, 0.7])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1276,13 +1298,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "7zfs_qQIw1cz"
+        "id": "7zfs_qQIw1cz",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "combined_model = tf.keras.Sequential([\n",
         "    layers.Dense(512, kernel_regularizer=regularizers.l2(0.0001),\n",
@@ -1301,21 +1321,23 @@
         "])\n",
         "\n",
         "regularizer_histories['combined'] = compile_and_fit(combined_model, \"regularizers/combined\")"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "qDqBBxfI0Yd8"
+        "id": "qDqBBxfI0Yd8",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "plotter.plot(regularizer_histories)\n",
         "plt.ylim([0.5, 0.7])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1359,19 +1381,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "doMtyYoqFEO5"
+        "id": "doMtyYoqFEO5",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "display.IFrame(\n",
         "    src=\"https://tensorboard.dev/experiment/fGInKDo8TXes1z7HQku9mw/#scalars&_smoothingWeight=0.97\",\n",
         "    width = \"100%\",\n",
         "    height=\"800px\")\n"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1419,22 +1441,5 @@
         "Remember that each method can help on its own, but often combining them can be even more effective."
       ]
     }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [],
-      "machine_shape": "hm",
-      "name": "overfit_and_underfit.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }


### PR DESCRIPTION
This PR fixes the issue about the failure to open the TensorBoard viewer in the section "View in TensorBoard".

![image](https://user-images.githubusercontent.com/30427632/82534178-ad5e1f00-9b7f-11ea-8452-e03aaee67da8.png)

To reproduce this, you may need to "Factory reset runtime".

This is caused by skipping to load the TensorBoard notebook extension. So I add a few lines of comments and codes to load it.