### PR TITLE
Add clang-format install instructions to docs

### DIFF
--- a/site/en/community/contribute/code_style.md
+++ b/site/en/community/contribute/code_style.md
@@ -57,17 +57,15 @@ Use `six` to write compatible code (for example, `six.moves.range`).
 ## C++ coding style
 
 Changes to TensorFlow C++ code should conform to the [Google C++ Style
-Guide](https://google.github.io/styleguide/cppguide.html). Use `clang-tidy` to
-check your C/C++ changes.
+Guide](https://google.github.io/styleguide/cppguide.html). Use `clang-format` to check your C/C++ changes.
 
-To install `clang-tidy` on Ubuntu 16+, do:
-
+To install on Ubuntu 16+, do:
 
 ```bash
-$ apt-get install -y clang-tidy
+$ apt-get install -y clang-format
 ```
 
-You can check a C/C++ file by using the following:
+You can check a C/C++ file's format by using the following:
 
 ```bash
 $ clang-format <my_cc_file> --style=google > /tmp/my_cc_file.cc

--- a/site/en/community/contribute/code_style.md
+++ b/site/en/community/contribute/code_style.md
@@ -65,7 +65,7 @@ To install on Ubuntu 16+, do:
 $ apt-get install -y clang-format
 ```
 
-You can check a C/C++ file's format by using the following:
+You can check the format of a C/C++ file with the following:
 
 ```bash
 $ clang-format <my_cc_file> --style=google > /tmp/my_cc_file.cc


### PR DESCRIPTION
Towards https://github.com/tensorflow/tensorflow/issues/41077. Not sure which flags you invoke `clang-tidy` with though.

`clang-format` is also available since Ubuntu 16.04: https://packages.ubuntu.com/search?keywords=clang-format