### PR TITLE
fix: only use tf.keras instead of keras

### DIFF
--- a/site/en/guide/ragged_tensor.ipynb
+++ b/site/en/guide/ragged_tensor.ipynb
@@ -63,6 +63,17 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
+        "id": "5DP8XNP-6zlu"
+      },
+      "source": [
+        "\n",
+        "**API Documentation:** [`tf.RaggedTensor`](https://www.tensorflow.org/api_docs/python/tf/ragged) [`tf.Ragged`](https://www.tensorflow.org/api_docs/python/tf/RaggedTensor)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
         "id": "cDIUjj07-rQg"
       },
       "source": [

--- a/site/en/tutorials/keras/classification.ipynb
+++ b/site/en/tutorials/keras/classification.ipynb
@@ -1,1047 +1,1034 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "MhoQ0WE77laV"
-   },
-   "source": [
-    "##### Copyright 2018 The TensorFlow Authors."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "cellView": "form",
-    "colab": {},
-    "colab_type": "code",
-    "id": "_ckMIh7O7s6D"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "# https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "cellView": "form",
-    "colab": {},
-    "colab_type": "code",
-    "id": "vasWnqRgy1H4"
-   },
-   "outputs": [],
-   "source": [
-    "#@title MIT License\n",
-    "#\n",
-    "# Copyright (c) 2017 François Chollet\n",
-    "#\n",
-    "# Permission is hereby granted, free of charge, to any person obtaining a\n",
-    "# copy of this software and associated documentation files (the \"Software\"),\n",
-    "# to deal in the Software without restriction, including without limitation\n",
-    "# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n",
-    "# and/or sell copies of the Software, and to permit persons to whom the\n",
-    "# Software is furnished to do so, subject to the following conditions:\n",
-    "#\n",
-    "# The above copyright notice and this permission notice shall be included in\n",
-    "# all copies or substantial portions of the Software.\n",
-    "#\n",
-    "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n",
-    "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n",
-    "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n",
-    "# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n",
-    "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
-    "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
-    "# DEALINGS IN THE SOFTWARE."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "jYysdyb-CaWM"
-   },
-   "source": [
-    "# Basic classification: Classify images of clothing"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "S5Uhzt6vVIB2"
-   },
-   "source": [
-    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
-    "  </td>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "FbVhjPpzn6BM"
-   },
-   "source": [
-    "This guide trains a neural network model to classify images of clothing, like sneakers and shirts. It's okay if you don't understand all the details; this is a fast-paced overview of a complete TensorFlow program with the details explained as you go.\n",
-    "\n",
-    "This guide uses [tf.keras](https://www.tensorflow.org/guide/keras), a high-level API to build and train models in TensorFlow."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "dzLKpmZICaWN"
-   },
-   "outputs": [],
-   "source": [
-    "# TensorFlow and tf.keras\n",
-    "import tensorflow as tf\n",
-    "\n",
-    "# Helper libraries\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "print(tf.__version__)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "yR0EdgrLCaWR"
-   },
-   "source": [
-    "## Import the Fashion MNIST dataset"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "DLdCchMdCaWQ"
-   },
-   "source": [
-    "This guide uses the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset which contains 70,000 grayscale images in 10 categories. The images show individual articles of clothing at low resolution (28 by 28 pixels), as seen here:\n",
-    "\n",
-    "<table>\n",
-    "  <tr><td>\n",
-    "    <img src=\"https://tensorflow.org/images/fashion-mnist-sprite.png\"\n",
-    "         alt=\"Fashion MNIST sprite\"  width=\"600\">\n",
-    "  </td></tr>\n",
-    "  <tr><td align=\"center\">\n",
-    "    <b>Figure 1.</b> <a href=\"https://github.com/zalandoresearch/fashion-mnist\">Fashion-MNIST samples</a> (by Zalando, MIT License).<br/>&nbsp;\n",
-    "  </td></tr>\n",
-    "</table>\n",
-    "\n",
-    "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. The MNIST dataset contains images of handwritten digits (0, 1, 2, etc.) in a format identical to that of the articles of clothing you'll use here.\n",
-    "\n",
-    "This guide uses Fashion MNIST for variety, and because it's a slightly more challenging problem than regular MNIST. Both datasets are relatively small and are used to verify that an algorithm works as expected. They're good starting points to test and debug code.\n",
-    "\n",
-    "Here, 60,000 images are used to train the network and 10,000 images to evaluate how accurately the network learned to classify images. You can access the Fashion MNIST directly from TensorFlow. Import and load the Fashion MNIST data directly from TensorFlow:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "7MqDQO0KCaWS"
-   },
-   "outputs": [],
-   "source": [
-    "fashion_mnist = tf.keras.datasets.fashion_mnist\n",
-    "\n",
-    "(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "t9FDsUlxCaWW"
-   },
-   "source": [
-    "Loading the dataset returns four NumPy arrays:\n",
-    "\n",
-    "* The `train_images` and `train_labels` arrays are the *training set*—the data the model uses to learn.\n",
-    "* The model is tested against the *test set*, the `test_images`, and `test_labels` arrays.\n",
-    "\n",
-    "The images are 28x28 NumPy arrays, with pixel values ranging from 0 to 255. The *labels* are an array of integers, ranging from 0 to 9. These correspond to the *class* of clothing the image represents:\n",
-    "\n",
-    "<table>\n",
-    "  <tr>\n",
-    "    <th>Label</th>\n",
-    "    <th>Class</th>\n",
-    "  </tr>\n",
-    "  <tr>\n",
-    "    <td>0</td>\n",
-    "    <td>T-shirt/top</td>\n",
-    "  </tr>\n",
-    "  <tr>\n",
-    "    <td>1</td>\n",
-    "    <td>Trouser</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>2</td>\n",
-    "    <td>Pullover</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>3</td>\n",
-    "    <td>Dress</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>4</td>\n",
-    "    <td>Coat</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>5</td>\n",
-    "    <td>Sandal</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>6</td>\n",
-    "    <td>Shirt</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>7</td>\n",
-    "    <td>Sneaker</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>8</td>\n",
-    "    <td>Bag</td>\n",
-    "  </tr>\n",
-    "    <tr>\n",
-    "    <td>9</td>\n",
-    "    <td>Ankle boot</td>\n",
-    "  </tr>\n",
-    "</table>\n",
-    "\n",
-    "Each image is mapped to a single label. Since the *class names* are not included with the dataset, store them here to use later when plotting the images:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "IjnLH5S2CaWx"
-   },
-   "outputs": [],
-   "source": [
-    "class_names = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',\n",
-    "               'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Brm0b_KACaWX"
-   },
-   "source": [
-    "## Explore the data\n",
-    "\n",
-    "Let's explore the format of the dataset before training the model. The following shows there are 60,000 images in the training set, with each image represented as 28 x 28 pixels:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "zW5k_xz1CaWX"
-   },
-   "outputs": [],
-   "source": [
-    "train_images.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "cIAcvQqMCaWf"
-   },
-   "source": [
-    "Likewise, there are 60,000 labels in the training set:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "TRFYHB2mCaWb"
-   },
-   "outputs": [],
-   "source": [
-    "len(train_labels)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "YSlYxFuRCaWk"
-   },
-   "source": [
-    "Each label is an integer between 0 and 9:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "XKnCTHz4CaWg"
-   },
-   "outputs": [],
-   "source": [
-    "train_labels"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "TMPI88iZpO2T"
-   },
-   "source": [
-    "There are 10,000 images in the test set. Again, each image is represented as 28 x 28 pixels:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "2KFnYlcwCaWl"
-   },
-   "outputs": [],
-   "source": [
-    "test_images.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "rd0A0Iu0CaWq"
-   },
-   "source": [
-    "And the test set contains 10,000 images labels:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "iJmPr5-ACaWn"
-   },
-   "outputs": [],
-   "source": [
-    "len(test_labels)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "ES6uQoLKCaWr"
-   },
-   "source": [
-    "## Preprocess the data\n",
-    "\n",
-    "The data must be preprocessed before training the network. If you inspect the first image in the training set, you will see that the pixel values fall in the range of 0 to 255:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "m4VEw8Ud9Quh"
-   },
-   "outputs": [],
-   "source": [
-    "plt.figure()\n",
-    "plt.imshow(train_images[0])\n",
-    "plt.colorbar()\n",
-    "plt.grid(False)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Wz7l27Lz9S1P"
-   },
-   "source": [
-    "Scale these values to a range of 0 to 1 before feeding them to the neural network model. To do so, divide the values by 255. It's important that the *training set* and the *testing set* be preprocessed in the same way:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "bW5WzIPlCaWv"
-   },
-   "outputs": [],
-   "source": [
-    "train_images = train_images / 255.0\n",
-    "\n",
-    "test_images = test_images / 255.0"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Ee638AlnCaWz"
-   },
-   "source": [
-    "To verify that the data is in the correct format and that you're ready to build and train the network, let's display the first 25 images from the *training set* and display the class name below each image."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "oZTImqg_CaW1"
-   },
-   "outputs": [],
-   "source": [
-    "plt.figure(figsize=(10,10))\n",
-    "for i in range(25):\n",
-    "    plt.subplot(5,5,i+1)\n",
-    "    plt.xticks([])\n",
-    "    plt.yticks([])\n",
-    "    plt.grid(False)\n",
-    "    plt.imshow(train_images[i], cmap=plt.cm.binary)\n",
-    "    plt.xlabel(class_names[train_labels[i]])\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "59veuiEZCaW4"
-   },
-   "source": [
-    "## Build the model\n",
-    "\n",
-    "Building the neural network requires configuring the layers of the model, then compiling the model."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Gxg1XGm0eOBy"
-   },
-   "source": [
-    "### Set up the layers\n",
-    "\n",
-    "The basic building block of a neural network is the *layer*. Layers extract representations from the data fed into them. Hopefully, these representations are meaningful for the problem at hand.\n",
-    "\n",
-    "Most of deep learning consists of chaining together simple layers. Most layers, such as `tf.keras.layers.Dense`, have parameters that are learned during training."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "9ODch-OFCaW4"
-   },
-   "outputs": [],
-   "source": [
-    "model = tf.keras.Sequential([\n",
-    "    tf.keras.layers.Flatten(input_shape=(28, 28)),\n",
-    "    tf.keras.layers.Dense(128, activation='relu'),\n",
-    "    tf.keras.layers.Dense(10)\n",
-    "])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "gut8A_7rCaW6"
-   },
-   "source": [
-    "The first layer in this network, `tf.keras.layers.Flatten`, transforms the format of the images from a two-dimensional array (of 28 by 28 pixels) to a one-dimensional array (of 28 * 28 = 784 pixels). Think of this layer as unstacking rows of pixels in the image and lining them up. This layer has no parameters to learn; it only reformats the data.\n",
-    "\n",
-    "After the pixels are flattened, the network consists of a sequence of two `tf.keras.layers.Dense` layers. These are densely connected, or fully connected, neural layers. The first `Dense` layer has 128 nodes (or neurons). The second (and last) layer returns a logits array with length of 10. Each node contains a score that indicates the current image belongs to one of the 10 classes.\n",
-    "\n",
-    "### Compile the model\n",
-    "\n",
-    "Before the model is ready for training, it needs a few more settings. These are added during the model's *compile* step:\n",
-    "\n",
-    "* *Loss function* —This measures how accurate the model is during training. You want to minimize this function to \"steer\" the model in the right direction.\n",
-    "* *Optimizer* —This is how the model is updated based on the data it sees and its loss function.\n",
-    "* *Metrics* —Used to monitor the training and testing steps. The following example uses *accuracy*, the fraction of the images that are correctly classified."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Lhan11blCaW7"
-   },
-   "outputs": [],
-   "source": [
-    "model.compile(optimizer='adam',\n",
-    "              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
-    "              metrics=['accuracy'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "qKF6uW-BCaW-"
-   },
-   "source": [
-    "## Train the model\n",
-    "\n",
-    "Training the neural network model requires the following steps:\n",
-    "\n",
-    "1. Feed the training data to the model. In this example, the training data is in the `train_images` and `train_labels` arrays.\n",
-    "2. The model learns to associate images and labels.\n",
-    "3. You ask the model to make predictions about a test set—in this example, the `test_images` array.\n",
-    "4. Verify that the predictions match the labels from the `test_labels` array.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Z4P4zIV7E28Z"
-   },
-   "source": [
-    "### Feed the model\n",
-    "\n",
-    "To start training,  call the `model.fit` method—so called because it \"fits\" the model to the training data:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "xvwvpA64CaW_"
-   },
-   "outputs": [],
-   "source": [
-    "model.fit(train_images, train_labels, epochs=10)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "W3ZVOhugCaXA"
-   },
-   "source": [
-    "As the model trains, the loss and accuracy metrics are displayed. This model reaches an accuracy of about 0.91 (or 91%) on the training data."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "wCpr6DGyE28h"
-   },
-   "source": [
-    "### Evaluate accuracy\n",
-    "\n",
-    "Next, compare how the model performs on the test dataset:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "VflXLEeECaXC"
-   },
-   "outputs": [],
-   "source": [
-    "test_loss, test_acc = model.evaluate(test_images,  test_labels, verbose=2)\n",
-    "\n",
-    "print('\\nTest accuracy:', test_acc)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "yWfgsmVXCaXG"
-   },
-   "source": [
-    "It turns out that the accuracy on the test dataset is a little less than the accuracy on the training dataset. This gap between training accuracy and test accuracy represents *overfitting*. Overfitting happens when a machine learning model performs worse on new, previously unseen inputs than it does on the training data. An overfitted model \"memorizes\" the noise and details in the training dataset to a point where it negatively impacts the performance of the model on the new data. For more information, see the following:\n",
-    "*   [Demonstrate overfitting](https://www.tensorflow.org/tutorials/keras/overfit_and_underfit#demonstrate_overfitting)\n",
-    "*   [Strategies to prevent overfitting](https://www.tensorflow.org/tutorials/keras/overfit_and_underfit#strategies_to_prevent_overfitting)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "v-PyD1SYE28q"
-   },
-   "source": [
-    "### Make predictions\n",
-    "\n",
-    "With the model trained, you can use it to make predictions about some images.\n",
-    "The model's linear outputs, [logits](https://developers.google.com/machine-learning/glossary#logits). Attach a softmax layer to convert the logits to probabilities, which are easier to interpret. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "DnfNA0CrQLSD"
-   },
-   "outputs": [],
-   "source": [
-    "probability_model = tf.keras.Sequential([model, \n",
-    "                                         tf.keras.layers.Softmax()])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Gl91RPhdCaXI"
-   },
-   "outputs": [],
-   "source": [
-    "predictions = probability_model.predict(test_images)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "x9Kk1voUCaXJ"
-   },
-   "source": [
-    "Here, the model has predicted the label for each image in the testing set. Let's take a look at the first prediction:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "3DmJEUinCaXK"
-   },
-   "outputs": [],
-   "source": [
-    "predictions[0]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "-hw1hgeSCaXN"
-   },
-   "source": [
-    "A prediction is an array of 10 numbers. They represent the model's \"confidence\" that the image corresponds to each of the 10 different articles of clothing. You can see which label has the highest confidence value:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "qsqenuPnCaXO"
-   },
-   "outputs": [],
-   "source": [
-    "np.argmax(predictions[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "E51yS7iCCaXO"
-   },
-   "source": [
-    "So, the model is most confident that this image is an ankle boot, or `class_names[9]`. Examining the test label shows that this classification is correct:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Sd7Pgsu6CaXP"
-   },
-   "outputs": [],
-   "source": [
-    "test_labels[0]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "ygh2yYC972ne"
-   },
-   "source": [
-    "Graph this to look at the full set of 10 class predictions."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "DvYmmrpIy6Y1"
-   },
-   "outputs": [],
-   "source": [
-    "def plot_image(i, predictions_array, true_label, img):\n",
-    "  true_label, img = true_label[i], img[i]\n",
-    "  plt.grid(False)\n",
-    "  plt.xticks([])\n",
-    "  plt.yticks([])\n",
-    "\n",
-    "  plt.imshow(img, cmap=plt.cm.binary)\n",
-    "\n",
-    "  predicted_label = np.argmax(predictions_array)\n",
-    "  if predicted_label == true_label:\n",
-    "    color = 'blue'\n",
-    "  else:\n",
-    "    color = 'red'\n",
-    "\n",
-    "  plt.xlabel(\"{} {:2.0f}% ({})\".format(class_names[predicted_label],\n",
-    "                                100*np.max(predictions_array),\n",
-    "                                class_names[true_label]),\n",
-    "                                color=color)\n",
-    "\n",
-    "def plot_value_array(i, predictions_array, true_label):\n",
-    "  true_label = true_label[i]\n",
-    "  plt.grid(False)\n",
-    "  plt.xticks(range(10))\n",
-    "  plt.yticks([])\n",
-    "  thisplot = plt.bar(range(10), predictions_array, color=\"#777777\")\n",
-    "  plt.ylim([0, 1])\n",
-    "  predicted_label = np.argmax(predictions_array)\n",
-    "\n",
-    "  thisplot[predicted_label].set_color('red')\n",
-    "  thisplot[true_label].set_color('blue')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Zh9yABaME29S"
-   },
-   "source": [
-    "### Verify predictions\n",
-    "\n",
-    "With the model trained, you can use it to make predictions about some images."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "d4Ov9OFDMmOD"
-   },
-   "source": [
-    "Let's look at the 0th image, predictions, and prediction array. Correct prediction labels are blue and incorrect prediction labels are red. The number gives the percentage (out of 100) for the predicted label."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "HV5jw-5HwSmO"
-   },
-   "outputs": [],
-   "source": [
-    "i = 0\n",
-    "plt.figure(figsize=(6,3))\n",
-    "plt.subplot(1,2,1)\n",
-    "plot_image(i, predictions[i], test_labels, test_images)\n",
-    "plt.subplot(1,2,2)\n",
-    "plot_value_array(i, predictions[i],  test_labels)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Ko-uzOufSCSe"
-   },
-   "outputs": [],
-   "source": [
-    "i = 12\n",
-    "plt.figure(figsize=(6,3))\n",
-    "plt.subplot(1,2,1)\n",
-    "plot_image(i, predictions[i], test_labels, test_images)\n",
-    "plt.subplot(1,2,2)\n",
-    "plot_value_array(i, predictions[i],  test_labels)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "kgdvGD52CaXR"
-   },
-   "source": [
-    "Let's plot several images with their predictions. Note that the model can be wrong even when very confident."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "hQlnbqaw2Qu_"
-   },
-   "outputs": [],
-   "source": [
-    "# Plot the first X test images, their predicted labels, and the true labels.\n",
-    "# Color correct predictions in blue and incorrect predictions in red.\n",
-    "num_rows = 5\n",
-    "num_cols = 3\n",
-    "num_images = num_rows*num_cols\n",
-    "plt.figure(figsize=(2*2*num_cols, 2*num_rows))\n",
-    "for i in range(num_images):\n",
-    "  plt.subplot(num_rows, 2*num_cols, 2*i+1)\n",
-    "  plot_image(i, predictions[i], test_labels, test_images)\n",
-    "  plt.subplot(num_rows, 2*num_cols, 2*i+2)\n",
-    "  plot_value_array(i, predictions[i], test_labels)\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "R32zteKHCaXT"
-   },
-   "source": [
-    "## Use the trained model\n",
-    "\n",
-    "Finally, use the trained model to make a prediction about a single image."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "yRJ7JU7JCaXT"
-   },
-   "outputs": [],
-   "source": [
-    "# Grab an image from the test dataset.\n",
-    "img = test_images[1]\n",
-    "\n",
-    "print(img.shape)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "vz3bVp21CaXV"
-   },
-   "source": [
-    "`tf.keras` models are optimized to make predictions on a *batch*, or collection, of examples at once. Accordingly, even though you're using a single image, you need to add it to a list:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "lDFh5yF_CaXW"
-   },
-   "outputs": [],
-   "source": [
-    "# Add the image to a batch where it's the only member.\n",
-    "img = (np.expand_dims(img,0))\n",
-    "\n",
-    "print(img.shape)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "EQ5wLTkcCaXY"
-   },
-   "source": [
-    "Now predict the correct label for this image:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "o_rzNSdrCaXY"
-   },
-   "outputs": [],
-   "source": [
-    "predictions_single = probability_model.predict(img)\n",
-    "\n",
-    "print(predictions_single)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "6Ai-cpLjO-3A"
-   },
-   "outputs": [],
-   "source": [
-    "plot_value_array(1, predictions_single[0], test_labels)\n",
-    "_ = plt.xticks(range(10), class_names, rotation=45)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "cU1Y2OAMCaXb"
-   },
-   "source": [
-    "`tf.keras.Model.predict` returns a list of lists—one list for each image in the batch of data. Grab the predictions for our (only) image in the batch:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "2tRmdq_8CaXb"
-   },
-   "outputs": [],
-   "source": [
-    "np.argmax(predictions_single[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "YFc2HbEVCaXd"
-   },
-   "source": [
-    "And the model predicts a label as expected."
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "collapsed_sections": [],
-   "name": "classification.ipynb",
-   "private_outputs": true,
-   "provenance": [],
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.7"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "MhoQ0WE77laV"
+      },
+      "source": [
+        "##### Copyright 2018 The TensorFlow Authors."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "colab": {},
+        "colab_type": "code",
+        "id": "_ckMIh7O7s6D"
+      },
+      "outputs": [],
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "colab": {},
+        "colab_type": "code",
+        "id": "vasWnqRgy1H4"
+      },
+      "outputs": [],
+      "source": [
+        "#@title MIT License\n",
+        "#\n",
+        "# Copyright (c) 2017 François Chollet\n",
+        "#\n",
+        "# Permission is hereby granted, free of charge, to any person obtaining a\n",
+        "# copy of this software and associated documentation files (the \"Software\"),\n",
+        "# to deal in the Software without restriction, including without limitation\n",
+        "# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n",
+        "# and/or sell copies of the Software, and to permit persons to whom the\n",
+        "# Software is furnished to do so, subject to the following conditions:\n",
+        "#\n",
+        "# The above copyright notice and this permission notice shall be included in\n",
+        "# all copies or substantial portions of the Software.\n",
+        "#\n",
+        "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n",
+        "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n",
+        "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n",
+        "# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n",
+        "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
+        "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
+        "# DEALINGS IN THE SOFTWARE."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "jYysdyb-CaWM"
+      },
+      "source": [
+        "# Basic classification: Classify images of clothing"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "S5Uhzt6vVIB2"
+      },
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "FbVhjPpzn6BM"
+      },
+      "source": [
+        "This guide trains a neural network model to classify images of clothing, like sneakers and shirts. It's okay if you don't understand all the details; this is a fast-paced overview of a complete TensorFlow program with the details explained as you go.\n",
+        "\n",
+        "This guide uses [tf.keras](https://www.tensorflow.org/guide/keras), a high-level API to build and train models in TensorFlow."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "dzLKpmZICaWN"
+      },
+      "outputs": [],
+      "source": [
+        "# TensorFlow and tf.keras\n",
+        "import tensorflow as tf\n",
+        "\n",
+        "# Helper libraries\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "print(tf.__version__)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "yR0EdgrLCaWR"
+      },
+      "source": [
+        "## Import the Fashion MNIST dataset"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "DLdCchMdCaWQ"
+      },
+      "source": [
+        "This guide uses the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset which contains 70,000 grayscale images in 10 categories. The images show individual articles of clothing at low resolution (28 by 28 pixels), as seen here:\n",
+        "\n",
+        "<table>\n",
+        "  <tr><td>\n",
+        "    <img src=\"https://tensorflow.org/images/fashion-mnist-sprite.png\"\n",
+        "         alt=\"Fashion MNIST sprite\"  width=\"600\">\n",
+        "  </td></tr>\n",
+        "  <tr><td align=\"center\">\n",
+        "    <b>Figure 1.</b> <a href=\"https://github.com/zalandoresearch/fashion-mnist\">Fashion-MNIST samples</a> (by Zalando, MIT License).<br/>&nbsp;\n",
+        "  </td></tr>\n",
+        "</table>\n",
+        "\n",
+        "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. The MNIST dataset contains images of handwritten digits (0, 1, 2, etc.) in a format identical to that of the articles of clothing you'll use here.\n",
+        "\n",
+        "This guide uses Fashion MNIST for variety, and because it's a slightly more challenging problem than regular MNIST. Both datasets are relatively small and are used to verify that an algorithm works as expected. They're good starting points to test and debug code.\n",
+        "\n",
+        "Here, 60,000 images are used to train the network and 10,000 images to evaluate how accurately the network learned to classify images. You can access the Fashion MNIST directly from TensorFlow. Import and load the Fashion MNIST data directly from TensorFlow:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "7MqDQO0KCaWS"
+      },
+      "outputs": [],
+      "source": [
+        "fashion_mnist = tf.keras.datasets.fashion_mnist\n",
+        "\n",
+        "(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "t9FDsUlxCaWW"
+      },
+      "source": [
+        "Loading the dataset returns four NumPy arrays:\n",
+        "\n",
+        "* The `train_images` and `train_labels` arrays are the *training set*—the data the model uses to learn.\n",
+        "* The model is tested against the *test set*, the `test_images`, and `test_labels` arrays.\n",
+        "\n",
+        "The images are 28x28 NumPy arrays, with pixel values ranging from 0 to 255. The *labels* are an array of integers, ranging from 0 to 9. These correspond to the *class* of clothing the image represents:\n",
+        "\n",
+        "<table>\n",
+        "  <tr>\n",
+        "    <th>Label</th>\n",
+        "    <th>Class</th>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td>0</td>\n",
+        "    <td>T-shirt/top</td>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td>1</td>\n",
+        "    <td>Trouser</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>2</td>\n",
+        "    <td>Pullover</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>3</td>\n",
+        "    <td>Dress</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>4</td>\n",
+        "    <td>Coat</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>5</td>\n",
+        "    <td>Sandal</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>6</td>\n",
+        "    <td>Shirt</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>7</td>\n",
+        "    <td>Sneaker</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>8</td>\n",
+        "    <td>Bag</td>\n",
+        "  </tr>\n",
+        "    <tr>\n",
+        "    <td>9</td>\n",
+        "    <td>Ankle boot</td>\n",
+        "  </tr>\n",
+        "</table>\n",
+        "\n",
+        "Each image is mapped to a single label. Since the *class names* are not included with the dataset, store them here to use later when plotting the images:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "IjnLH5S2CaWx"
+      },
+      "outputs": [],
+      "source": [
+        "class_names = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',\n",
+        "               'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Brm0b_KACaWX"
+      },
+      "source": [
+        "## Explore the data\n",
+        "\n",
+        "Let's explore the format of the dataset before training the model. The following shows there are 60,000 images in the training set, with each image represented as 28 x 28 pixels:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "zW5k_xz1CaWX"
+      },
+      "outputs": [],
+      "source": [
+        "train_images.shape"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "cIAcvQqMCaWf"
+      },
+      "source": [
+        "Likewise, there are 60,000 labels in the training set:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "TRFYHB2mCaWb"
+      },
+      "outputs": [],
+      "source": [
+        "len(train_labels)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "YSlYxFuRCaWk"
+      },
+      "source": [
+        "Each label is an integer between 0 and 9:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "XKnCTHz4CaWg"
+      },
+      "outputs": [],
+      "source": [
+        "train_labels"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "TMPI88iZpO2T"
+      },
+      "source": [
+        "There are 10,000 images in the test set. Again, each image is represented as 28 x 28 pixels:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "2KFnYlcwCaWl"
+      },
+      "outputs": [],
+      "source": [
+        "test_images.shape"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "rd0A0Iu0CaWq"
+      },
+      "source": [
+        "And the test set contains 10,000 images labels:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "iJmPr5-ACaWn"
+      },
+      "outputs": [],
+      "source": [
+        "len(test_labels)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "ES6uQoLKCaWr"
+      },
+      "source": [
+        "## Preprocess the data\n",
+        "\n",
+        "The data must be preprocessed before training the network. If you inspect the first image in the training set, you will see that the pixel values fall in the range of 0 to 255:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "m4VEw8Ud9Quh"
+      },
+      "outputs": [],
+      "source": [
+        "plt.figure()\n",
+        "plt.imshow(train_images[0])\n",
+        "plt.colorbar()\n",
+        "plt.grid(False)\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Wz7l27Lz9S1P"
+      },
+      "source": [
+        "Scale these values to a range of 0 to 1 before feeding them to the neural network model. To do so, divide the values by 255. It's important that the *training set* and the *testing set* be preprocessed in the same way:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "bW5WzIPlCaWv"
+      },
+      "outputs": [],
+      "source": [
+        "train_images = train_images / 255.0\n",
+        "\n",
+        "test_images = test_images / 255.0"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Ee638AlnCaWz"
+      },
+      "source": [
+        "To verify that the data is in the correct format and that you're ready to build and train the network, let's display the first 25 images from the *training set* and display the class name below each image."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "oZTImqg_CaW1"
+      },
+      "outputs": [],
+      "source": [
+        "plt.figure(figsize=(10,10))\n",
+        "for i in range(25):\n",
+        "    plt.subplot(5,5,i+1)\n",
+        "    plt.xticks([])\n",
+        "    plt.yticks([])\n",
+        "    plt.grid(False)\n",
+        "    plt.imshow(train_images[i], cmap=plt.cm.binary)\n",
+        "    plt.xlabel(class_names[train_labels[i]])\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "59veuiEZCaW4"
+      },
+      "source": [
+        "## Build the model\n",
+        "\n",
+        "Building the neural network requires configuring the layers of the model, then compiling the model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Gxg1XGm0eOBy"
+      },
+      "source": [
+        "### Set up the layers\n",
+        "\n",
+        "The basic building block of a neural network is the *layer*. Layers extract representations from the data fed into them. Hopefully, these representations are meaningful for the problem at hand.\n",
+        "\n",
+        "Most of deep learning consists of chaining together simple layers. Most layers, such as `tf.keras.layers.Dense`, have parameters that are learned during training."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "9ODch-OFCaW4"
+      },
+      "outputs": [],
+      "source": [
+        "model = tf.keras.Sequential([\n",
+        "    tf.keras.layers.Flatten(input_shape=(28, 28)),\n",
+        "    tf.keras.layers.Dense(128, activation='relu'),\n",
+        "    tf.keras.layers.Dense(10)\n",
+        "])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "gut8A_7rCaW6"
+      },
+      "source": [
+        "The first layer in this network, `tf.keras.layers.Flatten`, transforms the format of the images from a two-dimensional array (of 28 by 28 pixels) to a one-dimensional array (of 28 * 28 = 784 pixels). Think of this layer as unstacking rows of pixels in the image and lining them up. This layer has no parameters to learn; it only reformats the data.\n",
+        "\n",
+        "After the pixels are flattened, the network consists of a sequence of two `tf.keras.layers.Dense` layers. These are densely connected, or fully connected, neural layers. The first `Dense` layer has 128 nodes (or neurons). The second (and last) layer returns a logits array with length of 10. Each node contains a score that indicates the current image belongs to one of the 10 classes.\n",
+        "\n",
+        "### Compile the model\n",
+        "\n",
+        "Before the model is ready for training, it needs a few more settings. These are added during the model's *compile* step:\n",
+        "\n",
+        "* *Loss function* —This measures how accurate the model is during training. You want to minimize this function to \"steer\" the model in the right direction.\n",
+        "* *Optimizer* —This is how the model is updated based on the data it sees and its loss function.\n",
+        "* *Metrics* —Used to monitor the training and testing steps. The following example uses *accuracy*, the fraction of the images that are correctly classified."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "Lhan11blCaW7"
+      },
+      "outputs": [],
+      "source": [
+        "model.compile(optimizer='adam',\n",
+        "              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+        "              metrics=['accuracy'])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "qKF6uW-BCaW-"
+      },
+      "source": [
+        "## Train the model\n",
+        "\n",
+        "Training the neural network model requires the following steps:\n",
+        "\n",
+        "1. Feed the training data to the model. In this example, the training data is in the `train_images` and `train_labels` arrays.\n",
+        "2. The model learns to associate images and labels.\n",
+        "3. You ask the model to make predictions about a test set—in this example, the `test_images` array.\n",
+        "4. Verify that the predictions match the labels from the `test_labels` array.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Z4P4zIV7E28Z"
+      },
+      "source": [
+        "### Feed the model\n",
+        "\n",
+        "To start training,  call the `model.fit` method—so called because it \"fits\" the model to the training data:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "xvwvpA64CaW_"
+      },
+      "outputs": [],
+      "source": [
+        "model.fit(train_images, train_labels, epochs=10)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "W3ZVOhugCaXA"
+      },
+      "source": [
+        "As the model trains, the loss and accuracy metrics are displayed. This model reaches an accuracy of about 0.91 (or 91%) on the training data."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "wCpr6DGyE28h"
+      },
+      "source": [
+        "### Evaluate accuracy\n",
+        "\n",
+        "Next, compare how the model performs on the test dataset:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "VflXLEeECaXC"
+      },
+      "outputs": [],
+      "source": [
+        "test_loss, test_acc = model.evaluate(test_images,  test_labels, verbose=2)\n",
+        "\n",
+        "print('\\nTest accuracy:', test_acc)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "yWfgsmVXCaXG"
+      },
+      "source": [
+        "It turns out that the accuracy on the test dataset is a little less than the accuracy on the training dataset. This gap between training accuracy and test accuracy represents *overfitting*. Overfitting happens when a machine learning model performs worse on new, previously unseen inputs than it does on the training data. An overfitted model \"memorizes\" the noise and details in the training dataset to a point where it negatively impacts the performance of the model on the new data. For more information, see the following:\n",
+        "*   [Demonstrate overfitting](https://www.tensorflow.org/tutorials/keras/overfit_and_underfit#demonstrate_overfitting)\n",
+        "*   [Strategies to prevent overfitting](https://www.tensorflow.org/tutorials/keras/overfit_and_underfit#strategies_to_prevent_overfitting)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "v-PyD1SYE28q"
+      },
+      "source": [
+        "### Make predictions\n",
+        "\n",
+        "With the model trained, you can use it to make predictions about some images.\n",
+        "The model's linear outputs, [logits](https://developers.google.com/machine-learning/glossary#logits). Attach a softmax layer to convert the logits to probabilities, which are easier to interpret. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "DnfNA0CrQLSD"
+      },
+      "outputs": [],
+      "source": [
+        "probability_model = tf.keras.Sequential([model, \n",
+        "                                         tf.keras.layers.Softmax()])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "Gl91RPhdCaXI"
+      },
+      "outputs": [],
+      "source": [
+        "predictions = probability_model.predict(test_images)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "x9Kk1voUCaXJ"
+      },
+      "source": [
+        "Here, the model has predicted the label for each image in the testing set. Let's take a look at the first prediction:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "3DmJEUinCaXK"
+      },
+      "outputs": [],
+      "source": [
+        "predictions[0]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "-hw1hgeSCaXN"
+      },
+      "source": [
+        "A prediction is an array of 10 numbers. They represent the model's \"confidence\" that the image corresponds to each of the 10 different articles of clothing. You can see which label has the highest confidence value:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "qsqenuPnCaXO"
+      },
+      "outputs": [],
+      "source": [
+        "np.argmax(predictions[0])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "E51yS7iCCaXO"
+      },
+      "source": [
+        "So, the model is most confident that this image is an ankle boot, or `class_names[9]`. Examining the test label shows that this classification is correct:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "Sd7Pgsu6CaXP"
+      },
+      "outputs": [],
+      "source": [
+        "test_labels[0]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "ygh2yYC972ne"
+      },
+      "source": [
+        "Graph this to look at the full set of 10 class predictions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "DvYmmrpIy6Y1"
+      },
+      "outputs": [],
+      "source": [
+        "def plot_image(i, predictions_array, true_label, img):\n",
+        "  true_label, img = true_label[i], img[i]\n",
+        "  plt.grid(False)\n",
+        "  plt.xticks([])\n",
+        "  plt.yticks([])\n",
+        "\n",
+        "  plt.imshow(img, cmap=plt.cm.binary)\n",
+        "\n",
+        "  predicted_label = np.argmax(predictions_array)\n",
+        "  if predicted_label == true_label:\n",
+        "    color = 'blue'\n",
+        "  else:\n",
+        "    color = 'red'\n",
+        "\n",
+        "  plt.xlabel(\"{} {:2.0f}% ({})\".format(class_names[predicted_label],\n",
+        "                                100*np.max(predictions_array),\n",
+        "                                class_names[true_label]),\n",
+        "                                color=color)\n",
+        "\n",
+        "def plot_value_array(i, predictions_array, true_label):\n",
+        "  true_label = true_label[i]\n",
+        "  plt.grid(False)\n",
+        "  plt.xticks(range(10))\n",
+        "  plt.yticks([])\n",
+        "  thisplot = plt.bar(range(10), predictions_array, color=\"#777777\")\n",
+        "  plt.ylim([0, 1])\n",
+        "  predicted_label = np.argmax(predictions_array)\n",
+        "\n",
+        "  thisplot[predicted_label].set_color('red')\n",
+        "  thisplot[true_label].set_color('blue')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Zh9yABaME29S"
+      },
+      "source": [
+        "### Verify predictions\n",
+        "\n",
+        "With the model trained, you can use it to make predictions about some images."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "d4Ov9OFDMmOD"
+      },
+      "source": [
+        "Let's look at the 0th image, predictions, and prediction array. Correct prediction labels are blue and incorrect prediction labels are red. The number gives the percentage (out of 100) for the predicted label."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "HV5jw-5HwSmO"
+      },
+      "outputs": [],
+      "source": [
+        "i = 0\n",
+        "plt.figure(figsize=(6,3))\n",
+        "plt.subplot(1,2,1)\n",
+        "plot_image(i, predictions[i], test_labels, test_images)\n",
+        "plt.subplot(1,2,2)\n",
+        "plot_value_array(i, predictions[i],  test_labels)\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "Ko-uzOufSCSe"
+      },
+      "outputs": [],
+      "source": [
+        "i = 12\n",
+        "plt.figure(figsize=(6,3))\n",
+        "plt.subplot(1,2,1)\n",
+        "plot_image(i, predictions[i], test_labels, test_images)\n",
+        "plt.subplot(1,2,2)\n",
+        "plot_value_array(i, predictions[i],  test_labels)\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "kgdvGD52CaXR"
+      },
+      "source": [
+        "Let's plot several images with their predictions. Note that the model can be wrong even when very confident."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "hQlnbqaw2Qu_"
+      },
+      "outputs": [],
+      "source": [
+        "# Plot the first X test images, their predicted labels, and the true labels.\n",
+        "# Color correct predictions in blue and incorrect predictions in red.\n",
+        "num_rows = 5\n",
+        "num_cols = 3\n",
+        "num_images = num_rows*num_cols\n",
+        "plt.figure(figsize=(2*2*num_cols, 2*num_rows))\n",
+        "for i in range(num_images):\n",
+        "  plt.subplot(num_rows, 2*num_cols, 2*i+1)\n",
+        "  plot_image(i, predictions[i], test_labels, test_images)\n",
+        "  plt.subplot(num_rows, 2*num_cols, 2*i+2)\n",
+        "  plot_value_array(i, predictions[i], test_labels)\n",
+        "plt.tight_layout()\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "R32zteKHCaXT"
+      },
+      "source": [
+        "## Use the trained model\n",
+        "\n",
+        "Finally, use the trained model to make a prediction about a single image."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "yRJ7JU7JCaXT"
+      },
+      "outputs": [],
+      "source": [
+        "# Grab an image from the test dataset.\n",
+        "img = test_images[1]\n",
+        "\n",
+        "print(img.shape)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "vz3bVp21CaXV"
+      },
+      "source": [
+        "`tf.keras` models are optimized to make predictions on a *batch*, or collection, of examples at once. Accordingly, even though you're using a single image, you need to add it to a list:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "lDFh5yF_CaXW"
+      },
+      "outputs": [],
+      "source": [
+        "# Add the image to a batch where it's the only member.\n",
+        "img = (np.expand_dims(img,0))\n",
+        "\n",
+        "print(img.shape)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "EQ5wLTkcCaXY"
+      },
+      "source": [
+        "Now predict the correct label for this image:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "o_rzNSdrCaXY"
+      },
+      "outputs": [],
+      "source": [
+        "predictions_single = probability_model.predict(img)\n",
+        "\n",
+        "print(predictions_single)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "6Ai-cpLjO-3A"
+      },
+      "outputs": [],
+      "source": [
+        "plot_value_array(1, predictions_single[0], test_labels)\n",
+        "_ = plt.xticks(range(10), class_names, rotation=45)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "cU1Y2OAMCaXb"
+      },
+      "source": [
+        "`tf.keras.Model.predict` returns a list of lists—one list for each image in the batch of data. Grab the predictions for our (only) image in the batch:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "2tRmdq_8CaXb"
+      },
+      "outputs": [],
+      "source": [
+        "np.argmax(predictions_single[0])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "YFc2HbEVCaXd"
+      },
+      "source": [
+        "And the model predicts a label as expected."
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "classification.ipynb",
+      "private_outputs": true,
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/site/en/tutorials/keras/classification.ipynb
+++ b/site/en/tutorials/keras/classification.ipynb
@@ -1,1035 +1,1047 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "MhoQ0WE77laV"
-      },
-      "source": [
-        "##### Copyright 2018 The TensorFlow Authors."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
-        "id": "_ckMIh7O7s6D"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
-        "id": "vasWnqRgy1H4"
-      },
-      "outputs": [],
-      "source": [
-        "#@title MIT License\n",
-        "#\n",
-        "# Copyright (c) 2017 François Chollet\n",
-        "#\n",
-        "# Permission is hereby granted, free of charge, to any person obtaining a\n",
-        "# copy of this software and associated documentation files (the \"Software\"),\n",
-        "# to deal in the Software without restriction, including without limitation\n",
-        "# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n",
-        "# and/or sell copies of the Software, and to permit persons to whom the\n",
-        "# Software is furnished to do so, subject to the following conditions:\n",
-        "#\n",
-        "# The above copyright notice and this permission notice shall be included in\n",
-        "# all copies or substantial portions of the Software.\n",
-        "#\n",
-        "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n",
-        "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n",
-        "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n",
-        "# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n",
-        "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
-        "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
-        "# DEALINGS IN THE SOFTWARE."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "jYysdyb-CaWM"
-      },
-      "source": [
-        "# Basic classification: Classify images of clothing"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "S5Uhzt6vVIB2"
-      },
-      "source": [
-        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
-        "  </td>\n",
-        "</table>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "FbVhjPpzn6BM"
-      },
-      "source": [
-        "This guide trains a neural network model to classify images of clothing, like sneakers and shirts. It's okay if you don't understand all the details; this is a fast-paced overview of a complete TensorFlow program with the details explained as you go.\n",
-        "\n",
-        "This guide uses [tf.keras](https://www.tensorflow.org/guide/keras), a high-level API to build and train models in TensorFlow."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "dzLKpmZICaWN"
-      },
-      "outputs": [],
-      "source": [
-        "# TensorFlow and tf.keras\n",
-        "import tensorflow as tf\n",
-        "from tensorflow import keras\n",
-        "\n",
-        "# Helper libraries\n",
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "print(tf.__version__)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "yR0EdgrLCaWR"
-      },
-      "source": [
-        "## Import the Fashion MNIST dataset"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "DLdCchMdCaWQ"
-      },
-      "source": [
-        "This guide uses the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset which contains 70,000 grayscale images in 10 categories. The images show individual articles of clothing at low resolution (28 by 28 pixels), as seen here:\n",
-        "\n",
-        "<table>\n",
-        "  <tr><td>\n",
-        "    <img src=\"https://tensorflow.org/images/fashion-mnist-sprite.png\"\n",
-        "         alt=\"Fashion MNIST sprite\"  width=\"600\">\n",
-        "  </td></tr>\n",
-        "  <tr><td align=\"center\">\n",
-        "    <b>Figure 1.</b> <a href=\"https://github.com/zalandoresearch/fashion-mnist\">Fashion-MNIST samples</a> (by Zalando, MIT License).<br/>&nbsp;\n",
-        "  </td></tr>\n",
-        "</table>\n",
-        "\n",
-        "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. The MNIST dataset contains images of handwritten digits (0, 1, 2, etc.) in a format identical to that of the articles of clothing you'll use here.\n",
-        "\n",
-        "This guide uses Fashion MNIST for variety, and because it's a slightly more challenging problem than regular MNIST. Both datasets are relatively small and are used to verify that an algorithm works as expected. They're good starting points to test and debug code.\n",
-        "\n",
-        "Here, 60,000 images are used to train the network and 10,000 images to evaluate how accurately the network learned to classify images. You can access the Fashion MNIST directly from TensorFlow. Import and load the Fashion MNIST data directly from TensorFlow:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "7MqDQO0KCaWS"
-      },
-      "outputs": [],
-      "source": [
-        "fashion_mnist = keras.datasets.fashion_mnist\n",
-        "\n",
-        "(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "t9FDsUlxCaWW"
-      },
-      "source": [
-        "Loading the dataset returns four NumPy arrays:\n",
-        "\n",
-        "* The `train_images` and `train_labels` arrays are the *training set*—the data the model uses to learn.\n",
-        "* The model is tested against the *test set*, the `test_images`, and `test_labels` arrays.\n",
-        "\n",
-        "The images are 28x28 NumPy arrays, with pixel values ranging from 0 to 255. The *labels* are an array of integers, ranging from 0 to 9. These correspond to the *class* of clothing the image represents:\n",
-        "\n",
-        "<table>\n",
-        "  <tr>\n",
-        "    <th>Label</th>\n",
-        "    <th>Class</th>\n",
-        "  </tr>\n",
-        "  <tr>\n",
-        "    <td>0</td>\n",
-        "    <td>T-shirt/top</td>\n",
-        "  </tr>\n",
-        "  <tr>\n",
-        "    <td>1</td>\n",
-        "    <td>Trouser</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>2</td>\n",
-        "    <td>Pullover</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>3</td>\n",
-        "    <td>Dress</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>4</td>\n",
-        "    <td>Coat</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>5</td>\n",
-        "    <td>Sandal</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>6</td>\n",
-        "    <td>Shirt</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>7</td>\n",
-        "    <td>Sneaker</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>8</td>\n",
-        "    <td>Bag</td>\n",
-        "  </tr>\n",
-        "    <tr>\n",
-        "    <td>9</td>\n",
-        "    <td>Ankle boot</td>\n",
-        "  </tr>\n",
-        "</table>\n",
-        "\n",
-        "Each image is mapped to a single label. Since the *class names* are not included with the dataset, store them here to use later when plotting the images:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "IjnLH5S2CaWx"
-      },
-      "outputs": [],
-      "source": [
-        "class_names = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',\n",
-        "               'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Brm0b_KACaWX"
-      },
-      "source": [
-        "## Explore the data\n",
-        "\n",
-        "Let's explore the format of the dataset before training the model. The following shows there are 60,000 images in the training set, with each image represented as 28 x 28 pixels:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "zW5k_xz1CaWX"
-      },
-      "outputs": [],
-      "source": [
-        "train_images.shape"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "cIAcvQqMCaWf"
-      },
-      "source": [
-        "Likewise, there are 60,000 labels in the training set:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "TRFYHB2mCaWb"
-      },
-      "outputs": [],
-      "source": [
-        "len(train_labels)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "YSlYxFuRCaWk"
-      },
-      "source": [
-        "Each label is an integer between 0 and 9:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "XKnCTHz4CaWg"
-      },
-      "outputs": [],
-      "source": [
-        "train_labels"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "TMPI88iZpO2T"
-      },
-      "source": [
-        "There are 10,000 images in the test set. Again, each image is represented as 28 x 28 pixels:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "2KFnYlcwCaWl"
-      },
-      "outputs": [],
-      "source": [
-        "test_images.shape"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "rd0A0Iu0CaWq"
-      },
-      "source": [
-        "And the test set contains 10,000 images labels:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "iJmPr5-ACaWn"
-      },
-      "outputs": [],
-      "source": [
-        "len(test_labels)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "ES6uQoLKCaWr"
-      },
-      "source": [
-        "## Preprocess the data\n",
-        "\n",
-        "The data must be preprocessed before training the network. If you inspect the first image in the training set, you will see that the pixel values fall in the range of 0 to 255:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "m4VEw8Ud9Quh"
-      },
-      "outputs": [],
-      "source": [
-        "plt.figure()\n",
-        "plt.imshow(train_images[0])\n",
-        "plt.colorbar()\n",
-        "plt.grid(False)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Wz7l27Lz9S1P"
-      },
-      "source": [
-        "Scale these values to a range of 0 to 1 before feeding them to the neural network model. To do so, divide the values by 255. It's important that the *training set* and the *testing set* be preprocessed in the same way:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "bW5WzIPlCaWv"
-      },
-      "outputs": [],
-      "source": [
-        "train_images = train_images / 255.0\n",
-        "\n",
-        "test_images = test_images / 255.0"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Ee638AlnCaWz"
-      },
-      "source": [
-        "To verify that the data is in the correct format and that you're ready to build and train the network, let's display the first 25 images from the *training set* and display the class name below each image."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "oZTImqg_CaW1"
-      },
-      "outputs": [],
-      "source": [
-        "plt.figure(figsize=(10,10))\n",
-        "for i in range(25):\n",
-        "    plt.subplot(5,5,i+1)\n",
-        "    plt.xticks([])\n",
-        "    plt.yticks([])\n",
-        "    plt.grid(False)\n",
-        "    plt.imshow(train_images[i], cmap=plt.cm.binary)\n",
-        "    plt.xlabel(class_names[train_labels[i]])\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "59veuiEZCaW4"
-      },
-      "source": [
-        "## Build the model\n",
-        "\n",
-        "Building the neural network requires configuring the layers of the model, then compiling the model."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Gxg1XGm0eOBy"
-      },
-      "source": [
-        "### Set up the layers\n",
-        "\n",
-        "The basic building block of a neural network is the *layer*. Layers extract representations from the data fed into them. Hopefully, these representations are meaningful for the problem at hand.\n",
-        "\n",
-        "Most of deep learning consists of chaining together simple layers. Most layers, such as `tf.keras.layers.Dense`, have parameters that are learned during training."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "9ODch-OFCaW4"
-      },
-      "outputs": [],
-      "source": [
-        "model = keras.Sequential([\n",
-        "    keras.layers.Flatten(input_shape=(28, 28)),\n",
-        "    keras.layers.Dense(128, activation='relu'),\n",
-        "    keras.layers.Dense(10)\n",
-        "])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "gut8A_7rCaW6"
-      },
-      "source": [
-        "The first layer in this network, `tf.keras.layers.Flatten`, transforms the format of the images from a two-dimensional array (of 28 by 28 pixels) to a one-dimensional array (of 28 * 28 = 784 pixels). Think of this layer as unstacking rows of pixels in the image and lining them up. This layer has no parameters to learn; it only reformats the data.\n",
-        "\n",
-        "After the pixels are flattened, the network consists of a sequence of two `tf.keras.layers.Dense` layers. These are densely connected, or fully connected, neural layers. The first `Dense` layer has 128 nodes (or neurons). The second (and last) layer returns a logits array with length of 10. Each node contains a score that indicates the current image belongs to one of the 10 classes.\n",
-        "\n",
-        "### Compile the model\n",
-        "\n",
-        "Before the model is ready for training, it needs a few more settings. These are added during the model's *compile* step:\n",
-        "\n",
-        "* *Loss function* —This measures how accurate the model is during training. You want to minimize this function to \"steer\" the model in the right direction.\n",
-        "* *Optimizer* —This is how the model is updated based on the data it sees and its loss function.\n",
-        "* *Metrics* —Used to monitor the training and testing steps. The following example uses *accuracy*, the fraction of the images that are correctly classified."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "Lhan11blCaW7"
-      },
-      "outputs": [],
-      "source": [
-        "model.compile(optimizer='adam',\n",
-        "              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
-        "              metrics=['accuracy'])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "qKF6uW-BCaW-"
-      },
-      "source": [
-        "## Train the model\n",
-        "\n",
-        "Training the neural network model requires the following steps:\n",
-        "\n",
-        "1. Feed the training data to the model. In this example, the training data is in the `train_images` and `train_labels` arrays.\n",
-        "2. The model learns to associate images and labels.\n",
-        "3. You ask the model to make predictions about a test set—in this example, the `test_images` array.\n",
-        "4. Verify that the predictions match the labels from the `test_labels` array.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Z4P4zIV7E28Z"
-      },
-      "source": [
-        "### Feed the model\n",
-        "\n",
-        "To start training,  call the `model.fit` method—so called because it \"fits\" the model to the training data:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "xvwvpA64CaW_"
-      },
-      "outputs": [],
-      "source": [
-        "model.fit(train_images, train_labels, epochs=10)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "W3ZVOhugCaXA"
-      },
-      "source": [
-        "As the model trains, the loss and accuracy metrics are displayed. This model reaches an accuracy of about 0.91 (or 91%) on the training data."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "wCpr6DGyE28h"
-      },
-      "source": [
-        "### Evaluate accuracy\n",
-        "\n",
-        "Next, compare how the model performs on the test dataset:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "VflXLEeECaXC"
-      },
-      "outputs": [],
-      "source": [
-        "test_loss, test_acc = model.evaluate(test_images,  test_labels, verbose=2)\n",
-        "\n",
-        "print('\\nTest accuracy:', test_acc)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "yWfgsmVXCaXG"
-      },
-      "source": [
-        "It turns out that the accuracy on the test dataset is a little less than the accuracy on the training dataset. This gap between training accuracy and test accuracy represents *overfitting*. Overfitting happens when a machine learning model performs worse on new, previously unseen inputs than it does on the training data. An overfitted model \"memorizes\" the noise and details in the training dataset to a point where it negatively impacts the performance of the model on the new data. For more information, see the following:\n",
-        "*   [Demonstrate overfitting](https://www.tensorflow.org/tutorials/keras/overfit_and_underfit#demonstrate_overfitting)\n",
-        "*   [Strategies to prevent overfitting](https://www.tensorflow.org/tutorials/keras/overfit_and_underfit#strategies_to_prevent_overfitting)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "v-PyD1SYE28q"
-      },
-      "source": [
-        "### Make predictions\n",
-        "\n",
-        "With the model trained, you can use it to make predictions about some images.\n",
-        "The model's linear outputs, [logits](https://developers.google.com/machine-learning/glossary#logits). Attach a softmax layer to convert the logits to probabilities, which are easier to interpret. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "DnfNA0CrQLSD"
-      },
-      "outputs": [],
-      "source": [
-        "probability_model = tf.keras.Sequential([model, \n",
-        "                                         tf.keras.layers.Softmax()])"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "Gl91RPhdCaXI"
-      },
-      "outputs": [],
-      "source": [
-        "predictions = probability_model.predict(test_images)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "x9Kk1voUCaXJ"
-      },
-      "source": [
-        "Here, the model has predicted the label for each image in the testing set. Let's take a look at the first prediction:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "3DmJEUinCaXK"
-      },
-      "outputs": [],
-      "source": [
-        "predictions[0]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "-hw1hgeSCaXN"
-      },
-      "source": [
-        "A prediction is an array of 10 numbers. They represent the model's \"confidence\" that the image corresponds to each of the 10 different articles of clothing. You can see which label has the highest confidence value:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "qsqenuPnCaXO"
-      },
-      "outputs": [],
-      "source": [
-        "np.argmax(predictions[0])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "E51yS7iCCaXO"
-      },
-      "source": [
-        "So, the model is most confident that this image is an ankle boot, or `class_names[9]`. Examining the test label shows that this classification is correct:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "Sd7Pgsu6CaXP"
-      },
-      "outputs": [],
-      "source": [
-        "test_labels[0]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "ygh2yYC972ne"
-      },
-      "source": [
-        "Graph this to look at the full set of 10 class predictions."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "DvYmmrpIy6Y1"
-      },
-      "outputs": [],
-      "source": [
-        "def plot_image(i, predictions_array, true_label, img):\n",
-        "  true_label, img = true_label[i], img[i]\n",
-        "  plt.grid(False)\n",
-        "  plt.xticks([])\n",
-        "  plt.yticks([])\n",
-        "\n",
-        "  plt.imshow(img, cmap=plt.cm.binary)\n",
-        "\n",
-        "  predicted_label = np.argmax(predictions_array)\n",
-        "  if predicted_label == true_label:\n",
-        "    color = 'blue'\n",
-        "  else:\n",
-        "    color = 'red'\n",
-        "\n",
-        "  plt.xlabel(\"{} {:2.0f}% ({})\".format(class_names[predicted_label],\n",
-        "                                100*np.max(predictions_array),\n",
-        "                                class_names[true_label]),\n",
-        "                                color=color)\n",
-        "\n",
-        "def plot_value_array(i, predictions_array, true_label):\n",
-        "  true_label = true_label[i]\n",
-        "  plt.grid(False)\n",
-        "  plt.xticks(range(10))\n",
-        "  plt.yticks([])\n",
-        "  thisplot = plt.bar(range(10), predictions_array, color=\"#777777\")\n",
-        "  plt.ylim([0, 1])\n",
-        "  predicted_label = np.argmax(predictions_array)\n",
-        "\n",
-        "  thisplot[predicted_label].set_color('red')\n",
-        "  thisplot[true_label].set_color('blue')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Zh9yABaME29S"
-      },
-      "source": [
-        "### Verify predictions\n",
-        "\n",
-        "With the model trained, you can use it to make predictions about some images."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "d4Ov9OFDMmOD"
-      },
-      "source": [
-        "Let's look at the 0th image, predictions, and prediction array. Correct prediction labels are blue and incorrect prediction labels are red. The number gives the percentage (out of 100) for the predicted label."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "HV5jw-5HwSmO"
-      },
-      "outputs": [],
-      "source": [
-        "i = 0\n",
-        "plt.figure(figsize=(6,3))\n",
-        "plt.subplot(1,2,1)\n",
-        "plot_image(i, predictions[i], test_labels, test_images)\n",
-        "plt.subplot(1,2,2)\n",
-        "plot_value_array(i, predictions[i],  test_labels)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "Ko-uzOufSCSe"
-      },
-      "outputs": [],
-      "source": [
-        "i = 12\n",
-        "plt.figure(figsize=(6,3))\n",
-        "plt.subplot(1,2,1)\n",
-        "plot_image(i, predictions[i], test_labels, test_images)\n",
-        "plt.subplot(1,2,2)\n",
-        "plot_value_array(i, predictions[i],  test_labels)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "kgdvGD52CaXR"
-      },
-      "source": [
-        "Let's plot several images with their predictions. Note that the model can be wrong even when very confident."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "hQlnbqaw2Qu_"
-      },
-      "outputs": [],
-      "source": [
-        "# Plot the first X test images, their predicted labels, and the true labels.\n",
-        "# Color correct predictions in blue and incorrect predictions in red.\n",
-        "num_rows = 5\n",
-        "num_cols = 3\n",
-        "num_images = num_rows*num_cols\n",
-        "plt.figure(figsize=(2*2*num_cols, 2*num_rows))\n",
-        "for i in range(num_images):\n",
-        "  plt.subplot(num_rows, 2*num_cols, 2*i+1)\n",
-        "  plot_image(i, predictions[i], test_labels, test_images)\n",
-        "  plt.subplot(num_rows, 2*num_cols, 2*i+2)\n",
-        "  plot_value_array(i, predictions[i], test_labels)\n",
-        "plt.tight_layout()\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "R32zteKHCaXT"
-      },
-      "source": [
-        "## Use the trained model\n",
-        "\n",
-        "Finally, use the trained model to make a prediction about a single image."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "yRJ7JU7JCaXT"
-      },
-      "outputs": [],
-      "source": [
-        "# Grab an image from the test dataset.\n",
-        "img = test_images[1]\n",
-        "\n",
-        "print(img.shape)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "vz3bVp21CaXV"
-      },
-      "source": [
-        "`tf.keras` models are optimized to make predictions on a *batch*, or collection, of examples at once. Accordingly, even though you're using a single image, you need to add it to a list:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "lDFh5yF_CaXW"
-      },
-      "outputs": [],
-      "source": [
-        "# Add the image to a batch where it's the only member.\n",
-        "img = (np.expand_dims(img,0))\n",
-        "\n",
-        "print(img.shape)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "EQ5wLTkcCaXY"
-      },
-      "source": [
-        "Now predict the correct label for this image:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "o_rzNSdrCaXY"
-      },
-      "outputs": [],
-      "source": [
-        "predictions_single = probability_model.predict(img)\n",
-        "\n",
-        "print(predictions_single)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "6Ai-cpLjO-3A"
-      },
-      "outputs": [],
-      "source": [
-        "plot_value_array(1, predictions_single[0], test_labels)\n",
-        "_ = plt.xticks(range(10), class_names, rotation=45)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "cU1Y2OAMCaXb"
-      },
-      "source": [
-        "`keras.Model.predict` returns a list of lists—one list for each image in the batch of data. Grab the predictions for our (only) image in the batch:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "2tRmdq_8CaXb"
-      },
-      "outputs": [],
-      "source": [
-        "np.argmax(predictions_single[0])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "YFc2HbEVCaXd"
-      },
-      "source": [
-        "And the model predicts a label as expected."
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [],
-      "name": "classification.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "MhoQ0WE77laV"
+   },
+   "source": [
+    "##### Copyright 2018 The TensorFlow Authors."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {},
+    "colab_type": "code",
+    "id": "_ckMIh7O7s6D"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {},
+    "colab_type": "code",
+    "id": "vasWnqRgy1H4"
+   },
+   "outputs": [],
+   "source": [
+    "#@title MIT License\n",
+    "#\n",
+    "# Copyright (c) 2017 François Chollet\n",
+    "#\n",
+    "# Permission is hereby granted, free of charge, to any person obtaining a\n",
+    "# copy of this software and associated documentation files (the \"Software\"),\n",
+    "# to deal in the Software without restriction, including without limitation\n",
+    "# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n",
+    "# and/or sell copies of the Software, and to permit persons to whom the\n",
+    "# Software is furnished to do so, subject to the following conditions:\n",
+    "#\n",
+    "# The above copyright notice and this permission notice shall be included in\n",
+    "# all copies or substantial portions of the Software.\n",
+    "#\n",
+    "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n",
+    "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n",
+    "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n",
+    "# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n",
+    "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
+    "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
+    "# DEALINGS IN THE SOFTWARE."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "jYysdyb-CaWM"
+   },
+   "source": [
+    "# Basic classification: Classify images of clothing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "S5Uhzt6vVIB2"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/keras/classification\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "FbVhjPpzn6BM"
+   },
+   "source": [
+    "This guide trains a neural network model to classify images of clothing, like sneakers and shirts. It's okay if you don't understand all the details; this is a fast-paced overview of a complete TensorFlow program with the details explained as you go.\n",
+    "\n",
+    "This guide uses [tf.keras](https://www.tensorflow.org/guide/keras), a high-level API to build and train models in TensorFlow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "dzLKpmZICaWN"
+   },
+   "outputs": [],
+   "source": [
+    "# TensorFlow and tf.keras\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "# Helper libraries\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "print(tf.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "yR0EdgrLCaWR"
+   },
+   "source": [
+    "## Import the Fashion MNIST dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "DLdCchMdCaWQ"
+   },
+   "source": [
+    "This guide uses the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset which contains 70,000 grayscale images in 10 categories. The images show individual articles of clothing at low resolution (28 by 28 pixels), as seen here:\n",
+    "\n",
+    "<table>\n",
+    "  <tr><td>\n",
+    "    <img src=\"https://tensorflow.org/images/fashion-mnist-sprite.png\"\n",
+    "         alt=\"Fashion MNIST sprite\"  width=\"600\">\n",
+    "  </td></tr>\n",
+    "  <tr><td align=\"center\">\n",
+    "    <b>Figure 1.</b> <a href=\"https://github.com/zalandoresearch/fashion-mnist\">Fashion-MNIST samples</a> (by Zalando, MIT License).<br/>&nbsp;\n",
+    "  </td></tr>\n",
+    "</table>\n",
+    "\n",
+    "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. The MNIST dataset contains images of handwritten digits (0, 1, 2, etc.) in a format identical to that of the articles of clothing you'll use here.\n",
+    "\n",
+    "This guide uses Fashion MNIST for variety, and because it's a slightly more challenging problem than regular MNIST. Both datasets are relatively small and are used to verify that an algorithm works as expected. They're good starting points to test and debug code.\n",
+    "\n",
+    "Here, 60,000 images are used to train the network and 10,000 images to evaluate how accurately the network learned to classify images. You can access the Fashion MNIST directly from TensorFlow. Import and load the Fashion MNIST data directly from TensorFlow:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "7MqDQO0KCaWS"
+   },
+   "outputs": [],
+   "source": [
+    "fashion_mnist = tf.keras.datasets.fashion_mnist\n",
+    "\n",
+    "(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "t9FDsUlxCaWW"
+   },
+   "source": [
+    "Loading the dataset returns four NumPy arrays:\n",
+    "\n",
+    "* The `train_images` and `train_labels` arrays are the *training set*—the data the model uses to learn.\n",
+    "* The model is tested against the *test set*, the `test_images`, and `test_labels` arrays.\n",
+    "\n",
+    "The images are 28x28 NumPy arrays, with pixel values ranging from 0 to 255. The *labels* are an array of integers, ranging from 0 to 9. These correspond to the *class* of clothing the image represents:\n",
+    "\n",
+    "<table>\n",
+    "  <tr>\n",
+    "    <th>Label</th>\n",
+    "    <th>Class</th>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td>0</td>\n",
+    "    <td>T-shirt/top</td>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <td>1</td>\n",
+    "    <td>Trouser</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>2</td>\n",
+    "    <td>Pullover</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>3</td>\n",
+    "    <td>Dress</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>4</td>\n",
+    "    <td>Coat</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>5</td>\n",
+    "    <td>Sandal</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>6</td>\n",
+    "    <td>Shirt</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>7</td>\n",
+    "    <td>Sneaker</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>8</td>\n",
+    "    <td>Bag</td>\n",
+    "  </tr>\n",
+    "    <tr>\n",
+    "    <td>9</td>\n",
+    "    <td>Ankle boot</td>\n",
+    "  </tr>\n",
+    "</table>\n",
+    "\n",
+    "Each image is mapped to a single label. Since the *class names* are not included with the dataset, store them here to use later when plotting the images:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "IjnLH5S2CaWx"
+   },
+   "outputs": [],
+   "source": [
+    "class_names = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',\n",
+    "               'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Brm0b_KACaWX"
+   },
+   "source": [
+    "## Explore the data\n",
+    "\n",
+    "Let's explore the format of the dataset before training the model. The following shows there are 60,000 images in the training set, with each image represented as 28 x 28 pixels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "zW5k_xz1CaWX"
+   },
+   "outputs": [],
+   "source": [
+    "train_images.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "cIAcvQqMCaWf"
+   },
+   "source": [
+    "Likewise, there are 60,000 labels in the training set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "TRFYHB2mCaWb"
+   },
+   "outputs": [],
+   "source": [
+    "len(train_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "YSlYxFuRCaWk"
+   },
+   "source": [
+    "Each label is an integer between 0 and 9:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "XKnCTHz4CaWg"
+   },
+   "outputs": [],
+   "source": [
+    "train_labels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "TMPI88iZpO2T"
+   },
+   "source": [
+    "There are 10,000 images in the test set. Again, each image is represented as 28 x 28 pixels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "2KFnYlcwCaWl"
+   },
+   "outputs": [],
+   "source": [
+    "test_images.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "rd0A0Iu0CaWq"
+   },
+   "source": [
+    "And the test set contains 10,000 images labels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "iJmPr5-ACaWn"
+   },
+   "outputs": [],
+   "source": [
+    "len(test_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ES6uQoLKCaWr"
+   },
+   "source": [
+    "## Preprocess the data\n",
+    "\n",
+    "The data must be preprocessed before training the network. If you inspect the first image in the training set, you will see that the pixel values fall in the range of 0 to 255:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "m4VEw8Ud9Quh"
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.imshow(train_images[0])\n",
+    "plt.colorbar()\n",
+    "plt.grid(False)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Wz7l27Lz9S1P"
+   },
+   "source": [
+    "Scale these values to a range of 0 to 1 before feeding them to the neural network model. To do so, divide the values by 255. It's important that the *training set* and the *testing set* be preprocessed in the same way:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "bW5WzIPlCaWv"
+   },
+   "outputs": [],
+   "source": [
+    "train_images = train_images / 255.0\n",
+    "\n",
+    "test_images = test_images / 255.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Ee638AlnCaWz"
+   },
+   "source": [
+    "To verify that the data is in the correct format and that you're ready to build and train the network, let's display the first 25 images from the *training set* and display the class name below each image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "oZTImqg_CaW1"
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,10))\n",
+    "for i in range(25):\n",
+    "    plt.subplot(5,5,i+1)\n",
+    "    plt.xticks([])\n",
+    "    plt.yticks([])\n",
+    "    plt.grid(False)\n",
+    "    plt.imshow(train_images[i], cmap=plt.cm.binary)\n",
+    "    plt.xlabel(class_names[train_labels[i]])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "59veuiEZCaW4"
+   },
+   "source": [
+    "## Build the model\n",
+    "\n",
+    "Building the neural network requires configuring the layers of the model, then compiling the model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Gxg1XGm0eOBy"
+   },
+   "source": [
+    "### Set up the layers\n",
+    "\n",
+    "The basic building block of a neural network is the *layer*. Layers extract representations from the data fed into them. Hopefully, these representations are meaningful for the problem at hand.\n",
+    "\n",
+    "Most of deep learning consists of chaining together simple layers. Most layers, such as `tf.keras.layers.Dense`, have parameters that are learned during training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "9ODch-OFCaW4"
+   },
+   "outputs": [],
+   "source": [
+    "model = tf.keras.Sequential([\n",
+    "    tf.keras.layers.Flatten(input_shape=(28, 28)),\n",
+    "    tf.keras.layers.Dense(128, activation='relu'),\n",
+    "    tf.keras.layers.Dense(10)\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "gut8A_7rCaW6"
+   },
+   "source": [
+    "The first layer in this network, `tf.keras.layers.Flatten`, transforms the format of the images from a two-dimensional array (of 28 by 28 pixels) to a one-dimensional array (of 28 * 28 = 784 pixels). Think of this layer as unstacking rows of pixels in the image and lining them up. This layer has no parameters to learn; it only reformats the data.\n",
+    "\n",
+    "After the pixels are flattened, the network consists of a sequence of two `tf.keras.layers.Dense` layers. These are densely connected, or fully connected, neural layers. The first `Dense` layer has 128 nodes (or neurons). The second (and last) layer returns a logits array with length of 10. Each node contains a score that indicates the current image belongs to one of the 10 classes.\n",
+    "\n",
+    "### Compile the model\n",
+    "\n",
+    "Before the model is ready for training, it needs a few more settings. These are added during the model's *compile* step:\n",
+    "\n",
+    "* *Loss function* —This measures how accurate the model is during training. You want to minimize this function to \"steer\" the model in the right direction.\n",
+    "* *Optimizer* —This is how the model is updated based on the data it sees and its loss function.\n",
+    "* *Metrics* —Used to monitor the training and testing steps. The following example uses *accuracy*, the fraction of the images that are correctly classified."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Lhan11blCaW7"
+   },
+   "outputs": [],
+   "source": [
+    "model.compile(optimizer='adam',\n",
+    "              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+    "              metrics=['accuracy'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "qKF6uW-BCaW-"
+   },
+   "source": [
+    "## Train the model\n",
+    "\n",
+    "Training the neural network model requires the following steps:\n",
+    "\n",
+    "1. Feed the training data to the model. In this example, the training data is in the `train_images` and `train_labels` arrays.\n",
+    "2. The model learns to associate images and labels.\n",
+    "3. You ask the model to make predictions about a test set—in this example, the `test_images` array.\n",
+    "4. Verify that the predictions match the labels from the `test_labels` array.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Z4P4zIV7E28Z"
+   },
+   "source": [
+    "### Feed the model\n",
+    "\n",
+    "To start training,  call the `model.fit` method—so called because it \"fits\" the model to the training data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "xvwvpA64CaW_"
+   },
+   "outputs": [],
+   "source": [
+    "model.fit(train_images, train_labels, epochs=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "W3ZVOhugCaXA"
+   },
+   "source": [
+    "As the model trains, the loss and accuracy metrics are displayed. This model reaches an accuracy of about 0.91 (or 91%) on the training data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "wCpr6DGyE28h"
+   },
+   "source": [
+    "### Evaluate accuracy\n",
+    "\n",
+    "Next, compare how the model performs on the test dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "VflXLEeECaXC"
+   },
+   "outputs": [],
+   "source": [
+    "test_loss, test_acc = model.evaluate(test_images,  test_labels, verbose=2)\n",
+    "\n",
+    "print('\\nTest accuracy:', test_acc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "yWfgsmVXCaXG"
+   },
+   "source": [
+    "It turns out that the accuracy on the test dataset is a little less than the accuracy on the training dataset. This gap between training accuracy and test accuracy represents *overfitting*. Overfitting happens when a machine learning model performs worse on new, previously unseen inputs than it does on the training data. An overfitted model \"memorizes\" the noise and details in the training dataset to a point where it negatively impacts the performance of the model on the new data. For more information, see the following:\n",
+    "*   [Demonstrate overfitting](https://www.tensorflow.org/tutorials/keras/overfit_and_underfit#demonstrate_overfitting)\n",
+    "*   [Strategies to prevent overfitting](https://www.tensorflow.org/tutorials/keras/overfit_and_underfit#strategies_to_prevent_overfitting)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "v-PyD1SYE28q"
+   },
+   "source": [
+    "### Make predictions\n",
+    "\n",
+    "With the model trained, you can use it to make predictions about some images.\n",
+    "The model's linear outputs, [logits](https://developers.google.com/machine-learning/glossary#logits). Attach a softmax layer to convert the logits to probabilities, which are easier to interpret. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "DnfNA0CrQLSD"
+   },
+   "outputs": [],
+   "source": [
+    "probability_model = tf.keras.Sequential([model, \n",
+    "                                         tf.keras.layers.Softmax()])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Gl91RPhdCaXI"
+   },
+   "outputs": [],
+   "source": [
+    "predictions = probability_model.predict(test_images)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "x9Kk1voUCaXJ"
+   },
+   "source": [
+    "Here, the model has predicted the label for each image in the testing set. Let's take a look at the first prediction:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "3DmJEUinCaXK"
+   },
+   "outputs": [],
+   "source": [
+    "predictions[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "-hw1hgeSCaXN"
+   },
+   "source": [
+    "A prediction is an array of 10 numbers. They represent the model's \"confidence\" that the image corresponds to each of the 10 different articles of clothing. You can see which label has the highest confidence value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "qsqenuPnCaXO"
+   },
+   "outputs": [],
+   "source": [
+    "np.argmax(predictions[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "E51yS7iCCaXO"
+   },
+   "source": [
+    "So, the model is most confident that this image is an ankle boot, or `class_names[9]`. Examining the test label shows that this classification is correct:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Sd7Pgsu6CaXP"
+   },
+   "outputs": [],
+   "source": [
+    "test_labels[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ygh2yYC972ne"
+   },
+   "source": [
+    "Graph this to look at the full set of 10 class predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "DvYmmrpIy6Y1"
+   },
+   "outputs": [],
+   "source": [
+    "def plot_image(i, predictions_array, true_label, img):\n",
+    "  true_label, img = true_label[i], img[i]\n",
+    "  plt.grid(False)\n",
+    "  plt.xticks([])\n",
+    "  plt.yticks([])\n",
+    "\n",
+    "  plt.imshow(img, cmap=plt.cm.binary)\n",
+    "\n",
+    "  predicted_label = np.argmax(predictions_array)\n",
+    "  if predicted_label == true_label:\n",
+    "    color = 'blue'\n",
+    "  else:\n",
+    "    color = 'red'\n",
+    "\n",
+    "  plt.xlabel(\"{} {:2.0f}% ({})\".format(class_names[predicted_label],\n",
+    "                                100*np.max(predictions_array),\n",
+    "                                class_names[true_label]),\n",
+    "                                color=color)\n",
+    "\n",
+    "def plot_value_array(i, predictions_array, true_label):\n",
+    "  true_label = true_label[i]\n",
+    "  plt.grid(False)\n",
+    "  plt.xticks(range(10))\n",
+    "  plt.yticks([])\n",
+    "  thisplot = plt.bar(range(10), predictions_array, color=\"#777777\")\n",
+    "  plt.ylim([0, 1])\n",
+    "  predicted_label = np.argmax(predictions_array)\n",
+    "\n",
+    "  thisplot[predicted_label].set_color('red')\n",
+    "  thisplot[true_label].set_color('blue')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Zh9yABaME29S"
+   },
+   "source": [
+    "### Verify predictions\n",
+    "\n",
+    "With the model trained, you can use it to make predictions about some images."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "d4Ov9OFDMmOD"
+   },
+   "source": [
+    "Let's look at the 0th image, predictions, and prediction array. Correct prediction labels are blue and incorrect prediction labels are red. The number gives the percentage (out of 100) for the predicted label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "HV5jw-5HwSmO"
+   },
+   "outputs": [],
+   "source": [
+    "i = 0\n",
+    "plt.figure(figsize=(6,3))\n",
+    "plt.subplot(1,2,1)\n",
+    "plot_image(i, predictions[i], test_labels, test_images)\n",
+    "plt.subplot(1,2,2)\n",
+    "plot_value_array(i, predictions[i],  test_labels)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Ko-uzOufSCSe"
+   },
+   "outputs": [],
+   "source": [
+    "i = 12\n",
+    "plt.figure(figsize=(6,3))\n",
+    "plt.subplot(1,2,1)\n",
+    "plot_image(i, predictions[i], test_labels, test_images)\n",
+    "plt.subplot(1,2,2)\n",
+    "plot_value_array(i, predictions[i],  test_labels)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "kgdvGD52CaXR"
+   },
+   "source": [
+    "Let's plot several images with their predictions. Note that the model can be wrong even when very confident."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "hQlnbqaw2Qu_"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot the first X test images, their predicted labels, and the true labels.\n",
+    "# Color correct predictions in blue and incorrect predictions in red.\n",
+    "num_rows = 5\n",
+    "num_cols = 3\n",
+    "num_images = num_rows*num_cols\n",
+    "plt.figure(figsize=(2*2*num_cols, 2*num_rows))\n",
+    "for i in range(num_images):\n",
+    "  plt.subplot(num_rows, 2*num_cols, 2*i+1)\n",
+    "  plot_image(i, predictions[i], test_labels, test_images)\n",
+    "  plt.subplot(num_rows, 2*num_cols, 2*i+2)\n",
+    "  plot_value_array(i, predictions[i], test_labels)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "R32zteKHCaXT"
+   },
+   "source": [
+    "## Use the trained model\n",
+    "\n",
+    "Finally, use the trained model to make a prediction about a single image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "yRJ7JU7JCaXT"
+   },
+   "outputs": [],
+   "source": [
+    "# Grab an image from the test dataset.\n",
+    "img = test_images[1]\n",
+    "\n",
+    "print(img.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "vz3bVp21CaXV"
+   },
+   "source": [
+    "`tf.keras` models are optimized to make predictions on a *batch*, or collection, of examples at once. Accordingly, even though you're using a single image, you need to add it to a list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "lDFh5yF_CaXW"
+   },
+   "outputs": [],
+   "source": [
+    "# Add the image to a batch where it's the only member.\n",
+    "img = (np.expand_dims(img,0))\n",
+    "\n",
+    "print(img.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "EQ5wLTkcCaXY"
+   },
+   "source": [
+    "Now predict the correct label for this image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "o_rzNSdrCaXY"
+   },
+   "outputs": [],
+   "source": [
+    "predictions_single = probability_model.predict(img)\n",
+    "\n",
+    "print(predictions_single)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "6Ai-cpLjO-3A"
+   },
+   "outputs": [],
+   "source": [
+    "plot_value_array(1, predictions_single[0], test_labels)\n",
+    "_ = plt.xticks(range(10), class_names, rotation=45)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "cU1Y2OAMCaXb"
+   },
+   "source": [
+    "`tf.keras.Model.predict` returns a list of lists—one list for each image in the batch of data. Grab the predictions for our (only) image in the batch:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "2tRmdq_8CaXb"
+   },
+   "outputs": [],
+   "source": [
+    "np.argmax(predictions_single[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "YFc2HbEVCaXd"
+   },
+   "source": [
+    "And the model predicts a label as expected."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "classification.ipynb",
+   "private_outputs": true,
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
In <a href="https://www.tensorflow.org/tutorials/keras/classification?hl=en">Basic classification</a>,
```keras``` is used in two different way. first is using ```tf.keras``` imported by ```import tensorflow as tf```, second way is importing ```from tensorflow import keras``` and use ```keras```. It seems unclear and might be hard to understand the difference between ```keras``` library and ```keras``` which is imported by ```from tensorflow import keras``` to new user if ```tf.keras``` is handled differently in same doc, so changed to only use ```tf.keras```