### PR TITLE
Fix comment in autodiff.ipynb

### DIFF
--- a/site/en/guide/autodiff.ipynb
+++ b/site/en/guide/autodiff.ipynb
@@ -228,7 +228,7 @@
         "\n",
         "# Use the tape to compute the derivative of z with respect to the\n",
         "# intermediate value y.\n",
-        "# dz_dx = 2 * y, where y = x ^ 2\n",
+        "# dz_dy = 2 * y, where y = x ^ 2\n",
         "print(t.gradient(z, y))"
       ]
     },


### PR DESCRIPTION
In the comment it said 'dz_dx', however 'dz_dy' is meant