### PR TITLE
Enhance the TensorFlow Multi-worker training with Keras tutorial - provide an example of 2 workers in TF_CONFIG

### DIFF
--- a/site/en/tutorials/distribute/multi_worker_with_keras.ipynb
+++ b/site/en/tutorials/distribute/multi_worker_with_keras.ipynb
@@ -456,7 +456,7 @@
         "\n",
         "The reason you need to save on the chief and workers at the same time, is because you might be aggregating variables during checkpointing which requires both the chief and workers to participate in the allreduce communication protocol. On the other hand, letting chief and workers save to the same model directory will result in errors due to contention.\n",
         "\n",
-        "With `MultiWorkerMirroredStrategy`, the program is run on every worker, and in order to know whether the current worker is chief, we take advantage of the cluster resolver object that has attributes `task_type` and `task_id`. `task_type` tells you what the current job is (e.g. 'worker'), and `task_id` tells you the identifier of the worker. The worker with id 0 is designated as the chief worker.\n",
+        "With `MultiWorkerMirroredStrategy`, the program is run on every worker, and in order to know whether the current worker is chief, it takes advantage of the cluster resolver object that has attributes `task_type` and `task_id`. `task_type` tells you what the current job is (e.g. 'worker'), and `task_id` tells you the identifier of the worker. The worker with id 0 is designated as the chief worker.\n",
         "\n",
         "In the code snippet below, `write_filepath` provides the file path to write, which depends on the worker id. In the case of chief (worker with id 0), it writes to the original file path; for others, it creates a temporary directory (with id in the directory path) to write in:"
       ]
@@ -527,7 +527,7 @@
         "id": "8LXUVVl9_v5x"
       },
       "source": [
-        "As we described above, later on the model should only be loaded from the path chief saved to, so let's remove the temporary ones the non-chief workers saved:"
+        "As described above, later on the model should only be loaded from the path chief saved to, so let's remove the temporary ones the non-chief workers saved:"
       ]
     },
     {
@@ -551,7 +551,7 @@
         "id": "Nr-2PKlHAPBT"
       },
       "source": [
-        "Now, when it's time to load, let's use convenient `tf.keras.models.load_model` API, and continue with further work. Here, we assume only using single worker to load and continue training, in which case you do not call `tf.keras.models.load_model` within another `strategy.scope()`."
+        "Now, when it's time to load, let's use convenient `tf.keras.models.load_model` API, and continue with further work. Here, assume only using single worker to load and continue training, in which case you do not call `tf.keras.models.load_model` within another `strategy.scope()`."
       ]
     },
     {
@@ -566,7 +566,7 @@
       "source": [
         "loaded_model = tf.keras.models.load_model(model_path)\n",
         "\n",
-        "# Now that we have the model restored, and can continue with the training.\n",
+        "# Now that the model is restored, and can continue with the training.\n",
         "loaded_model.fit(single_worker_dataset, epochs=2, steps_per_epoch=20)"
       ]
     },

--- a/site/en/tutorials/distribute/multi_worker_with_keras.ipynb
+++ b/site/en/tutorials/distribute/multi_worker_with_keras.ipynb
@@ -111,7 +111,7 @@
         "\n",
         "Now, let's prepare the MNIST dataset. The [MNIST dataset](http://yann.lecun.com/exdb/mnist/) comprises 60,000\n",
         "training examples and 10,000 test examples of the handwritten digits 0–9,\n",
-        "formatted as 28x28-pixel monochrome images. In this example, we will take the training part of the datasets to demonstrate."
+        "formatted as 28x28-pixel monochrome images. In this example, you will take the training part of the datasets to demonstrate."
       ]
     },
     {
@@ -127,7 +127,7 @@
         "def mnist_dataset(batch_size):\n",
         "  (x_train, y_train), _ = tf.keras.datasets.mnist.load_data()\n",
         "  # The `x` arrays are in uint8 and have values in the range [0, 255].\n",
-        "  # We need to convert them to float32 with values in the range [0, 1]\n",
+        "  # You need to convert them to float32 with values in the range [0, 1]\n",
         "  x_train = x_train / np.float32(255)\n",
         "  y_train = y_train.astype(np.int64)\n",
         "  train_dataset = tf.data.Dataset.from_tensor_slices(\n",
@@ -143,7 +143,7 @@
       },
       "source": [
         "## Build the Keras model\n",
-        "Here we use `tf.keras.Sequential` API to build and compile a simple convolutional neural networks Keras model to train with our MNIST dataset.\n",
+        "Here, you use `tf.keras.Sequential` API to build and compile a simple convolutional neural networks Keras model to train with the MNIST dataset.\n",
         "\n",
         "Note: For a more comprehensive walkthrough of building Keras model, please see [TensorFlow Keras Guide](https://www.tensorflow.org/guide/keras#sequential_model).\n"
       ]
@@ -213,7 +213,7 @@
         "\n",
         "There are two components of `TF_CONFIG`: `cluster` and `task`. `cluster` provides information about the training cluster, which is a dict consisting of different types of jobs such as `worker`. In multi-worker training with `MultiWorkerMirroredStrategy`, there is usually one `worker` that takes on a little more responsibility like saving checkpoint and writing summary file for TensorBoard in addition to what a regular `worker` does. Such worker is referred to as the `chief` worker, and it is customary that the `worker` with `index` 0 is appointed as the chief `worker` (in fact this is how `tf.distribute.Strategy` is implemented). `task` on the other hand provides information of the current task. The first component `cluster` is the same for all workers, and the second component `task` is different on each worker and specifies the `type` and `index` of that worker. \n",
         "\n",
-        "In this example, we set the task `type` to `\"worker\"` and the task `index` to `0`. This means the machine that has such setting is the first worker, which will be appointed as the chief worker and do more work than other workers. Note that other machines will need to have `TF_CONFIG` environment variable set as well, and it should have the same `cluster` dict, but different task `type` or task `index` depending on what the roles of those machines are.\n",
+        "In this example, you set the task `type` to `\"worker\"` and the task `index` to `0`. This means the machine that has such setting is the first worker, which will be appointed as the chief worker and do more work than other workers. Note that other machines will need to have `TF_CONFIG` environment variable set as well, and it should have the same `cluster` dict, but different task `type` or task `index` depending on what the roles of those machines are.\n",
         "\n",
         "For illustration purposes, this tutorial shows how one may set a `TF_CONFIG` with 2 workers on `localhost`.  In practice, users would create multiple workers on external IP addresses/ports, and set `TF_CONFIG` on each worker appropriately. So, for example, if you have 2 workers, you should set the task `index` to `0` and `1` separately.\n",
         "\n",
@@ -318,7 +318,7 @@
         "num_workers = 4\n",
         "\n",
         "# Here the batch size scales up by number of workers since \n",
-        "# `tf.data.Dataset.batch` expects the global batch size. Previously we used 64, \n",
+        "# `tf.data.Dataset.batch` expects the global batch size. Previously, you used 64, \n",
         "# and now this becomes 128.\n",
         "global_batch_size = per_worker_batch_size * num_workers\n",
         "multi_worker_dataset = mnist_dataset(global_batch_size)\n",
@@ -368,7 +368,7 @@
         "id": "NBCtYvmCH-7g"
       },
       "source": [
-        "Another thing to notice is the batch size for the `datasets`. In the code snippet above, we use `global_batch_size = per_worker_batch_size * num_workers`, which is `num_workers` times as large as the case it was for single worker, because the effective per worker batch size is the global batch size (the parameter passed in `tf.data.Dataset.batch()`) divided by the number of workers, and with this change we are keeping the per worker batch size same as before."
+        "Another thing to notice is the batch size for the `datasets`. In the code snippet above, you use `global_batch_size = per_worker_batch_size * num_workers`, which is `num_workers` times as large as the case it was for single worker, because the effective per worker batch size is the global batch size (the parameter passed in `tf.data.Dataset.batch()`) divided by the number of workers, and with this change you are keeping the per worker batch size same as before."
       ]
     },
     {
@@ -420,12 +420,12 @@
       "source": [
         "## Fault tolerance\n",
         "\n",
-        "In synchronous training, the cluster would fail if one of the workers fails and no failure-recovery mechanism exists. Using Keras with `tf.distribute.Strategy` comes with the advantage of fault tolerance in cases where workers die or are otherwise unstable. We do this by preserving training state in the distributed file system of your choice, such that upon restart of the instance that previously failed or preempted, the training state is recovered.\n",
+        "In synchronous training, the cluster would fail if one of the workers fails and no failure-recovery mechanism exists. Using Keras with `tf.distribute.Strategy` comes with the advantage of fault tolerance in cases where workers die or are otherwise unstable. You do this by preserving training state in the distributed file system of your choice, such that upon restart of the instance that previously failed or preempted, the training state is recovered.\n",
         "\n",
         "Since all the workers are kept in sync in terms of training epochs and steps, other workers would need to wait for the failed or preempted worker to restart to continue.\n",
         "\n",
         "Note:\n",
-        "Previously, the `ModelCheckpoint` callback provided a mechanism to restore training state upon restart from job failure for multi-worker training. We are introducing a new [`BackupAndRestore`](#scrollTo=kmH8uCUhfn4w) callback, to also add the support to single worker training for a consistent experience, and removed fault tolerance functionality from existing `ModelCheckpoint` callback. From now on, applications that rely on this behavior should migrate to the new callback."
+        "Previously, the `ModelCheckpoint` callback provided a mechanism to restore training state upon restart from job failure for multi-worker training. The TensorFlow team are introducing a new [`BackupAndRestore`](#scrollTo=kmH8uCUhfn4w) callback, to also add the support to single worker training for a consistent experience, and removed fault tolerance functionality from existing `ModelCheckpoint` callback. From now on, applications that rely on this behavior should migrate to the new callback."
       ]
     },
     {
@@ -452,7 +452,7 @@
       "source": [
         "## Model saving and loading\n",
         "\n",
-        "To save your model using `model.save` or `tf.saved_model.save`, the destination for saving needs to be different for each worker. On the non-chief workers, you will need to save the model to a temporary directory, and on the chief, you will need to save to the provided model directory. The temporary directories on the worker need to be unique to prevent errors resulting from multiple workers trying to write to the same location. The model saved in all the directories are identical and typically only the model saved by the chief should be referenced for restoring or serving. We recommend that you have some cleanup logic that deletes the temporary directories created by the workers once your training has completed.\n",
+        "To save your model using `model.save` or `tf.saved_model.save`, the destination for saving needs to be different for each worker. On the non-chief workers, you will need to save the model to a temporary directory, and on the chief, you will need to save to the provided model directory. The temporary directories on the worker need to be unique to prevent errors resulting from multiple workers trying to write to the same location. The model saved in all the directories are identical and typically only the model saved by the chief should be referenced for restoring or serving. You should have some cleanup logic that deletes the temporary directories created by the workers once your training has completed.\n",
         "\n",
         "The reason you need to save on the chief and workers at the same time, is because you might be aggregating variables during checkpointing which requires both the chief and workers to participate in the allreduce communication protocol. On the other hand, letting chief and workers save to the same model directory will result in errors due to contention.\n",
         "\n",

--- a/site/en/tutorials/distribute/multi_worker_with_keras.ipynb
+++ b/site/en/tutorials/distribute/multi_worker_with_keras.ipynb
@@ -215,7 +215,7 @@
         "\n",
         "In this example, we set the task `type` to `\"worker\"` and the task `index` to `0`. This means the machine that has such setting is the first worker, which will be appointed as the chief worker and do more work than other workers. Note that other machines will need to have `TF_CONFIG` environment variable set as well, and it should have the same `cluster` dict, but different task `type` or task `index` depending on what the roles of those machines are.\n",
         "\n",
-        "For illustration purposes, this tutorial shows how one may set a `TF_CONFIG` with 2 workers on `localhost`.  In practice, users would create multiple workers on external IP addresses/ports, and set `TF_CONFIG` on each worker appropriately.\n",
+        "For illustration purposes, this tutorial shows how one may set a `TF_CONFIG` with 2 workers on `localhost`.  In practice, users would create multiple workers on external IP addresses/ports, and set `TF_CONFIG` on each worker appropriately. So, for example, if you have 2 workers, you should set the task `index` to `0` and `1` separately.\n",
         "\n",
         "Warning: Do not execute the following code in Colab.  TensorFlow's runtime will attempt to create a gRPC server at the specified IP address and port, which will likely fail.\n",
         "\n",
@@ -343,7 +343,7 @@
         "### Dataset sharding and batch size\n",
         "In multi-worker training with `MultiWorkerMirroredStrategy`, sharding the dataset is needed to ensure convergence and performance. However, note that in above code snippet, the datasets are directly passed to `model.fit()` without needing to shard; this is because `tf.distribute.Strategy` API takes care of the dataset sharding automatically. It shards the dataset at the file level which may create skewed shards. In extreme cases where there is only one file, only the first shard (i.e. worker) will get training or evaluation data and as a result all workers will get errors.\n",
         "\n",
-        "If you prefer manual sharding for your training, automatic sharding can be turned off via `tf.data.experimental.DistributeOptions` api. Concretely,"
+        "If you prefer manual sharding for your training, automatic sharding can be turned off via `tf.data.experimental.DistributeOptions` API. For example:"
       ]
     },
     {


### PR DESCRIPTION
This PR updates the **[TensorFlow Multi-worker training with Keras](https://www.tensorflow.org/tutorials/distribute/multi_worker_with_keras)** notebook by addressing https://github.com/tensorflow/tensorflow/issues/41257 and potentially helping with issues, such as https://github.com/tensorflow/tensorflow/issues/39922:

- Provided a sentence with an example of 2 workers in `TF_CONFIG` (background: to create multiple workers on external IP addresses/ports, you configure `TF_CONFIG` on each worker)
- Made a small change to the section that explains how to turn off automatic manual sharding for training in `tf.data.experimental.DistributeOptions` for clarity

Thank you @guptapriya and @lamberta 

