### PR TITLE
GitHub actions pr workflows

### DIFF
--- a/.github/workflows/label-lgtm.yaml
+++ b/.github/workflows/label-lgtm.yaml
@@ -1,0 +1,43 @@
+# This workflow adds the community approval label ("lgtm") to pull requests.
+# It does *not* indicate maintainer approval. This a way to visually highlight
+# that someone/anyone thinks the pull request is ready for further review.
+# This event is triggered by a pull request approval, or simply a comment that
+# contains the text "lgtm".
+name: Community approval
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  approval:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check pull request approval
+      if: "contains(github.event.review.state, 'approved')"
+      env:
+        URL: "${{ github.event.pull_request.issue_url }}"
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          "${URL}/labels" \
+          --data '{"labels":["lgtm"]}'
+
+  lgtm:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check comment LGTM
+      # contains is case-insensitive.
+      if: "contains(github.event.comment.body, 'LGTM')"
+      env:
+        URL: "${{ github.event.issue.url }}"
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          "${URL}/labels" \
+          --data '{"labels":["lgtm"]}'

--- a/.github/workflows/welcome.yaml
+++ b/.github/workflows/welcome.yaml
@@ -1,0 +1,58 @@
+# Greet new pull requests that modify notebooks with a comment that includes
+# Colab preview links and instructions to use the tensorflow-docs notebook tools.
+name: Welcome
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  message:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Fetch master branch
+      run: git fetch -u origin master:master
+    - name: Post comment
+      env:
+        URL: "${{ github.event.pull_request.issue_url }}"
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        # Source is the user's forked repo.
+        SRC_REPO: "${{ github.event.pull_request.head.repo.full_name }}"
+        SRC_BRANCH: "${{ github.event.pull_request.head.ref }}"
+        # Dest is repo that's being submitted to.
+        DEST_REPO: "${{ github.event.pull_request.base.repo.full_name }}"
+        PR_NUM: "${{ github.event.pull_request.number }}"
+      run: |
+        # Only want notebooks modified in this pull request.
+        readarray -t notebooks < <(git diff --name-only master | grep '\.ipynb$' || true)
+        if [[ ${#notebooks[@]} -eq 0 ]]; then
+          echo "No notebooks modified in this pull request."
+        else
+          msg="<h4>Preview</h4>\n"
+          msg+="Preview and run these notebook edits with Google Colab:\n<ul>\n"
+          # Link to PR branch in user's fork that is always current.
+          for fp in "${notebooks[@]}"; do
+            gh_path="${SRC_REPO}/blob/${SRC_BRANCH}/${fp}"
+            colab_url="https://colab.research.google.com/github/${gh_path}"
+            msg+="<li><a href='${colab_url}'>${fp}</a></li>\n"
+          done
+          msg+="</ul>\n"
+
+          msg+="<h4>Format and style</h4>\n"
+          msg+="Use the TensorFlow docs <a href='https://github.com/tensorflow/docs/tree/master/tools/tensorflow_docs/tools'>notebook tools</a> to format for consistent source diffs and lint for style:\n"
+          msg+="<pre>\n$ python3 -m pip install -U --user git+https://github.com/tensorflow/docs\n<br/>"
+          msg+="$ python3 -m tensorflow_docs.tools.nbfmt notebook.ipynb\n<br/>"
+          msg+="$ python3 -m tensorflow_docs.tools.nblint --arg=repo:tensorflow/docs notebook.ipynb\n</pre>\n"
+
+          reviewnb_url="https://app.reviewnb.com/${DEST_REPO}/pull/${PR_NUM}/files/"
+          msg+="Rendered <a href='${reviewnb_url}'>notebook diffs</a> available on ReviewNB.com.\n"
+
+          # Escape string for JSON
+          body="$(echo -n -e $msg | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
+          # Post comment
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            "${URL}/comments" \
+            --data "{\"body\": $body}"
+        fi

--- a/tools/tensorflow_docs/tools/README.md
+++ b/tools/tensorflow_docs/tools/README.md
@@ -1,0 +1,83 @@
+# TensorFlow Docs notebook tools
+
+The `tensorflow-docs` package contains a collection of notebook tools designed
+for open source documentation workflows.
+
+[Jupyter notebooks](https://nbformat.readthedocs.io/en/latest/) are the
+preferred documentation format for TensorFlow
+[guides](https://www.tensorflow.org/guide) and
+[tutorials](https://www.tensorflow.org/tutorials). These docs integrate with
+[Google Colab](https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/quickstart/beginner.ipynb)
+for reproducible environments, regularly tested code examples, and more
+maintainable documentation.
+
+
+## Install
+
+Use `pip` to install the latest `tensorflow-docs` package directly from the
+[tensorflow/docs](https://github.com/tensorflow/docs) GitHub repository:
+
+```
+$ python3 -m pip install -U --user git+https://github.com/tensorflow/docs
+```
+
+
+## nbfmt
+
+A notebook formatting tool that makes Jupyter notebook source diffs consistent
+and easier to review. Since notebook authoring environments differ with regards
+to file output, indentation, metadata and other non-specified fields; `nbfmt`
+uses opinionated defaults with a preference for the TensorFlow docs Colab
+workflow. To format a notebook, install the `tensorflow-docs` package and run
+the `nbfmt` tool:
+
+```
+$ python3 -m tensorflow_docs.tools.nbfmt [options] notebook.ipynb [...]
+
+$ python3 -m tensorflow_docs.tools.nbfmt --help
+```
+
+`nbfmt` accepts directory arguments that format all child notebooks (skipping
+non-notebook files).
+
+For TensorFlow docs projects, notebooks *without* output cells are executed and
+tested; notebooks *with* saved output cells are published as-is. `nbfmt`
+respects the notebook state and uses the `--preserve_outputs=True|False` option
+to explicitly keep or clear output cells.
+
+The `--test` flag is for continuous integration tests. This does not format the
+notebook, rather it exits with an error code if the notebook is not in an
+up-to-date formatted state. See the tensorflow/docs
+[GitHub Actions workflow](https://github.com/tensorflow/docs/blob/master/.github/workflows/ci.yaml)
+for an example.
+
+
+## nblint
+
+A notebook linting tool that checks documentation style rules. Used to catch
+common errors and useful for CI tests. To lint a notebook, install the
+`tensorflow-docs` package and run the `nblint` tool:
+
+```
+$ python3 -m tensorflow_docs.tools.nblint [options] notebook.ipynb [...]
+
+$ python3 -m tensorflow_docs.tools.nblint --help
+```
+
+Some styles require a user-defined argument passed at the command-line. For
+example, the `tensorflow` style (default) uses the `repo` argument to check links:
+
+```
+$ python3 -m tensorflow_docs.tools.nblint --arg=repo:tensorflow/docs notebook.ipynb
+```
+
+Lints are assertions that test specific sections of the notebook. These lints
+are collected into
+[style modules](https://github.com/tensorflow/docs/tree/master/tools/tensorflow_docs/tools/nblint/style).
+`nblint` tests the `google` and `tensorflow` styles by default, and different
+styles can be set with the `--styles` option:
+
+```
+$ python3 -m tensorflow_docs.tools.nblint --arg=repo:tensorflow/docs-1l0n \
+    --styles=tensorflow,tensorflow_docs_l10n notebook.ipynb
+```


### PR DESCRIPTION
Add GitHub Actions for:
- Add welcome comment with Colab preview links, tensorflow-docs tools, and link to nbreview.com
- Apply community "lgtm" label on any PR approval or comment.

GH Actions tested here: https://github.com/lamberta/tf-docs/pull/3
Can now remove tfdocsbot@ from the tensorflow/docs repo.

Also adds README doc for tensorflow-docs notebook tools.
