### PR TITLE
Enhance the TensorFlow NumPy guide, fix typographical errors

### DIFF
--- a/site/en/guide/tf_numpy.ipynb
+++ b/site/en/guide/tf_numpy.ipynb
@@ -192,7 +192,7 @@
         "### Broadcasting\n",
         "\n",
         "Similar to TensorFlow, NumPy defines rich semantics for \"broadcasting\" values.\n",
-        "Checkout the [NumPy broadcasting guide](https://numpy.org/doc/stable/user/basics.broadcasting.html). Also compare this with [TensorFlow broadcasting semantics](https://www.tensorflow.org/guide/tensor#broadcasting).\n"
+        "You can check out the [NumPy broadcasting guide](https://numpy.org/doc/stable/user/basics.broadcasting.html) for more information and compare this with [TensorFlow broadcasting semantics](https://www.tensorflow.org/guide/tensor#broadcasting)."
       ]
     },
     {
@@ -218,7 +218,7 @@
       "source": [
         "### Indexing\n",
         "\n",
-        "NumPy defines very sophistsicated indexing rules. See the [NumPy Indexing guide](https://numpy.org/doc/stable/reference/arrays.indexing.html). Note the use of ND arrays as indices below."
+        "NumPy defines very sophisticated indexing rules. See the [NumPy Indexing guide](https://numpy.org/doc/stable/reference/arrays.indexing.html). Note the use of ND arrays as indices below."
       ]
     },
     {
@@ -309,7 +309,7 @@
       "source": [
         "## TensorFlow NumPy and NumPy\n",
         "\n",
-        "TensorFlow NumPy implements a subset of the full NumPy spec. While more symbols will be added over time, there are systematic features that will not be supported in the near future. These include NumPy C API support, Swig integration, Fortran storage order, views and `stride_tricks`, and some dtypes (like `np.recarray`, `np.object`). For more details, please see the [TensorFlow NumPy API Documentation](https://www.tensorflow.org/api_docs/python/tf/experimental/numpy)\n"
+        "TensorFlow NumPy implements a subset of the full NumPy spec. While more symbols will be added over time, there are systematic features that will not be supported in the near future. These include NumPy C API support, Swig integration, Fortran storage order, views and `stride_tricks`, and some `dtype`s (like `np.recarray` and `np.object`). For more details, please see the [TensorFlow NumPy API Documentation](https://www.tensorflow.org/api_docs/python/tf/experimental/numpy).\n"
       ]
     },
     {
@@ -322,9 +322,9 @@
         "\n",
         "TensorFlow ND arrays can interoperate with NumPy functions. These objects implement the `__array__` interface. NumPy uses this interface to convert function arguments to `np.ndarray` values before processing them.\n",
         "\n",
-        "Similarly, TensorFlow NumPy functions can accept inputs of different types including `tf.Tensor` and `np.ndarray`. These input are converted to ND array by calling `ndarray.asarray` on them. \n",
+        "Similarly, TensorFlow NumPy functions can accept inputs of different types including `tf.Tensor` and `np.ndarray`. These inputs are converted to an ND array by calling `ndarray.asarray` on them. \n",
         "\n",
-        "Conversion of ND array to and from `np.ndarray` may trigger actual data copies. Please see section on [buffer copies](#Buffer-copies) for more details."
+        "Conversion of the ND array to and from `np.ndarray` may trigger actual data copies. Please see the section on [buffer copies](#Buffer-copies) for more details."
       ]
     },
     {
@@ -365,7 +365,7 @@
       "source": [
         "### Buffer copies\n",
         "\n",
-        "Intermixing TensorFlow NumPy with NumPy code may trigger data copies. This is because TensorFlow NumPy has stricter requirments on memory alignment than those of NumPy.\n",
+        "Intermixing TensorFlow NumPy with NumPy code may trigger data copies. This is because TensorFlow NumPy has stricter requirements on memory alignment than those of NumPy.\n",
         "\n",
         "When a `np.ndarray` is passed to TensorFlow Numpy, it will check for alignment requirements and trigger a copy if needed. When passing an ND array CPU buffer to NumPy, generally the buffer will satisfy alignment requirements and NumPy will not need to create a copy.\n",
         "\n",
@@ -449,9 +449,9 @@
       "source": [
         "### TensorFlow interoperability\n",
         "\n",
-        "ND array can be passed to TensorFlow APIs. These calls internally convert  ND array inputs to `tf.Tensor`. As mentioned earlier, such conversion does not actually do data copies, even for data placed on accelerators or remote devices.\n",
+        "An ND array can be passed to TensorFlow APIs. These calls internally convert  ND array inputs to `tf.Tensor`. As mentioned earlier, such conversion does not actually do data copies, even for data placed on accelerators or remote devices.\n",
         "\n",
-        "Conversely, `tf.Tensor` objects can be passed to `tf.experimental.numpy` APIs. These inputs will internally be converted to ND array without performing data copies."
+        "Conversely, `tf.Tensor` objects can be passed to `tf.experimental.numpy` APIs. These inputs will internally be converted to an ND array without performing data copies."
       ]
     },
     {
@@ -481,9 +481,9 @@
       "source": [
         "#### Operator precedence\n",
         "\n",
-        "When ND array and `tf.Tensor` objects are combined using operators, a precedence rule is used to determine which object executes the operator. This is controllled by the `__array_priority__` value defined by these classes.\n",
+        "When ND array and `tf.Tensor` objects are combined using operators, a precedence rule is used to determine which object executes the operator. This is controlled by the `__array_priority__` value defined by these classes.\n",
         "\n",
-        "`tf.Tensor` defines an `__array_priority__` higher than that of ND array. This means that the ND array input will be converted to `tf.Tensor` and the `tf.Tensor` version of the operator will be called. \n",
+        "A `tf.Tensor` defines an `__array_priority__` higher than that of an ND array. This means that the ND array input will be converted to `tf.Tensor` and the `tf.Tensor` version of the operator will be called. \n",
         "\n",
         "The code below demonstrates how that affects the output type.\n"
       ]
@@ -510,7 +510,7 @@
         "\n",
         "TensorFlow's GradientTape can be used for backpropagation through TensorFlow and TensorFlow NumPy code. GradientTape APIs can also return ND array outputs.\n",
         "\n",
-        "Use the model created in [Example Model](#example-modle) section, and compute gradients and jacobians."
+        "Use the model created in [Example Model](#example-model) section, and compute gradients and jacobians."
       ]
     },
     {
@@ -615,7 +615,7 @@
       "source": [
         "### Vectorization: tf.vectorized_map\n",
         "\n",
-        "TensorFlow has inbuilt support for vectorizing parallel loops, which allows speedups of one to two orders of magnitude. These speedups are accessible via `tf.vectorized_map` API and apply to TensorFlow NumPy code as well.\n",
+        "TensorFlow has inbuilt support for vectorizing parallel loops, which allows speedups of one to two orders of magnitude. These speedups are accessible via the `tf.vectorized_map` API and apply to TensorFlow NumPy code as well.\n",
         "\n",
         "It is sometimes useful to compute the gradient of each output in a batch w.r.t. the corresponding input batch element. Such computation can be done efficiently using `tf.vectorized_map` as shown below."
       ]
@@ -691,9 +691,9 @@
       "source": [
         "### Device placement\n",
         "\n",
-        "TensorFlow NumPy can place operations on CPUs, GPUs, TPUs and remote devices. It uses standard TensorFlow mechanisms for device placement. Below we show a simple example to list all device and then place some computaton on a particular device.\n",
+        "TensorFlow NumPy can place operations on CPUs, GPUs, TPUs and remote devices. It uses standard TensorFlow mechanisms for device placement. Below we show a simple example to list all devices and then place some computation on a particular device.\n",
         "\n",
-        "TenorFlow also has APIs for replicating computation across devices and performing collective reductions which will not be covered here."
+        "TensorFlow also has APIs for replicating computation across devices and performing collective reductions which will not be covered here."
       ]
     },
     {
@@ -789,7 +789,7 @@
         "\n",
         "TensorFlow NumPy uses highly optimized TensorFlow kernels that can be dispatched on CPUs, GPUs and TPUs. TensorFlow also performs many compiler optimizations, like operation fusion, which translate to performance and memory improvements. See [TensorFlow graph optimization with Grappler](./graph_optimization.ipynb) to learn more.\n",
         "\n",
-        "However TensorFlow has higher overheads for dispatching operations compared to NumPy. For workloads composed of small operations (less than about 10 microseconds), these overheads can dominate the runtime and NumPy could provide better performance. For other case, TensorFlow should generally provide better performance.\n",
+        "However TensorFlow has higher overheads for dispatching operations compared to NumPy. For workloads composed of small operations (less than about 10 microseconds), these overheads can dominate the runtime and NumPy could provide better performance. For other cases, TensorFlow should generally provide better performance.\n",
         "\n",
         "Run the benchmark below to compare NumPy and TensorFlow Numpy performance for different input sizes."
       ]

--- a/site/en/guide/tf_numpy.ipynb
+++ b/site/en/guide/tf_numpy.ipynb
@@ -120,7 +120,7 @@
       "source": [
         "## TensorFlow NumPy ND array\n",
         "\n",
-        "An instance of `tf.experimental.numpy.ndarray`, which we will call **ND Array**, represents a multidimensional dense array of a given `dtype` placed on a certain device. Each one of these objects internally wraps a `tf.Tensor`. Check out the ND array class for useful methods like `ndarray.T`, `ndarray.reshape`, `ndarray.ravel` and others.\n",
+        "An instance of `tf.experimental.numpy.ndarray`, called **ND Array**, represents a multidimensional dense array of a given `dtype` placed on a certain device. Each one of these objects internally wraps a `tf.Tensor`. Check out the ND array class for useful methods like `ndarray.T`, `ndarray.reshape`, `ndarray.ravel` and others.\n",
         "\n",
         "First create an ND array object, and then invoke different methods. "
       ]
@@ -284,7 +284,7 @@
         "  def predict(self, inputs):\n",
         "    if self.weights is None:\n",
         "      size = inputs.shape[1]\n",
-        "      # Note that we use `tnp.float32` type for performance.\n",
+        "      # Note that type `tnp.float32` is used for performance.\n",
         "      stddev = tnp.sqrt(size).astype(tnp.float32)\n",
         "      w1 = tnp.random.randn(size, 64).astype(tnp.float32) / stddev\n",
         "      bias = tnp.random.randn(64).astype(tnp.float32)\n",
@@ -659,7 +659,7 @@
       },
       "outputs": [],
       "source": [
-        "# Here we benchmark the vectorized computation above and compare with\n",
+        "# Benchmark the vectorized computation above and compare with\n",
         "# unvectorized sequential computation using `tf.map_fn`.\n",
         "@tf.function\n",
         "def unvectorized_per_example_gradients(inputs, labels):\n",
@@ -691,7 +691,7 @@
       "source": [
         "### Device placement\n",
         "\n",
-        "TensorFlow NumPy can place operations on CPUs, GPUs, TPUs and remote devices. It uses standard TensorFlow mechanisms for device placement. Below we show a simple example to list all devices and then place some computation on a particular device.\n",
+        "TensorFlow NumPy can place operations on CPUs, GPUs, TPUs and remote devices. It uses standard TensorFlow mechanisms for device placement. Below a simple example shows how to list all devices and then place some computation on a particular device.\n",
         "\n",
         "TensorFlow also has APIs for replicating computation across devices and performing collective reductions which will not be covered here."
       ]
@@ -842,7 +842,7 @@
       },
       "outputs": [],
       "source": [
-        "# Here we define a simple implementation of `sigmoid`, and benchmark it using\n",
+        "# Define a simple implementation of `sigmoid`, and benchmark it using\n",
         "# NumPy and TensorFlow NumPy for different input sizes.\n",
         "\n",
         "def np_sigmoid(y):\n",

--- a/site/en/guide/tf_numpy.ipynb
+++ b/site/en/guide/tf_numpy.ipynb
@@ -483,7 +483,7 @@
         "\n",
         "When ND array and `tf.Tensor` objects are combined using operators, a precedence rule is used to determine which object executes the operator. This is controlled by the `__array_priority__` value defined by these classes.\n",
         "\n",
-        "A `tf.Tensor` defines an `__array_priority__` higher than that of an ND array. This means that the ND array input will be converted to `tf.Tensor` and the `tf.Tensor` version of the operator will be called. \n",
+        "`tf.Tensor` defines an `__array_priority__` higher than that of ND array. This means that the ND array input will be converted to `tf.Tensor` and the `tf.Tensor` version of the operator will be called. \n",
         "\n",
         "The code below demonstrates how that affects the output type.\n"
       ]


### PR DESCRIPTION
Hi @yashk2810 @lamberta @guptadhaval18 Thank you for the awesome work on the [TensorFlow NumPy guide](https://www.tensorflow.org/guide/tf_numpy?hl=el).

I've noticed a few typographical errors and created this PR to fix them + add some minor improvements to the guide. (There're a few things I'm not 100% sure about - see below.)

The notebook was originally edited in Google Colab and then run through the `tensorflow_docs.tools.nbfmt` tool.

Here's a summary of the proposed changes:

1. Split a verb (a typo: "checkout" -> "check out") and combine sentences -> _You can do X for reason Y and also do Z_.

```diff
- "Checkout the [NumPy broadcasting guide](https://numpy.org/doc/stable/user/basics.broadcasting.html). Also compare this with [TensorFlow broadcasting semantics](https://www.tensorflow.org/guide/tensor#broadcasting)."
+ "You can check out the [NumPy broadcasting guide](https://numpy.org/doc/stable/user/basics.broadcasting.html) for more information and compare this with [TensorFlow broadcasting semantics](https://www.tensorflow.org/guide/tensor#broadcasting)."
```

2. Fix a typo: "sophistsicated" -> "sophisticated".

```diff
- "NumPy defines very sophistsicated indexing rules..."
+ "NumPy defines very sophisticated indexing rules..."

- Wrap "dtype" with back ticks (as in: a NumPy `dtype`):

```diff
- "...and `stride_tricks`, and some dtypes (like `np.recarray`, `np.object`)..."
+ "...and `stride_tricks`, and some `dtype`s (like `np.recarray` and `np.object`)..."
```

3. Three things:
- Fix a typo by changing a noun from singular ("these input") to plural ("these inputs").
- Add an indefinite article ("an") to "ND array".
- Add a definite article—"the"—to "ND array" in the next sentence.

```diff
- "...can accept inputs of different types including `tf.Tensor` and `np.ndarray`. These input are converted to ND array..."
- "Conversion of ND array to and from `np.ndarray` may trigger..."
+ "...can accept inputs of different types including `tf.Tensor` and `np.ndarray`. These inputs are converted to an ND array..."
+ "Conversion of the ND array to and from `np.ndarray` may trigger..."
```

4. Fix a typo: "requirments" -> "requirements".

```diff
- "...This is because TensorFlow NumPy has stricter requirments on memory alignment than those of NumPy."
+ "...This is because TensorFlow NumPy has stricter requirements on memory alignment than those of NumPy."
```

5. Add an indefinite article—"an"—to "ND array":

```diff
"### TensorFlow interoperability"

- "ND array can be passed to TensorFlow APIs. These calls internally convert  ND array inputs to `tf.Tensor`..."
+ "An ND array can be passed to TensorFlow APIs. These calls internally convert  ND array inputs to `tf.Tensor`..."
...
"Conversely, `tf.Tensor` objects can be passed to `tf.experimental.numpy` APIs."
- "These inputs will internally be converted to ND array without performing data copies."
+ "These inputs will internally be converted to an ND array without performing data copies."
```

6. Fix a typo: "controllled" -> "controlled".

```diff
- "...This is controllled by the `__array_priority__` value defined by these classes."
+ "...This is controlled by the `__array_priority__` value defined by these classes."
```

7. Fix a typo which fixes a link: "#example-modle" -> "#example-model".

```diff
- "Use the model created in [Example Model](#example-modle) section, and compute gradients and jacobians."
+ "Use the model created in [Example Model](#example-model) section, and compute gradients and jacobians."
```

8. Fix two typos: "all device" -> "all devices", "computaton" -> "computation", "TenorFlow" -> "TensorFlow".

```diff
- "Below we show a simple example to list all device and then place some computaton on a particular device."
+ "Below we show a simple example to list all devices and then place some computation on a particular device."
- "TenorFlow also has APIs for replicating computation across devices and performing collective reductions which will not be covered here."
+ "TensorFlow also has APIs for replicating computation across devices and performing collective reductions which will not be covered here."
```

9. Fix a typo by amending a noun from singular ("for all case") to plural ("for all cases").

```diff
- "For other case, TensorFlow should generally provide better performance."
+ "For other cases, TensorFlow should generally provide better performance."
```

---

Note: I'm familiar with `tf.vectorized_map` (and `vmap` by JAX) but not 100% sure here about whether a definite article—"the"—is needed.

```diff
- "These speedups are accessible via `tf.vectorized_map` API and apply to TensorFlow NumPy code as well."
+ "These speedups are accessible via the `tf.vectorized_map` API and apply to TensorFlow NumPy code as well."
```

Let me know if you have any questions. 

Thank you!