### PR TITLE
DeepDream : use a single `tf.roll` op to shift the two dimensions instead of two ops

### DIFF
--- a/site/en/tutorials/generative/deepdream.ipynb
+++ b/site/en/tutorials/generative/deepdream.ipynb
@@ -474,9 +474,8 @@
         "def random_roll(img, maxroll):\n",
         "  # Randomly shift the image to avoid tiled boundaries.\n",
         "  shift = tf.random.uniform(shape=[2], minval=-maxroll, maxval=maxroll, dtype=tf.int32)\n",
-        "  shift_down, shift_right = shift[0],shift[1] \n",
-        "  img_rolled = tf.roll(tf.roll(img, shift_right, axis=1), shift_down, axis=0)\n",
-        "  return shift_down, shift_right, img_rolled"
+        "  img_rolled = tf.roll(img, shift=shift, axis=[0,1])\n",
+        "  return shift, img_rolled"
       ]
     },
     {
@@ -487,7 +486,7 @@
       },
       "outputs": [],
       "source": [
-        "shift_down, shift_right, img_rolled = random_roll(np.array(original_img), 512)\n",
+        "shift, img_rolled = random_roll(np.array(original_img), 512)\n",
         "show(img_rolled)"
       ]
     },
@@ -518,7 +517,7 @@
         "        tf.TensorSpec(shape=[], dtype=tf.int32),)\n",
         "  )\n",
         "  def __call__(self, img, tile_size=512):\n",
-        "    shift_down, shift_right, img_rolled = random_roll(img, tile_size)\n",
+        "    shift, img_rolled = random_roll(img, tile_size)\n",
         "\n",
         "    # Initialize the image gradients to zero.\n",
         "    gradients = tf.zeros_like(img_rolled)\n",
@@ -547,7 +546,7 @@
         "        gradients = gradients + tape.gradient(loss, img_rolled)\n",
         "\n",
         "    # Undo the random shift applied to the image and its gradients.\n",
-        "    gradients = tf.roll(tf.roll(gradients, -shift_right, axis=1), -shift_down, axis=0)\n",
+        "    gradients = tf.roll(gradients, shift=-shift, axis=[0,1])\n",
         "\n",
         "    # Normalize the gradients.\n",
         "    gradients /= tf.math.reduce_std(gradients) + 1e-8 \n",


### PR DESCRIPTION
In the DeepDream tutorial, the `tf.roll` op is being used inefficiently by using 2 operations to roll two dimensions one at a time. The `tf.roll` supports the ability to shift multiple dimensions simultaneously so instead of doing:

```python
shift = tf.random.uniform(shape=[2], minval=-maxroll, maxval=maxroll, dtype=tf.int32)
shift_down, shift_right = shift[0],shift[1] 
img_rolled = tf.roll(tf.roll(img, shift_right, axis=1), shift_down, axis=0)
```

Why not do the equivalent in one `tf.roll` operation:

```python
shift = tf.random.uniform(shape=[2], minval=-maxroll, maxval=maxroll, dtype=tf.int32)
img_rolled = tf.roll(img, shift=shift, axis=[0,1])
```

That way we can showcase how to use `tf.roll` in a better way.