### PR TITLE
A minor spelling error in the doc

### DIFF
--- a/site/en/guide/tensor.ipynb
+++ b/site/en/guide/tensor.ipynb
@@ -548,7 +548,7 @@
       "source": [
         "### Single-axis indexing\n",
         "\n",
-        "TensorFlow follow standard python indexing rules, similar to [indexing a list or a string in python](https://docs.python.org/3/tutorial/introduction.html#strings), and the bacic rules for numpy indexing.\n",
+        "TensorFlow follow standard python indexing rules, similar to [indexing a list or a string in python](https://docs.python.org/3/tutorial/introduction.html#strings), and the basic rules for numpy indexing.\n",
         "\n",
         "* indexes start at `0`\n",
         "* negative indices count backwards from the end\n",


### PR DESCRIPTION
The term `basic` was written as `bacic`. This has been changed.