### PR TITLE
Remove Python 2 mentions

### DIFF
--- a/site/en/community/contribute/code_style.md
+++ b/site/en/community/contribute/code_style.md
@@ -28,30 +28,12 @@ $ pylint --rcfile=/tmp/pylintrc myfile.py
 
 ### Supported Python versions
 
-TensorFlow supports Python 2.7 and Python >= 3.4. See the
+TensorFlow supports Python >= 3.5. Note that Python 3.8 support requires TensorFlow 2.2 or later. See the
 [installation guide](https://www.tensorflow.org/install) for details.
 
 See the TensorFlow
 [continuous build status](https://github.com/tensorflow/tensorflow/blob/master/README.md#continuous-build-status)
 for official and community supported builds.
-
-#### Legacy Python compatibility
-
-TensorFlow will support Legacy Python (Python 2.7) until
-[January 1, 2020](https://groups.google.com/a/tensorflow.org/forum/#!searchin/announce/python$202.7%7Csort:date/announce/gVwS5RC8mds/dCt1ka2XAAAJ).
-Until that time, all code will need to be compatible with the Python versions
-listed above.
-
-These lines should be present in every Python file:
-
-
-```python
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-```
-
-Use `six` to write compatible code (for example, `six.moves.range`).
 
 
 ## C++ coding style

--- a/site/en/community/contribute/code_style.md
+++ b/site/en/community/contribute/code_style.md
@@ -71,7 +71,7 @@ $ diff <my_cc_file> /tmp/my_cc_file.cc
 ### Python operations
 
 A TensorFlow _operation_ is a function that, given input tensors returns output
-tensors (or adds a op to a graph when building graphs).
+tensors (or adds an op to a graph when building graphs).
 
 *   The first argument should be tensors, followed by basic Python parameters.
     The last argument is `name` with a default value of `None`.

--- a/site/en/community/contribute/code_style.md
+++ b/site/en/community/contribute/code_style.md
@@ -28,7 +28,7 @@ $ pylint --rcfile=/tmp/pylintrc myfile.py
 
 ### Supported Python versions
 
-TensorFlow supports Python >= 3.5. Note that Python 3.8 support requires TensorFlow 2.2 or later. See the
+TensorFlow supports Python >= 3.5. See the
 [installation guide](https://www.tensorflow.org/install) for details.
 
 See the TensorFlow

--- a/site/en/guide/create_op.md
+++ b/site/en/guide/create_op.md
@@ -329,9 +329,9 @@ Here are the outputs of these functions on an Ubuntu machine.
 $ python
 >>> import tensorflow as tf
 >>> tf.sysconfig.get_include()
-'/usr/local/lib/python2.7/site-packages/tensorflow/include'
+'/usr/local/lib/python3.6/site-packages/tensorflow/include'
 >>> tf.sysconfig.get_lib()
-'/usr/local/lib/python2.7/site-packages/tensorflow'
+'/usr/local/lib/python3.6/site-packages/tensorflow'
 ```
 
 Assuming you have `g++` installed, here is the sequence of commands you can use
@@ -343,7 +343,7 @@ TF_LFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.ge
 g++ -std=c++11 -shared zero_out.cc -o zero_out.so -fPIC ${TF_CFLAGS[@]} ${TF_LFLAGS[@]} -O2
 ```
 
-On Mac OS X, the additional flag "-undefined dynamic_lookup" is required when
+On macOS, the additional flag "-undefined dynamic_lookup" is required when
 building the `.so` file.
 
 >   Note on `gcc` version `>=5`: gcc uses the new C++
@@ -1200,7 +1200,7 @@ generated Python code may change in a way that isn't compatible with old
 callers.  The Python API may be kept compatible by careful changes in a
 hand-written Python wrapper, by keeping the old signature except possibly adding
 new optional arguments to the end.  Generally incompatible changes may only be
-made when TensorFlow's changes major versions, and must conform to the
+made when TensorFlow changes major versions, and must conform to the
 [`GraphDef` version semantics](./versions.md#compatibility_of_graphs_and_checkpoints).
 
 ### GPU support

--- a/site/en/guide/profiler.md
+++ b/site/en/guide/profiler.md
@@ -296,7 +296,7 @@ The Timeline pane contains the following elements:
 1.  **Tool selector -** Contains various tools for interacting with the trace
     viewer such as Zoom, Pan, Select, and Timing. Use the Timing tool to mark a
     time interval.
-1.  **Events -** These show the time during which a op was executed or the
+1.  **Events -** These show the time during which an op was executed or the
     duration of meta-events, such as training steps
 
 ##### Sections and tracks

--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -71,8 +71,8 @@ landing_page:
           support</a>.
         </p>
         <pre class="prettyprint lang-bsh">
-        <code class="devsite-terminal">docker pull tensorflow/tensorflow:latest-py3  # Download latest stable image</code><br/>
-        <code class="devsite-terminal">docker run -it -p 8888:8888 tensorflow/tensorflow:latest-py3-jupyter  # Start Jupyter server</code>
+        <code class="devsite-terminal">docker pull tensorflow/tensorflow:latest  # Download latest stable image</code><br/>
+        <code class="devsite-terminal">docker run -it -p 8888:8888 tensorflow/tensorflow:latest-jupyter  # Start Jupyter server</code>
         </pre>
       buttons:
       - label: Read the Docker install guide

--- a/site/en/install/docker.md
+++ b/site/en/install/docker.md
@@ -41,14 +41,17 @@ using the following format:
 :             : example\: *2.1.0*                                           :
 | `devel`     | Nightly builds of a TensorFlow `master` development         |
 :             : environment. Includes TensorFlow source code.               :
+| `custom-op` | Special experimental image for developing TF custom ops.    |
+:             : More info here: https://github.com/tensorflow/custom-op.    :
 
 Each base *tag* has variants that add or change functionality:
 
 | Tag Variants      | Description                                                                       |
 | ---               | ---                                                                               |
 | *`tag`*`-gpu`     | The specified *tag* release with GPU support. ([See below](#gpu_support))         |
-| *`tag`*`-py3`     | The specified *tag* release with Python 3 support.                                |
 | *`tag`*`-jupyter` | The specified *tag* release with Jupyter (includes TensorFlow tutorial notebooks) |
+
+Versioned images <= 1.15.0 (1.x) and <= 2.1.0 (2.x) have Python 3 (3.5 for Ubuntu 16-based images; 3.6 for Ubuntu 18-based images) in images tagged "-py3" and Python 2.7 in images without "py" in the tag. Newer images have Python 3 in both tags. If you are using these containers for the first time, use the tags without "-py3" in them.
 
 You can use multiple variants at once. For example, the following downloads
 TensorFlow release images to your machine:
@@ -103,10 +106,10 @@ Permission issues can arise when files created within a container are exposed to
 the host. It's usually best to edit files on the host system.
 
 Start a [Jupyter Notebook](https://jupyter.org/){:.external} server using
-TensorFlow's nightly build with Python 3 support:
+TensorFlow's nightly build:
 
 <pre class="devsite-terminal devsite-click-to-copy">
-docker run -it -p 8888:8888 tensorflow/tensorflow:nightly-py3-jupyter
+docker run -it -p 8888:8888 tensorflow/tensorflow:nightly-jupyter
 </pre>
 
 Follow the instructions and open the URL in your host web browser:
@@ -149,7 +152,7 @@ docker run --gpus all -it --rm tensorflow/tensorflow:latest-gpu \
    python -c "import tensorflow as tf; print(tf.reduce_sum(tf.random.normal([1000, 1000])))"
 </pre>
 
-It can take a while to set up the GPU-enabled image. If repeatably running
+It can take a while to set up the GPU-enabled image. If repeatedly running
 GPU-based scripts, you can use `docker exec` to reuse a container.
 
 Use the latest TensorFlow GPU image to start a `bash` shell session in the container:

--- a/site/en/install/docker.md
+++ b/site/en/install/docker.md
@@ -51,8 +51,6 @@ Each base *tag* has variants that add or change functionality:
 | *`tag`*`-gpu`     | The specified *tag* release with GPU support. ([See below](#gpu_support))         |
 | *`tag`*`-jupyter` | The specified *tag* release with Jupyter (includes TensorFlow tutorial notebooks) |
 
-Versioned images <= 1.15.0 (1.x) and <= 2.1.0 (2.x) have Python 3 (3.5 for Ubuntu 16-based images; 3.6 for Ubuntu 18-based images) in images tagged "-py3" and Python 2.7 in images without "py" in the tag. Newer images have Python 3 in both tags. If you are using these containers for the first time, use the tags without "-py3" in them.
-
 You can use multiple variants at once. For example, the following downloads
 TensorFlow release images to your machine:
 

--- a/site/en/install/lang_c.md
+++ b/site/en/install/lang_c.md
@@ -13,7 +13,7 @@ in a future release.
 TensorFlow for C is supported on the following systems:
 
 * Linux, 64-bit, x86
-* macOS X, Version 10.12.6 (Sierra) or higher
+* macOS, Version 10.12.6 (Sierra) or higher
 * Windows, 64-bit x86
 
 ## Setup
@@ -79,7 +79,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/mydir/lib
 </pre>
 </section>
 <section>
-<h3>mac OS</h3>
+<h3>macOS</h3>
 <pre class="prettyprint lang-bsh">
 export LIBRARY_PATH=$LIBRARY_PATH:~/mydir/lib
 export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:~/mydir/lib

--- a/site/en/install/lang_go.md
+++ b/site/en/install/lang_go.md
@@ -14,7 +14,7 @@ Caution: The TensorFlow Go API is *not* covered by the TensorFlow
 TensorFlow for Go is supported on the following systems:
 
 * Linux, 64-bit, x86
-* macOS X, Version 10.12.6 (Sierra) or higher
+* macOS, Version 10.12.6 (Sierra) or higher
 
 
 ## Setup

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -186,7 +186,7 @@ the extracted JNI library.
 
 <div class="ds-selector-tabs">
 <section>
-<h3>Linux / mac OS</h3>
+<h3>Linux / macOS</h3>
 <pre class="devsite-terminal devsite-click-to-copy">java -cp libtensorflow-1.14.0.jar:. -Djava.library.path=./jni HelloTensorFlow</pre>
 </section>
 <section>

--- a/site/en/install/pip.html
+++ b/site/en/install/pip.html
@@ -87,11 +87,12 @@
 </section>
 
 <section>
-<h3>mac OS</h3>
+<h3>macOS</h3>
 <p>Install using the <a href="https://brew.sh/" class="external">Homebrew</a> package manager:</p>
 <pre class="prettyprint lang-bsh">
 <code class="devsite-terminal">/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"</code>
-<code class="devsite-terminal">export PATH="/usr/local/bin:/usr/local/sbin:$PATH"</code>
+<code class="devsite-terminal">export PATH="/usr/local/opt/python/libexec/bin:$PATH"</code>
+<code class="devsite-terminal"># if you are on macOS 10.12 (Sierra) use `export PATH="/usr/local/bin:/usr/local/sbin:$PATH"`</code>
 <code class="devsite-terminal">brew update</code>
 <code class="devsite-terminal">brew install python  # Python 3</code>
 <code class="devsite-terminal">sudo pip3 install -U virtualenv  # system-wide install</code>
@@ -153,7 +154,7 @@
 
 <div class="ds-selector-tabs">
 <section>
-<h3>Ubuntu / mac OS</h3>
+<h3>Ubuntu / macOS</h3>
 <p>
   Create a new virtual environment by choosing a Python interpreter and making a
   <code>./venv</code> directory to hold it:

--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -303,8 +303,7 @@ code and dependencies required to build TensorFlow. See the TensorFlow
 
 ### CPU-only
 
-The following example uses the `:devel` image to build a CPU-only
-Python&nbsp;2 package from the latest TensorFlow source code. See the
+The following example uses the `:devel` image to build a CPU-only package from the latest TensorFlow source code. See the
 [Docker guide](./docker.md) for available TensorFlow `-devel` tags.
 
 Download the latest development image and start a Docker container that we'll
@@ -373,14 +372,14 @@ machine only requires the
 [GPU support guide](./gpu.md) and the TensorFlow [Docker guide](./docker.md)
 to set up [nvidia-docker](https://github.com/NVIDIA/nvidia-docker){:.external} (Linux only).
 
-The following example downloads the TensorFlow `:devel-gpu-py3` image
+The following example downloads the TensorFlow `:devel-gpu` image
 and uses `nvidia-docker` to run the GPU-enabled container. This development image
-is configured to build a Python 3 *pip* package with GPU support:
+is configured to build a *pip* package with GPU support:
 
 <pre class="prettyprint lang-bsh">
-<code class="devsite-terminal">docker pull tensorflow/tensorflow<var>:devel-gpu-py3</var></code>
+<code class="devsite-terminal">docker pull tensorflow/tensorflow<var>:devel-gpu</var></code>
 <code class="devsite-terminal">docker run --gpus all -it -w /tensorflow -v $PWD:/mnt -e HOST_PERMS="$(id -u):$(id -g)" \
-    tensorflow/tensorflow<var>:devel-gpu-py3</var> bash</code>
+    tensorflow/tensorflow<var>:devel-gpu</var> bash</code>
 <code class="devsite-terminal tfo-terminal-root">git pull  # within the container, download the latest source code</code>
 </pre>
 
@@ -404,7 +403,7 @@ Install and verify the package within the container and check for a GPU:
 
 <code class="devsite-terminal tfo-terminal-root">pip install /mnt/tensorflow-<var>version</var>-<var>tags</var>.whl</code>
 <code class="devsite-terminal tfo-terminal-root">cd /tmp  # don't import from source directory</code>
-<code class="devsite-terminal tfo-terminal-root">python -c "import tensorflow as tf; print(tf.contrib.eager.num_gpus())"</code>
+<code class="devsite-terminal tfo-terminal-root">python -c "import tensorflow as tf; print(\"Num GPUs Available: \", len(tf.config.experimental.list_physical_devices('GPU')))"</code>
 </pre>
 
 Success: TensorFlow is now installed.

--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -18,17 +18,18 @@ Install the following build tools to configure your development environment.
 <section>
 <h3>Ubuntu</h3>
 <pre class="prettyprint lang-bsh">
-<code class="devsite-terminal">sudo apt install python-dev python-pip  # or python3-dev python3-pip</code>
+<code class="devsite-terminal">sudo apt install python3-dev python3-pip</code>
 </pre>
 </section>
 <section>
-<h3>mac OS</h3>
+<h3>macOS</h3>
 <p>Requires Xcode 9.2 or later.</p>
 <p>Install using the <a href="https://brew.sh/" class="external">Homebrew</a> package manager:</p>
 <pre class="prettyprint lang-bsh">
 <code class="devsite-terminal">/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"</code>
-<code class="devsite-terminal">export PATH="/usr/local/bin:/usr/local/sbin:$PATH"</code>
-<code class="devsite-terminal">brew install python@2  # or python (Python 3)</code>
+<code class="devsite-terminal">export PATH="/usr/local/opt/python/libexec/bin:$PATH"</code>
+<code class="devsite-terminal"># if you are on macOS 10.12 (Sierra) use `export PATH="/usr/local/bin:/usr/local/sbin:$PATH"`</code>
+<code class="devsite-terminal">brew install python</code>
 </pre>
 </section>
 </div><!--/ds-selector-tabs-->
@@ -101,85 +102,71 @@ flags, for example).
 
 ### Sample session
 
-The `./configure` script The following shows a sample run of `./configure` (your
+The following shows a sample run of `./configure` script (your
 session may differ):
 
 <section class="expandable">
 <h4 class="showalways">View sample configuration session</h4>
 <pre class="devsite-terminal">
 ./configure
-You have bazel 0.15.0 installed.
-Please specify the location of python. [Default is /usr/bin/python]: <b>/usr/bin/python2.7</b>
+You have bazel 3.0.0 installed.
+Please specify the location of python. [Default is /usr/bin/python3]: 
+
 
 Found possible Python library paths:
-  /usr/local/lib/python2.7/dist-packages
-  /usr/lib/python2.7/dist-packages
-Please input the desired Python library path to use.  Default is [/usr/lib/python2.7/dist-packages]
+  /usr/lib/python3/dist-packages
+  /usr/local/lib/python3.6/dist-packages
+Please input the desired Python library path to use.  Default is [/usr/lib/python3/dist-packages]
 
-Do you wish to build TensorFlow with jemalloc as malloc support? [Y/n]:
-jemalloc as malloc support will be enabled for TensorFlow.
-
-Do you wish to build TensorFlow with Google Cloud Platform support? [Y/n]:
-Google Cloud Platform support will be enabled for TensorFlow.
-
-Do you wish to build TensorFlow with Hadoop File System support? [Y/n]:
-Hadoop File System support will be enabled for TensorFlow.
-
-Do you wish to build TensorFlow with Amazon AWS Platform support? [Y/n]:
-Amazon AWS Platform support will be enabled for TensorFlow.
-
-Do you wish to build TensorFlow with Apache Kafka Platform support? [Y/n]:
-Apache Kafka Platform support will be enabled for TensorFlow.
-
-Do you wish to build TensorFlow with XLA JIT support? [y/N]:
-No XLA JIT support will be enabled for TensorFlow.
-
-Do you wish to build TensorFlow with GDR support? [y/N]:
-No GDR support will be enabled for TensorFlow.
-
-Do you wish to build TensorFlow with VERBS support? [y/N]:
-No VERBS support will be enabled for TensorFlow.
-
-Do you wish to build TensorFlow with OpenCL SYCL support? [y/N]:
+Do you wish to build TensorFlow with OpenCL SYCL support? [y/N]: 
 No OpenCL SYCL support will be enabled for TensorFlow.
 
-Do you wish to build TensorFlow with CUDA support? [y/N]: <b>Y</b>
+Do you wish to build TensorFlow with ROCm support? [y/N]: 
+No ROCm support will be enabled for TensorFlow.
+
+Do you wish to build TensorFlow with CUDA support? [y/N]: Y
 CUDA support will be enabled for TensorFlow.
 
-Please specify the CUDA SDK version you want to use. [Leave empty to default to CUDA 9.0]: <b>9.0</b>
-
-Please specify the location where CUDA 9.0 toolkit is installed. Refer to README.md for more details. [Default is /usr/local/cuda]:
-
-Please specify the cuDNN version you want to use. [Leave empty to default to cuDNN 7.0]: <b>7.0</b>
-
-Please specify the location where cuDNN 7 library is installed. Refer to README.md for more details. [Default is /usr/local/cuda]:
-
-Do you wish to build TensorFlow with TensorRT support? [y/N]:
+Do you wish to build TensorFlow with TensorRT support? [y/N]: 
 No TensorRT support will be enabled for TensorFlow.
 
-Please specify the NCCL version you want to use. If NCLL 2.2 is not installed, then you can use version 1.3 that can be fetched automatically but it may have worse performance with multiple GPUs. [Default is 2.2]: 1.3
+Found CUDA 10.1 in:
+    /usr/local/cuda-10.1/targets/x86_64-linux/lib
+    /usr/local/cuda-10.1/targets/x86_64-linux/include
+Found cuDNN 7 in:
+    /usr/lib/x86_64-linux-gnu
+    /usr/include
 
-Please specify a list of comma-separated Cuda compute capabilities you want to build with.
-You can find the compute capability of your device at: https://developer.nvidia.com/cuda-gpus.
-Please note that each additional compute capability significantly increases your
-build time and binary size. [Default is: 3.5,7.0] <b>6.1</b>
 
-Do you want to use clang as CUDA compiler? [y/N]:
+Please specify a list of comma-separated CUDA compute capabilities you want to build with.
+You can find the compute capability of your device at: https://developer.nvidia.com/cuda-gpus. Each capability can be specified as "x.y" or "compute_xy" to include both virtual and binary GPU code, or as "sm_xy" to only include the binary code.
+Please note that each additional compute capability significantly increases your build time and binary size, and that TensorFlow only supports compute capabilities >= 3.5 [Default is: 3.5,7.0]: 6.1
+
+
+Do you want to use clang as CUDA compiler? [y/N]: 
 nvcc will be used as CUDA compiler.
 
-Please specify which gcc should be used by nvcc as the host compiler. [Default is /usr/bin/gcc]:
+Please specify which gcc should be used by nvcc as the host compiler. [Default is /usr/bin/gcc]: 
 
-Do you wish to build TensorFlow with MPI support? [y/N]:
-No MPI support will be enabled for TensorFlow.
 
-Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is -march=native]:
+Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is -march=native -Wno-sign-compare]: 
 
-Would you like to interactively configure ./WORKSPACE for Android builds? [y/N]:
+
+Would you like to interactively configure ./WORKSPACE for Android builds? [y/N]: 
 Not configuring the WORKSPACE for Android builds.
 
-Preconfigured Bazel build configs. You can use any of the below by adding "--config=<>" to your build command. See tools/bazel.rc for more details.
-    --config=mkl            # Build with MKL support.
-    --config=monolithic     # Config for mostly static monolithic build.
+Preconfigured Bazel build configs. You can use any of the below by adding "--config=<>" to your build command. See .bazelrc for more details.
+	--config=mkl         	# Build with MKL support.
+	--config=monolithic  	# Config for mostly static monolithic build.
+	--config=ngraph      	# Build with Intel nGraph support.
+	--config=numa        	# Build with NUMA support.
+	--config=dynamic_kernels	# (Experimental) Build kernels into separate shared objects.
+	--config=v2          	# Build TensorFlow 2.x instead of 1.x.
+Preconfigured Bazel build configs to DISABLE default on features:
+	--config=noaws       	# Disable AWS S3 filesystem support.
+	--config=nogcp       	# Disable GCP support.
+	--config=nohdfs      	# Disable HDFS support.
+	--config=nonccl      	# Disable NVIDIA NCCL support.
 Configuration finished
 </pre>
 </section>

--- a/site/en/r1/guide/debugger.md
+++ b/site/en/r1/guide/debugger.md
@@ -14,7 +14,7 @@ how to use the graphical user interface (GUI) of tfdbg, i.e., the
 
 Note: The TensorFlow debugger uses a
 [curses](https://en.wikipedia.org/wiki/Curses_\(programming_library\))-based text
-user interface. On Mac OS X, the `ncurses` library is required and can be
+user interface. On macOS, the `ncurses` library is required and can be
 installed with `brew install ncurses`. On Windows, curses isn't as
 well supported, so a [readline](https://en.wikipedia.org/wiki/GNU_Readline)-based
 interface can be used with tfdbg by installing `pyreadline` with `pip`. If you
@@ -201,7 +201,7 @@ Try the following commands at the `tfdbg>` prompt (referencing the code at
 | | `--op_type_filter <pattern>` | Execute the next `Session.run`, watching only nodes with op types matching the given regular-expression pattern. | `run --op_type_filter Variable.*` |
 | | `--tensor_dtype_filter <pattern>` | Execute the next `Session.run`, dumping only Tensors with data types (`dtype`s) matching the given regular-expression pattern. | `run --tensor_dtype_filter int.*` |
 | | `-p` | Execute the next `Session.run` call in profiling mode. | `run -p` |
-| **`ri`** | | **Display information about the run the current run, including fetches and feeds.** | `ri` |
+| **`ri`** | | **Display information about the current run, including fetches and feeds.** | `ri` |
 | **`config`** | | **Set or show persistent TFDBG UI configuration.** | |
 | | `set` | Set the value of a config item: {`graph_recursion_depth`, `mouse_mode`}. | `config set graph_recursion_depth 3` |
 | | `show` | Show current persistent UI configuration. | `config show` |

--- a/site/en/r1/guide/extend/op.md
+++ b/site/en/r1/guide/extend/op.md
@@ -331,9 +331,9 @@ Here are the outputs of these functions on an Ubuntu machine.
 $ python
 >>> import tensorflow as tf
 >>> tf.sysconfig.get_include()
-'/usr/local/lib/python2.7/site-packages/tensorflow/include'
+'/usr/local/lib/python3.6/site-packages/tensorflow/include'
 >>> tf.sysconfig.get_lib()
-'/usr/local/lib/python2.7/site-packages/tensorflow'
+'/usr/local/lib/python3.6/site-packages/tensorflow'
 ```
 
 Assuming you have `g++` installed, here is the sequence of commands you can use
@@ -345,7 +345,7 @@ TF_LFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.ge
 g++ -std=c++11 -shared zero_out.cc -o zero_out.so -fPIC ${TF_CFLAGS[@]} ${TF_LFLAGS[@]} -O2
 ```
 
-On Mac OS X, the additional flag "-undefined dynamic_lookup" is required when
+On macOS, the additional flag "-undefined dynamic_lookup" is required when
 building the `.so` file.
 
 >   Note on `gcc` version `>=5`: gcc uses the new C++
@@ -1188,7 +1188,7 @@ generated Python code may change in a way that isn't compatible with old
 callers.  The Python API may be kept compatible by careful changes in a
 hand-written Python wrapper, by keeping the old signature except possibly adding
 new optional arguments to the end.  Generally incompatible changes may only be
-made when TensorFlow's changes major versions, and must conform to the
+made when TensorFlow changes major versions, and must conform to the
 [`GraphDef` version semantics](../guide/version_compat.md#compatibility_of_graphs_and_checkpoints).
 
 ### GPU Support

--- a/site/en/r1/guide/performance/overview.md
+++ b/site/en/r1/guide/performance/overview.md
@@ -136,7 +136,7 @@ and AVX2. The result is a single binary that is optimized and compatible with
 most modern (post-2011) processors.
 
 TensorFlow can be compiled with the MKL optimizations using the following
-commands that depending on the version of the TensorFlow source used.
+commands that depend on the version of the TensorFlow source used.
 
 For TensorFlow source versions after 1.3.0:
 
@@ -258,7 +258,7 @@ bazel build -c opt --copt=-march="broadwell" --config=cuda //tensorflow/tools/pi
   of the GPUs that will be used, e.g. P100: 6.0, Titan X (Pascal): 6.1,
   Titan X (Maxwell): 5.2, and K80: 3.7.
 * Use a version of `gcc` that supports all of the optimizations of the target
-  CPU. The recommended minimum gcc version is 4.8.3. On OS X, upgrade to the
+  CPU. The recommended minimum gcc version is 4.8.3. On macOS, upgrade to the
   latest Xcode version and use the version of clang that comes with Xcode.
 * Install the latest stable CUDA platform and cuDNN libraries supported by
   TensorFlow.


### PR DESCRIPTION
- Removed Python 2 from a bunch of pages where it seemingly was missed during EOL clean up.
- Changed Docker install page as `py3` tag was dropped. Added `custom-op` tag while there.
- [Fixed ](https://github.com/tensorflow/docs/compare/master...Molkree:remove_python_2?expand=1#diff-a2de1331b653964bd3ba0a0031add631L420)`tf.contrib.eager.num_gpus()` in install instructions as it's not available in TF2. Noticed it last year and it's still not fixed D: It even had [issue](https://github.com/tensorflow/tensorflow/issues/33396) created by someone.
- And some extra typo fixes I noticed.