### PR TITLE
Fix to follow google style for time-series.ipynb

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -449,7 +449,7 @@
         "id": "HiurzTGQgf_D"
       },
       "source": [
-        "This gives the model access to the most important frequency features. In this case we knew ahead of time which frequencies were important. \n",
+        "This gives the model access to the most important frequency features. In this case you knew ahead of time which frequencies were important. \n",
         "\n",
         "If you didn't know, you can determine which frequencies are important using an `fft`. To check our assumptions, here is the `tf.signal.rfft` of the temperature over time. Note the obvious peaks at frequencies near `1/year` and `1/day`: "
       ]
@@ -536,7 +536,7 @@
       "source": [
         "The mean and standard deviation should only be computed using the training data so that the models have no access to the values in the validation and test sets.\n",
         "\n",
-        "It's also arguable that the model shouldn't have access to future values in the training set when training, and that this normalization should be done using moving averages. That's not the focus of this tutorial, and the validation and test sets ensure that we get (somewhat) honest metrics. So in the interest of simplicity this tutorial uses a simple average."
+        "It's also arguable that the model shouldn't have access to future values in the training set when training, and that this normalization should be done using moving averages. That's not the focus of this tutorial, and the validation and test sets ensure that you get (somewhat) honest metrics. So in the interest of simplicity this tutorial uses a simple average."
       ]
     },
     {


### PR DESCRIPTION
There was some line that doesn't follow the lint style before.
So, the CI pipeline failed if pr changes time-series.ipynb even if such pr follows lint style.

After this pr accepted, some pr should fetch origin and re-test CI pipeline: #1697, #1694, #1688, ...