### PR TITLE
Fix a wrong batch size in tutorial

### DIFF
--- a/site/en/tutorials/images/classification.ipynb
+++ b/site/en/tutorials/images/classification.ipynb
@@ -436,7 +436,7 @@
         "id": "60CnhEL4VrWQ"
       },
       "source": [
-        "Visualize the training images by extracting a batch of images from the training generator—which is 32 images in this example—then plot five of them with `matplotlib`."
+        "Visualize the training images by extracting a batch of images from the training generator—which are 128 images in this example—then plot five of them with `matplotlib`."
       ]
     },
     {


### PR DESCRIPTION
The correct size of batch is 128. Replace 32 with 128.
