### PR TITLE
Fix driver version to install CUDA on ubuntu 18.04

### DIFF
--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -95,14 +95,15 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
 <code class="devsite-terminal">sudo apt-get update</code>
 
 # Install NVIDIA driver
-<code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-driver-430</code>
+<code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-driver-440</code>
 # Reboot. Check that GPUs are visible using the command: nvidia-smi
 
 # Install development and runtime libraries (~4GB)
 <code class="devsite-terminal">sudo apt-get install --no-install-recommends \
     cuda-10-1 \
     libcudnn7=7.6.4.38-1+cuda10.1  \
-    libcudnn7-dev=7.6.4.38-1+cuda10.1
+    libcudnn7-dev=7.6.4.38-1+cuda10.1 \
+    cuda-drivers=440.64.00-1
 </code>
 
 # Install TensorRT. Requires that libcudnn7 is installed above.

--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -103,7 +103,7 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
     cuda-10-1 \
     libcudnn7=7.6.4.38-1+cuda10.1  \
     libcudnn7-dev=7.6.4.38-1+cuda10.1 \
-    cuda-drivers=440.64.00-1
+    cuda-drivers=440\*
 </code>
 
 # Install TensorRT. Requires that libcudnn7 is installed above.

--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -103,7 +103,7 @@ complicates installation of the NVIDIA driver and is beyond the scope of these i
     cuda-10-1 \
     libcudnn7=7.6.4.38-1+cuda10.1  \
     libcudnn7-dev=7.6.4.38-1+cuda10.1 \
-    cuda-drivers=440\*
+    cuda-drivers=440.64.00-1
 </code>
 
 # Install TensorRT. Requires that libcudnn7 is installed above.


### PR DESCRIPTION
The issue seems to appear while running line 102 of this doc to install CUDA on Ubuntu 18.04. When I run the following script as it's written in the documentation, I ran to an error.

<code class="devsite-terminal">sudo apt-get install --no-install-recommends \
    cuda-10-1 \
    libcudnn7=7.6.4.38-1+cuda10.1  \
    libcudnn7-dev=7.6.4.38-1+cuda10.1
</code>

The error is as follows: 
```
cuda-10-1 : Depends: cuda-runtime-10-1 (>= 10.1.243) but it is not going to be installed
            Depends: cuda-demo-suite-10-1 (>= 10.1.243) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```
I finally figured out why this happened:

When you install nvidia-driver-430, apt actually installed nvidia-driver-440
After that, when you install development and runtime libraries,
<code class="devsite-terminal">sudo apt-get install --no-install-recommends \
    cuda-10-1 \
    libcudnn7=7.6.4.38-1+cuda10.1  \
    libcudnn7-dev=7.6.4.38-1+cuda10.1
</code>
This will get the error that I elaborated above, cuda-10-1 dependencies cannot be installed.

That's because, NVIDIA has updated their package to cuda-drivers=450.36.06-1, which is compatible with CUDA 11, but not CUDA 10.
When you install cuda-10-1, you actually installing cuda-drivers=450.36.06-1, but this will make the whole system upgraded to nvidia-driver-450 with CUDA 11.

In conclude:
Update command from nvidia-driver-430 to nvidia-driver-440, because when you install 430, you actually installing 440.
Limit cuda-drivers version to 440.64.00-1, which means cuda-drivers=440.64.00-1