### PR TITLE
[Guides] Fix typo in Variable guide

### DIFF
--- a/site/en/guide/variable.ipynb
+++ b/site/en/guide/variable.ipynb
@@ -407,7 +407,7 @@
       "source": [
         "## Next steps\n",
         "\n",
-        "To understand how variables are typically used, see our guide on [automatic distribution](autodiff)."
+        "To understand how variables are typically used, see our guide on [automatic differentiation](autodiff)."
       ]
     }
   ],

--- a/site/en/guide/variable.ipynb
+++ b/site/en/guide/variable.ipynb
@@ -407,7 +407,7 @@
       "source": [
         "## Next steps\n",
         "\n",
-        "To understand how variables are typically used, see our guide on [automatic differentiation](autodiff)."
+        "To understand how variables are typically used, see our guide on [automatic differentiation](autodiff.ipynb)."
       ]
     }
   ],


### PR DESCRIPTION
Hey, the very last sentence in the [Variable guide](https://www.tensorflow.org/guide/variable) had a typo in the link text.