### PR TITLE
Fix typo 'peaking' -> 'peeking'.

### DIFF
--- a/site/en/tutorials/text/transformer.ipynb
+++ b/site/en/tutorials/text/transformer.ipynb
@@ -1683,7 +1683,7 @@
         "\n",
         "As the transformer predicts each word, *self-attention* allows it to look at the previous words in the input sequence to better predict the next word.\n",
         "\n",
-        "To prevent the model from peaking at the expected output the model uses a look-ahead mask."
+        "To prevent the model from peeking at the expected output the model uses a look-ahead mask."
       ]
     },
     {


### PR DESCRIPTION
Small typo fix in narrative documentation / tutorial. 