### PR TITLE
added option to pickle

### DIFF
--- a/site/en/tutorials/text/image_captioning.ipynb
+++ b/site/en/tutorials/text/image_captioning.ipynb
@@ -371,7 +371,8 @@
         "* First, you'll tokenize the captions (for example, by splitting on spaces). This gives us a  vocabulary of all of the unique words in the data (for example, \"surfing\", \"football\", and so on).\n",
         "* Next, you'll limit the vocabulary size to the top 5,000 words (to save memory). You'll replace all other words with the token \"UNK\" (unknown).\n",
         "* You then create word-to-index and index-to-word mappings.\n",
-        "* Finally, you pad all sequences to be the same length as the longest one."
+        "* Finally, you pad all sequences to be the same length as the longest one.\n",
+        "* Optional - You can also save the tokenizer object to reload it at a later stage without re-downloading the dataset. "
       ]
     },
     {
@@ -414,6 +415,19 @@
       "source": [
         "tokenizer.word_index['<pad>'] = 0\n",
         "tokenizer.index_word[0] = '<pad>'"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "a999dfa0fcec"
+      },
+      "outputs": [],
+      "source": [
+        "# OPTIONAL - Save tokenizer to reload without having to re-download dataset\n",
+        "with open('tokenizer.pickle', 'wb') as handle:\n",
+        "    pickle.dump(tokenizer, handle, protocol=pickle.HIGHEST_PROTOCOL)"
       ]
     },
     {

--- a/site/en/tutorials/text/image_captioning.ipynb
+++ b/site/en/tutorials/text/image_captioning.ipynb
@@ -1020,7 +1020,7 @@
       },
       "source": [
         "## Try it on your own images\n",
-        "For fun, below we've provided a method you can use to caption your own images with the model we've just trained. Keep in mind, it was trained on a relatively small amount of data, and your images may be different from the training data (so be prepared for weird results!)\n"
+        "For fun, a method is provided below that you can use to caption your own images with the model you've just trained. Keep in mind, it was trained on a relatively small amount of data, and your images may be different from the training data (so be prepared for weird results!)\n"
       ]
     },
     {


### PR DESCRIPTION
Option to use pickle to save tokenizer object. This removes the need to reuse or save the large dataset whenever the model is evaluated.