### PR TITLE
added option to pickle tokenizer

### DIFF
--- a/site/en/tutorials/text/image_captioning.ipynb
+++ b/site/en/tutorials/text/image_captioning.ipynb
@@ -1,4 +1,19 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "image_captioning.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -11,12 +26,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "VRLVEKiTEn04"
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -29,7 +42,9 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -86,11 +101,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "U8l4RJ0XRPEm"
       },
-      "outputs": [],
       "source": [
         "import tensorflow as tf\n",
         "\n",
@@ -112,7 +125,9 @@
         "from glob import glob\n",
         "from PIL import Image\n",
         "import pickle"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -129,11 +144,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "krQuPYTtRPE7"
       },
-      "outputs": [],
       "source": [
         "# Download caption annotation files\n",
         "annotation_folder = '/annotations/'\n",
@@ -156,7 +169,9 @@
         "  os.remove(image_zip)\n",
         "else:\n",
         "  PATH = os.path.abspath('.') + image_folder"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -170,23 +185,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "m8iBJCyVB2ud"
       },
-      "outputs": [],
       "source": [
         "with open(annotation_file, 'r') as f:\n",
         "    annotations = json.load(f)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "miER7EHMB3Ge"
       },
-      "outputs": [],
       "source": [
         "# Group all captions together having the same image ID.\n",
         "image_path_to_caption = collections.defaultdict(list)\n",
@@ -194,15 +207,15 @@
         "  caption = f\"<start> {val['caption']} <end>\"\n",
         "  image_path = PATH + 'COCO_train2014_' + '%012d.jpg' % (val['image_id'])\n",
         "  image_path_to_caption[image_path].append(caption)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "7vvqkqYGMhvm"
       },
-      "outputs": [],
       "source": [
         "image_paths = list(image_path_to_caption.keys())\n",
         "random.shuffle(image_paths)\n",
@@ -212,15 +225,15 @@
         "# lead to 30,000 examples.\n",
         "train_image_paths = image_paths[:6000]\n",
         "print(len(train_image_paths))"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "hrmdtMX8Lnyh"
       },
-      "outputs": [],
       "source": [
         "train_captions = []\n",
         "img_name_vector = []\n",
@@ -229,19 +242,21 @@
         "  caption_list = image_path_to_caption[image_path]\n",
         "  train_captions.extend(caption_list)\n",
         "  img_name_vector.extend([image_path] * len(caption_list))"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "RhCND0bCUP11"
       },
-      "outputs": [],
       "source": [
         "print(train_captions[0])\n",
         "Image.open(img_name_vector[0])"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -259,11 +274,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "zXR0217aRPFR"
       },
-      "outputs": [],
       "source": [
         "def load_image(image_path):\n",
         "    img = tf.io.read_file(image_path)\n",
@@ -271,7 +284,9 @@
         "    img = tf.image.resize(img, (299, 299))\n",
         "    img = tf.keras.applications.inception_v3.preprocess_input(img)\n",
         "    return img, image_path"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -289,11 +304,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "RD3vW4SsRPFW"
       },
-      "outputs": [],
       "source": [
         "image_model = tf.keras.applications.InceptionV3(include_top=False,\n",
         "                                                weights='imagenet')\n",
@@ -301,7 +314,9 @@
         "hidden_layer = image_model.layers[-1].output\n",
         "\n",
         "image_features_extract_model = tf.keras.Model(new_input, hidden_layer)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -336,11 +351,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "Dx_fvbVgRPGQ"
       },
-      "outputs": [],
       "source": [
         "# Get unique images\n",
         "encode_train = sorted(set(img_name_vector))\n",
@@ -358,7 +371,9 @@
         "  for bf, p in zip(batch_features, path):\n",
         "    path_of_feature = p.numpy().decode(\"utf-8\")\n",
         "    np.save(path_of_feature, bf.numpy())"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -371,29 +386,28 @@
         "* First, you'll tokenize the captions (for example, by splitting on spaces). This gives us a  vocabulary of all of the unique words in the data (for example, \"surfing\", \"football\", and so on).\n",
         "* Next, you'll limit the vocabulary size to the top 5,000 words (to save memory). You'll replace all other words with the token \"UNK\" (unknown).\n",
         "* You then create word-to-index and index-to-word mappings.\n",
-        "* Finally, you pad all sequences to be the same length as the longest one."
+        "* Finally, you pad all sequences to be the same length as the longest one.\n",
+        "* You also have the option of saving the tokenizer object as a file, so that it can be simply loaded at any other point, without having to re-download the dataset."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "HZfK8RhQRPFj"
       },
-      "outputs": [],
       "source": [
         "# Find the maximum length of any caption in our dataset\n",
         "def calc_max_length(tensor):\n",
         "    return max(len(t) for t in tensor)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "oJGE34aiRPFo"
       },
-      "outputs": [],
       "source": [
         "# Choose the top 5000 words from the vocabulary\n",
         "top_k = 5000\n",
@@ -402,56 +416,71 @@
         "                                                  filters='!\"#$%&()*+.,-/:;=?@[\\]^_`{|}~ ')\n",
         "tokenizer.fit_on_texts(train_captions)\n",
         "train_seqs = tokenizer.texts_to_sequences(train_captions)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "8Q44tNQVRPFt"
       },
-      "outputs": [],
       "source": [
         "tokenizer.word_index['<pad>'] = 0\n",
         "tokenizer.index_word[0] = '<pad>'"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
+      "metadata": {
+        "id": "UaVIMX0LKTq9"
+      },
+      "source": [
+        "# OPTIONAL - saving the tokenizer object\n",
+        "with open('tokenizer.pickle', 'wb') as handle:\n",
+        "    pickle.dump(tokenizer, handle, protocol=pickle.HIGHEST_PROTOCOL)"
+      ],
       "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
       "metadata": {
         "id": "0fpJb5ojRPFv"
       },
-      "outputs": [],
       "source": [
         "# Create the tokenized vectors\n",
         "train_seqs = tokenizer.texts_to_sequences(train_captions)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "AidglIZVRPF4"
       },
-      "outputs": [],
       "source": [
         "# Pad each vector to the max_length of the captions\n",
         "# If you do not provide a max_length value, pad_sequences calculates it automatically\n",
         "cap_vector = tf.keras.preprocessing.sequence.pad_sequences(train_seqs, padding='post')"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "gL0wkttkRPGA"
       },
-      "outputs": [],
       "source": [
         "# Calculates the max_length, which is used to store the attention weights\n",
         "max_length = calc_max_length(train_seqs)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -464,11 +493,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "iS7DDMszRPGF"
       },
-      "outputs": [],
       "source": [
         "img_to_cap_vector = collections.defaultdict(list)\n",
         "for img, cap in zip(img_name_vector, cap_vector):\n",
@@ -494,18 +521,20 @@
         "  capv_len = len(img_to_cap_vector[imgv])\n",
         "  img_name_val.extend([imgv] * capv_len)\n",
         "  cap_val.extend(img_to_cap_vector[imgv])"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "XmViPkRFRPGH"
       },
-      "outputs": [],
       "source": [
         "len(img_name_train), len(cap_train), len(img_name_val), len(cap_val)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -527,11 +556,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "Q3TnZ1ToRPGV"
       },
-      "outputs": [],
       "source": [
         "# Feel free to change these parameters according to your system's configuration\n",
         "\n",
@@ -545,29 +572,29 @@
         "# These two variables represent that vector shape\n",
         "features_shape = 2048\n",
         "attention_features_shape = 64"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "SmZS2N0bXG3T"
       },
-      "outputs": [],
       "source": [
         "# Load the numpy files\n",
         "def map_func(img_name, cap):\n",
         "  img_tensor = np.load(img_name.decode('utf-8')+'.npy')\n",
         "  return img_tensor, cap"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "FDF_Nm3tRPGZ"
       },
-      "outputs": [],
       "source": [
         "dataset = tf.data.Dataset.from_tensor_slices((img_name_train, cap_train))\n",
         "\n",
@@ -579,7 +606,9 @@
         "# Shuffle and batch\n",
         "dataset = dataset.shuffle(BUFFER_SIZE).batch(BATCH_SIZE)\n",
         "dataset = dataset.prefetch(buffer_size=tf.data.experimental.AUTOTUNE)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -601,11 +630,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "ja2LFTMSdeV3"
       },
-      "outputs": [],
       "source": [
         "class BahdanauAttention(tf.keras.Model):\n",
         "  def __init__(self, units):\n",
@@ -637,15 +664,15 @@
         "    context_vector = tf.reduce_sum(context_vector, axis=1)\n",
         "\n",
         "    return context_vector, attention_weights"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "AZ7R1RxHRPGf"
       },
-      "outputs": [],
       "source": [
         "class CNN_Encoder(tf.keras.Model):\n",
         "    # Since you have already extracted the features and dumped it using pickle\n",
@@ -659,15 +686,15 @@
         "        x = self.fc(x)\n",
         "        x = tf.nn.relu(x)\n",
         "        return x"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "V9UbGQmERPGi"
       },
-      "outputs": [],
       "source": [
         "class RNN_Decoder(tf.keras.Model):\n",
         "  def __init__(self, embedding_dim, units, vocab_size):\n",
@@ -710,27 +737,27 @@
         "\n",
         "  def reset_state(self, batch_size):\n",
         "    return tf.zeros((batch_size, self.units))"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "Qs_Sr03wRPGk"
       },
-      "outputs": [],
       "source": [
         "encoder = CNN_Encoder(embedding_dim)\n",
         "decoder = RNN_Decoder(embedding_dim, units, vocab_size)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "-bYN7xA0RPGl"
       },
-      "outputs": [],
       "source": [
         "optimizer = tf.keras.optimizers.Adam()\n",
         "loss_object = tf.keras.losses.SparseCategoricalCrossentropy(\n",
@@ -744,7 +771,9 @@
         "  loss_ *= mask\n",
         "\n",
         "  return tf.reduce_mean(loss_)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -757,33 +786,33 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "PpJAqPMWo0uE"
       },
-      "outputs": [],
       "source": [
         "checkpoint_path = \"./checkpoints/train\"\n",
         "ckpt = tf.train.Checkpoint(encoder=encoder,\n",
         "                           decoder=decoder,\n",
         "                           optimizer = optimizer)\n",
         "ckpt_manager = tf.train.CheckpointManager(ckpt, checkpoint_path, max_to_keep=5)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "fUkbqhc_uObw"
       },
-      "outputs": [],
       "source": [
         "start_epoch = 0\n",
         "if ckpt_manager.latest_checkpoint:\n",
         "  start_epoch = int(ckpt_manager.latest_checkpoint.split('-')[-1])\n",
         "  # restoring the latest checkpoint in checkpoint_path\n",
         "  ckpt.restore(ckpt_manager.latest_checkpoint)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -804,24 +833,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "Vt4WZ5mhJE-E"
       },
-      "outputs": [],
       "source": [
         "# adding this in a separate cell because if you run the training cell\n",
         "# many times, the loss_plot array will be reset\n",
         "loss_plot = []"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "sqgyz2ANKlpU"
       },
-      "outputs": [],
       "source": [
         "@tf.function\n",
         "def train_step(img_tensor, target):\n",
@@ -854,15 +881,15 @@
         "  optimizer.apply_gradients(zip(gradients, trainable_variables))\n",
         "\n",
         "  return loss, total_loss"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "UlA4VIQpRPGo"
       },
-      "outputs": [],
       "source": [
         "EPOCHS = 20\n",
         "\n",
@@ -886,22 +913,24 @@
         "    print ('Epoch {} Loss {:.6f}'.format(epoch + 1,\n",
         "                                         total_loss/num_steps))\n",
         "    print ('Time taken for 1 epoch {} sec\\n'.format(time.time() - start))"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "1Wm83G-ZBPcC"
       },
-      "outputs": [],
       "source": [
         "plt.plot(loss_plot)\n",
         "plt.xlabel('Epochs')\n",
         "plt.ylabel('Loss')\n",
         "plt.title('Loss Plot')\n",
         "plt.show()"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -918,11 +947,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "RCWpDtyNRPGs"
       },
-      "outputs": [],
       "source": [
         "def evaluate(image):\n",
         "    attention_plot = np.zeros((max_length, attention_features_shape))\n",
@@ -953,15 +980,15 @@
         "\n",
         "    attention_plot = attention_plot[:len(result), :]\n",
         "    return result, attention_plot"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "fD_y7PD6RPGt"
       },
-      "outputs": [],
       "source": [
         "def plot_attention(image, result, attention_plot):\n",
         "    temp_image = np.array(Image.open(image))\n",
@@ -978,15 +1005,15 @@
         "\n",
         "    plt.tight_layout()\n",
         "    plt.show()"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "7x8RiPHe_4qI"
       },
-      "outputs": [],
       "source": [
         "# captions on the validation set\n",
         "rid = np.random.randint(0, len(img_name_val))\n",
@@ -997,7 +1024,9 @@
         "print ('Real Caption:', real_caption)\n",
         "print ('Prediction Caption:', ' '.join(result))\n",
         "plot_attention(image, result, attention_plot)\n"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1011,11 +1040,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "9Psd1quzaAWg"
       },
-      "outputs": [],
       "source": [
         "image_url = 'https://tensorflow.org/images/surf.jpg'\n",
         "image_extension = image_url[-4:]\n",
@@ -1027,7 +1054,9 @@
         "plot_attention(image_path, result, attention_plot)\n",
         "# opening the image\n",
         "Image.open(image_path)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1040,19 +1069,5 @@
         "Congrats! You've just trained an image captioning model with attention. Next, take a look at this example [Neural Machine Translation with Attention](../sequences/nmt_with_attention.ipynb). It uses a similar architecture to translate between Spanish and English sentences. You can also experiment with training the code in this notebook on a different dataset."
       ]
     }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [],
-      "name": "image_captioning.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }

--- a/site/en/tutorials/text/image_captioning.ipynb
+++ b/site/en/tutorials/text/image_captioning.ipynb
@@ -1,19 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "image_captioning.ipynb",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -26,10 +11,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "VRLVEKiTEn04"
       },
+      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -42,9 +29,7 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -101,9 +86,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "U8l4RJ0XRPEm"
       },
+      "outputs": [],
       "source": [
         "import tensorflow as tf\n",
         "\n",
@@ -125,9 +112,7 @@
         "from glob import glob\n",
         "from PIL import Image\n",
         "import pickle"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -144,9 +129,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "krQuPYTtRPE7"
       },
+      "outputs": [],
       "source": [
         "# Download caption annotation files\n",
         "annotation_folder = '/annotations/'\n",
@@ -169,9 +156,7 @@
         "  os.remove(image_zip)\n",
         "else:\n",
         "  PATH = os.path.abspath('.') + image_folder"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -185,21 +170,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "m8iBJCyVB2ud"
       },
+      "outputs": [],
       "source": [
         "with open(annotation_file, 'r') as f:\n",
         "    annotations = json.load(f)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "miER7EHMB3Ge"
       },
+      "outputs": [],
       "source": [
         "# Group all captions together having the same image ID.\n",
         "image_path_to_caption = collections.defaultdict(list)\n",
@@ -207,15 +194,15 @@
         "  caption = f\"<start> {val['caption']} <end>\"\n",
         "  image_path = PATH + 'COCO_train2014_' + '%012d.jpg' % (val['image_id'])\n",
         "  image_path_to_caption[image_path].append(caption)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "7vvqkqYGMhvm"
       },
+      "outputs": [],
       "source": [
         "image_paths = list(image_path_to_caption.keys())\n",
         "random.shuffle(image_paths)\n",
@@ -225,15 +212,15 @@
         "# lead to 30,000 examples.\n",
         "train_image_paths = image_paths[:6000]\n",
         "print(len(train_image_paths))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "hrmdtMX8Lnyh"
       },
+      "outputs": [],
       "source": [
         "train_captions = []\n",
         "img_name_vector = []\n",
@@ -242,21 +229,19 @@
         "  caption_list = image_path_to_caption[image_path]\n",
         "  train_captions.extend(caption_list)\n",
         "  img_name_vector.extend([image_path] * len(caption_list))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "RhCND0bCUP11"
       },
+      "outputs": [],
       "source": [
         "print(train_captions[0])\n",
         "Image.open(img_name_vector[0])"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -274,9 +259,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "zXR0217aRPFR"
       },
+      "outputs": [],
       "source": [
         "def load_image(image_path):\n",
         "    img = tf.io.read_file(image_path)\n",
@@ -284,9 +271,7 @@
         "    img = tf.image.resize(img, (299, 299))\n",
         "    img = tf.keras.applications.inception_v3.preprocess_input(img)\n",
         "    return img, image_path"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -304,9 +289,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "RD3vW4SsRPFW"
       },
+      "outputs": [],
       "source": [
         "image_model = tf.keras.applications.InceptionV3(include_top=False,\n",
         "                                                weights='imagenet')\n",
@@ -314,9 +301,7 @@
         "hidden_layer = image_model.layers[-1].output\n",
         "\n",
         "image_features_extract_model = tf.keras.Model(new_input, hidden_layer)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -351,9 +336,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "Dx_fvbVgRPGQ"
       },
+      "outputs": [],
       "source": [
         "# Get unique images\n",
         "encode_train = sorted(set(img_name_vector))\n",
@@ -371,9 +358,7 @@
         "  for bf, p in zip(batch_features, path):\n",
         "    path_of_feature = p.numpy().decode(\"utf-8\")\n",
         "    np.save(path_of_feature, bf.numpy())"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -392,22 +377,24 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "HZfK8RhQRPFj"
       },
+      "outputs": [],
       "source": [
         "# Find the maximum length of any caption in our dataset\n",
         "def calc_max_length(tensor):\n",
         "    return max(len(t) for t in tensor)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "oJGE34aiRPFo"
       },
+      "outputs": [],
       "source": [
         "# Choose the top 5000 words from the vocabulary\n",
         "top_k = 5000\n",
@@ -416,71 +403,69 @@
         "                                                  filters='!\"#$%&()*+.,-/:;=?@[\\]^_`{|}~ ')\n",
         "tokenizer.fit_on_texts(train_captions)\n",
         "train_seqs = tokenizer.texts_to_sequences(train_captions)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "8Q44tNQVRPFt"
       },
+      "outputs": [],
       "source": [
         "tokenizer.word_index['<pad>'] = 0\n",
         "tokenizer.index_word[0] = '<pad>'"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "UaVIMX0LKTq9"
       },
+      "outputs": [],
       "source": [
         "# OPTIONAL - saving the tokenizer object\n",
         "with open('tokenizer.pickle', 'wb') as handle:\n",
         "    pickle.dump(tokenizer, handle, protocol=pickle.HIGHEST_PROTOCOL)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "0fpJb5ojRPFv"
       },
+      "outputs": [],
       "source": [
         "# Create the tokenized vectors\n",
         "train_seqs = tokenizer.texts_to_sequences(train_captions)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "AidglIZVRPF4"
       },
+      "outputs": [],
       "source": [
         "# Pad each vector to the max_length of the captions\n",
         "# If you do not provide a max_length value, pad_sequences calculates it automatically\n",
         "cap_vector = tf.keras.preprocessing.sequence.pad_sequences(train_seqs, padding='post')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "gL0wkttkRPGA"
       },
+      "outputs": [],
       "source": [
         "# Calculates the max_length, which is used to store the attention weights\n",
         "max_length = calc_max_length(train_seqs)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -493,9 +478,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "iS7DDMszRPGF"
       },
+      "outputs": [],
       "source": [
         "img_to_cap_vector = collections.defaultdict(list)\n",
         "for img, cap in zip(img_name_vector, cap_vector):\n",
@@ -521,20 +508,18 @@
         "  capv_len = len(img_to_cap_vector[imgv])\n",
         "  img_name_val.extend([imgv] * capv_len)\n",
         "  cap_val.extend(img_to_cap_vector[imgv])"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "XmViPkRFRPGH"
       },
+      "outputs": [],
       "source": [
         "len(img_name_train), len(cap_train), len(img_name_val), len(cap_val)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -556,9 +541,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "Q3TnZ1ToRPGV"
       },
+      "outputs": [],
       "source": [
         "# Feel free to change these parameters according to your system's configuration\n",
         "\n",
@@ -572,29 +559,29 @@
         "# These two variables represent that vector shape\n",
         "features_shape = 2048\n",
         "attention_features_shape = 64"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "SmZS2N0bXG3T"
       },
+      "outputs": [],
       "source": [
         "# Load the numpy files\n",
         "def map_func(img_name, cap):\n",
         "  img_tensor = np.load(img_name.decode('utf-8')+'.npy')\n",
         "  return img_tensor, cap"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "FDF_Nm3tRPGZ"
       },
+      "outputs": [],
       "source": [
         "dataset = tf.data.Dataset.from_tensor_slices((img_name_train, cap_train))\n",
         "\n",
@@ -606,9 +593,7 @@
         "# Shuffle and batch\n",
         "dataset = dataset.shuffle(BUFFER_SIZE).batch(BATCH_SIZE)\n",
         "dataset = dataset.prefetch(buffer_size=tf.data.experimental.AUTOTUNE)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -630,9 +615,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "ja2LFTMSdeV3"
       },
+      "outputs": [],
       "source": [
         "class BahdanauAttention(tf.keras.Model):\n",
         "  def __init__(self, units):\n",
@@ -664,15 +651,15 @@
         "    context_vector = tf.reduce_sum(context_vector, axis=1)\n",
         "\n",
         "    return context_vector, attention_weights"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "AZ7R1RxHRPGf"
       },
+      "outputs": [],
       "source": [
         "class CNN_Encoder(tf.keras.Model):\n",
         "    # Since you have already extracted the features and dumped it using pickle\n",
@@ -686,15 +673,15 @@
         "        x = self.fc(x)\n",
         "        x = tf.nn.relu(x)\n",
         "        return x"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "V9UbGQmERPGi"
       },
+      "outputs": [],
       "source": [
         "class RNN_Decoder(tf.keras.Model):\n",
         "  def __init__(self, embedding_dim, units, vocab_size):\n",
@@ -737,27 +724,27 @@
         "\n",
         "  def reset_state(self, batch_size):\n",
         "    return tf.zeros((batch_size, self.units))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "Qs_Sr03wRPGk"
       },
+      "outputs": [],
       "source": [
         "encoder = CNN_Encoder(embedding_dim)\n",
         "decoder = RNN_Decoder(embedding_dim, units, vocab_size)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "-bYN7xA0RPGl"
       },
+      "outputs": [],
       "source": [
         "optimizer = tf.keras.optimizers.Adam()\n",
         "loss_object = tf.keras.losses.SparseCategoricalCrossentropy(\n",
@@ -771,9 +758,7 @@
         "  loss_ *= mask\n",
         "\n",
         "  return tf.reduce_mean(loss_)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -786,33 +771,33 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "PpJAqPMWo0uE"
       },
+      "outputs": [],
       "source": [
         "checkpoint_path = \"./checkpoints/train\"\n",
         "ckpt = tf.train.Checkpoint(encoder=encoder,\n",
         "                           decoder=decoder,\n",
         "                           optimizer = optimizer)\n",
         "ckpt_manager = tf.train.CheckpointManager(ckpt, checkpoint_path, max_to_keep=5)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "fUkbqhc_uObw"
       },
+      "outputs": [],
       "source": [
         "start_epoch = 0\n",
         "if ckpt_manager.latest_checkpoint:\n",
         "  start_epoch = int(ckpt_manager.latest_checkpoint.split('-')[-1])\n",
         "  # restoring the latest checkpoint in checkpoint_path\n",
         "  ckpt.restore(ckpt_manager.latest_checkpoint)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -833,22 +818,24 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "Vt4WZ5mhJE-E"
       },
+      "outputs": [],
       "source": [
         "# adding this in a separate cell because if you run the training cell\n",
         "# many times, the loss_plot array will be reset\n",
         "loss_plot = []"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "sqgyz2ANKlpU"
       },
+      "outputs": [],
       "source": [
         "@tf.function\n",
         "def train_step(img_tensor, target):\n",
@@ -881,15 +868,15 @@
         "  optimizer.apply_gradients(zip(gradients, trainable_variables))\n",
         "\n",
         "  return loss, total_loss"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "UlA4VIQpRPGo"
       },
+      "outputs": [],
       "source": [
         "EPOCHS = 20\n",
         "\n",
@@ -913,24 +900,22 @@
         "    print ('Epoch {} Loss {:.6f}'.format(epoch + 1,\n",
         "                                         total_loss/num_steps))\n",
         "    print ('Time taken for 1 epoch {} sec\\n'.format(time.time() - start))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "1Wm83G-ZBPcC"
       },
+      "outputs": [],
       "source": [
         "plt.plot(loss_plot)\n",
         "plt.xlabel('Epochs')\n",
         "plt.ylabel('Loss')\n",
         "plt.title('Loss Plot')\n",
         "plt.show()"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -947,9 +932,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "RCWpDtyNRPGs"
       },
+      "outputs": [],
       "source": [
         "def evaluate(image):\n",
         "    attention_plot = np.zeros((max_length, attention_features_shape))\n",
@@ -980,15 +967,15 @@
         "\n",
         "    attention_plot = attention_plot[:len(result), :]\n",
         "    return result, attention_plot"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "fD_y7PD6RPGt"
       },
+      "outputs": [],
       "source": [
         "def plot_attention(image, result, attention_plot):\n",
         "    temp_image = np.array(Image.open(image))\n",
@@ -1005,15 +992,15 @@
         "\n",
         "    plt.tight_layout()\n",
         "    plt.show()"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "7x8RiPHe_4qI"
       },
+      "outputs": [],
       "source": [
         "# captions on the validation set\n",
         "rid = np.random.randint(0, len(img_name_val))\n",
@@ -1024,9 +1011,7 @@
         "print ('Real Caption:', real_caption)\n",
         "print ('Prediction Caption:', ' '.join(result))\n",
         "plot_attention(image, result, attention_plot)\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1040,9 +1025,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "9Psd1quzaAWg"
       },
+      "outputs": [],
       "source": [
         "image_url = 'https://tensorflow.org/images/surf.jpg'\n",
         "image_extension = image_url[-4:]\n",
@@ -1054,9 +1041,7 @@
         "plot_attention(image_path, result, attention_plot)\n",
         "# opening the image\n",
         "Image.open(image_path)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1069,5 +1054,19 @@
         "Congrats! You've just trained an image captioning model with attention. Next, take a look at this example [Neural Machine Translation with Attention](../sequences/nmt_with_attention.ipynb). It uses a similar architecture to translate between Spanish and English sentences. You can also experiment with training the code in this notebook on a different dataset."
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "image_captioning.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
I wanted to separately use this model once i've completed training. So along with saving checkpoints, I thought it would be a nice option to include saving the tokenizer as well, since the dataset it is fitted on is extremely large to reload. The model can now be loaded from the checkpoints folder and the tokenizer can also be loaded with pickle. The model can be evaluated against images during deployment or testing phases independently.