### PR TITLE
Threshold to be set 0 when using binary accuracy with raw prediction values (from_logits=True)

### DIFF
--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -636,7 +636,7 @@
         "base_learning_rate = 0.0001\n",
         "model.compile(optimizer=tf.keras.optimizers.RMSprop(lr=base_learning_rate),\n",
         "              loss=tf.keras.losses.BinaryCrossentropy(from_logits=True),\n",
-        "              metrics=['accuracy'])"
+        "              metrics=tf.keras.metrics.BinaryAccuracy(threshold=0.0))"
       ]
     },
     {


### PR DESCRIPTION
This is from [#41413](https://github.com/tensorflow/tensorflow/issues/41413) in *tensorflow/tensorflow* by HaraBeron.

In this tutorial raw prediction values (form_logit=True) are used. So we have negative values and positive values, while
"prediction will be treated as a logit, or a raw prediction value. Positive numbers predict class 1, negative numbers predict class 0."

According to [https://www.tensorflow.org/api_docs/python/tf/keras/metrics/BinaryAccuracy](https://www.tensorflow.org/api_docs/python/tf/keras/metrics/BinaryAccuracy)
As per default, threshold value to classify is 0.5:

>tf.keras.metrics.BinaryAccuracy(
>    name='binary_accuracy', dtype=None, threshold=0.5
>)