### PR TITLE
- updated the link of cloud management console in data performance an…

### DIFF
--- a/site/en/guide/data_performance_analysis.md
+++ b/site/en/guide/data_performance_analysis.md
@@ -85,8 +85,7 @@ available resources. In general, even when running your model on an accelerator
 like a GPU or TPU, the `tf.data` pipelines are run on the CPU. You can check
 your utilization with tools like [sar](https://linux.die.net/man/1/sar) and
 [htop](https://en.wikipedia.org/wiki/Htop), or in the
-[cloud monitoring console](console.cloud.google.com/compute/instances) if you’re
-running on GCP.
+[cloud monitoring console](https://cloud.google.com/monitoring/docs/monitoring_in_console) if you’re running on GCP.
 
 **If your utilization is low,** this suggests that your input pipeline may not
 be taking full advantage of the host CPU. You should consult the


### PR DESCRIPTION
Issue [#42218](https://github.com/tensorflow/tensorflow/issues/42218) mentions incorrect link to the cloud monitoring console in the tensorflow documentation.

Updated here with the link to the cloud monitoring in google cloud console documentation on GCP for appropriate navigation.

Please verify.