### PR TITLE
Increase epochs to 30 to match text

### DIFF
--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -530,7 +530,7 @@
       "outputs": [],
       "source": [
         "history = model.fit(train_batches,\n",
-        "                    epochs=10,\n",
+        "                    epochs=30,\n",
         "                    validation_data=test_batches,\n",
         "                    validation_steps=30)"
       ]


### PR DESCRIPTION
In the last section we have:
"This isn't the case for the validation loss and accuracy—they seem to peak after about twenty epochs."