### PR TITLE
Add nightly GitHub Actions workflow to sync Keras guides.

### DIFF
--- a/.github/workflows/bot-nightly.yaml
+++ b/.github/workflows/bot-nightly.yaml
@@ -1,0 +1,65 @@
+# Nightly jobs run by a bot collaborator.
+name: Nightly jobs
+on:
+  repository_dispatch:
+    types: [nightly]
+
+jobs:
+  snapshot-source:
+    name: Update Keras guides
+    if : ${{ github.actor == 'tfdocsbot' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: keras-team/keras-io
+        path: keras-io
+    - uses: actions/checkout@v2
+      with:
+        ref: snapshot-keras
+        fetch-depth: 0
+        path: docs
+    - name: Set up repo
+      run: |
+        # Set commit author.
+        git config --global user.name "$GITHUB_ACTOR"
+        git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        # Update branch.
+        cd docs
+        if ! git merge origin/master; then
+          echo "[${GITHUB_WORKFLOW}] Unable to update from master branch." >&2
+          exit 1
+        fi
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Install requirements
+      run: |
+        python3 -m pip install -U -r keras-io/requirements.txt
+        python3 -m pip install -U git+https://github.com/tensorflow/docs
+    - name: Generate Keras notebooks
+      run: |
+        mkdir -p keras-io/tf  # Make sure output dir exists.
+        cd keras-io/scripts/
+        echo "[${GITHUB_WORKFLOW}] Generate Keras guides ..."
+        python3 autogen.py generate_tf_guides
+        echo "[${GITHUB_WORKFLOW}] Format notebooks ..."
+        python3 -m tensorflow_docs.tools.nbfmt ../tf/
+    - name: Sync docs repo
+      env:
+        KERAS_GUIDES_DIR: site/en/guide/keras/
+      run: |
+        rsync --archive --del --checksum ./keras-io/tf/ "./docs/${KERAS_GUIDES_DIR}"
+        cd docs
+        if [[ -z $(git status -s | grep "$KERAS_GUIDES_DIR") ]]; then
+          echo "[${GITHUB_WORKFLOW}] No Keras guides updated, exiting."
+          exit 0
+        fi
+        # Match timestamp format to other snapshot messages.
+        fmt_rfc7231="%a, %d %b %Y %H:%M:%S %Z"
+        TIMESTAMP_STR=$(TZ=GMT date +"$fmt_rfc7231")
+
+        git add "./${KERAS_GUIDES_DIR}"
+        git commit -m "Keras guides snapshot: ${TIMESTAMP_STR}"
+        # Push to current branch.
+        echo "[${GITHUB_WORKFLOW}] Push changes to repo ..."
+        git push origin


### PR DESCRIPTION
Adds nightly workflow to generate notebooks and sync the Keras guides from https://github.com/keras-team/keras-io/tree/master/tf

These updates will live on the `snapshot-keras` branch.
Tested in https://github.com/lamberta/tf-docs/runs/1162780925?check_suite_focus=true

Commit: https://github.com/lamberta/tf-docs/commits/snapshot/keras

ref: b/169166095
