### PR TITLE
Remove duplicate sentence & fix a typo

### DIFF
--- a/site/en/guide/migrate.ipynb
+++ b/site/en/guide/migrate.ipynb
@@ -647,8 +647,6 @@
       "source": [
         "To convert this code, follow the pattern of mapping layers to layers as in the previous example.\n",
         "\n",
-        "A `v1.variable_scope` is effectively a layer of its own. So rewrite it as a `tf.keras.layers.Layer`. See [the guide](keras/custom_layers_and_models.ipynb) for details.\n",
-        "\n",
         "The general pattern is:\n",
         "\n",
         "* Collect layer parameters in `__init__`.\n",
@@ -1378,7 +1376,7 @@
         "\n",
         "Note: Unlike object based checkpoints, which can [defer loading](checkpoint.ipynb#loading_mechanics), name-based checkpoints require that all variables be built when the function is called. Some models defer building variables until you call `build` or run the model on a batch of data.\n",
         "\n",
-        "The [TensorFlow Estimator repository](https://github.com/tensorflow/estimator/blob/master/tensorflow_estimator/python/estimator/tools/checkpoint_converter.py) includes a [conversion tool](#checkpoint_converter) to upgrade the checkpoints for premade estimators from TensorFlow 1.X to 2.0. It may serve as an example of how to build a tool fr a similar use-case."
+        "The [TensorFlow Estimator repository](https://github.com/tensorflow/estimator/blob/master/tensorflow_estimator/python/estimator/tools/checkpoint_converter.py) includes a [conversion tool](#checkpoint_converter) to upgrade the checkpoints for premade estimators from TensorFlow 1.X to 2.0. It may serve as an example of how to build a tool for a similar use-case."
       ]
     },
     {
@@ -2160,7 +2158,8 @@
       "toc_visible": true
     },
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": "TensorFlow 2.2 on Python 3.6 (CUDA 10.1)",
+      "language": "python",
       "name": "python3"
     }
   },


### PR DESCRIPTION
>A v1.variable_scope is effectively a layer of its own. So rewrite it as a tf.keras.layers.Layer. See the guide for details.
>
>The general pattern is:
>
>- Collect layer parameters in __init__.
>- Build the variables in build.
>- Execute the calculations in call, and return the result.
>
>The v1.variable_scope is essentially a layer of its own. So rewrite it as a tf.keras.layers.Layer. See the guide for details.

First sentence is almost duplicate with last sentence. I just remove the first sentence.

And fix a typo "how to build a tool fr a similar use-case." --> "how to build a tool **for** a similar use-case."

Thanks. :)