### PR TITLE
Fix variable name typo

### DIFF
--- a/site/en/tutorials/generative/autoencoder.ipynb
+++ b/site/en/tutorials/generative/autoencoder.ipynb
@@ -162,7 +162,7 @@
         "latent_dim = 64 \n",
         "\n",
         "class Autoencoder(Model):\n",
-        "  def __init__(self, encoding_dim):\n",
+        "  def __init__(self, latent_dim):\n",
         "    super(Autoencoder, self).__init__()\n",
         "    self.latent_dim = latent_dim   \n",
         "    self.encoder = tf.keras.Sequential([\n",


### PR DESCRIPTION
Changed 'encoding_dim' to 'latent_dim'.