### PR TITLE
Fix intersection of train and validation sets when using tf.data

### DIFF
--- a/site/en/tutorials/load_data/images.ipynb
+++ b/site/en/tutorials/load_data/images.ipynb
@@ -707,7 +707,7 @@
       },
       "outputs": [],
       "source": [
-        "list_ds = tf.data.Dataset.list_files(str(data_dir/'*/*'))\n",
+        "list_ds = tf.data.Dataset.list_files(str(data_dir/'*/*'), shuffle=False)\n",
         "list_ds = list_ds.shuffle(image_count, reshuffle_each_iteration=False)"
       ]
     },


### PR DESCRIPTION
As [the documentation](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#list_files) states, `list_files()` shuffles filenames by default. So even though `shuffle()` with `reshuffle_each_iteration=False` is used after it, the dataset is still shuffled each iteration because of  `list_files()` default behavior.

This leads to approximately 80% elements of `val_ds` to be from `train_ds` (because `train_ds` indeed contains 80% of all the data). I've used this code to calculate the size of intersection:
```
def get_intersect_len(train, validation):
    train_set = set()
    for file in train:
      train_set.add(file.numpy())

    validation_set = set()
    for file in validation:
      validation_set.add(file.numpy())

    return len([path for path in validation_set if path in train_set])

get_intersect_len(train_ds, val_ds)
```

This also leads to the validation accuracy of the model being very close to its train accuracy.

Suggested fix is to explicitly disable shuffling in `list_files()`.