### PR TITLE
drop_remainder = True at tf.dataset.batch

### DIFF
--- a/site/en/guide/tpu.ipynb
+++ b/site/en/guide/tpu.ipynb
@@ -293,7 +293,7 @@
         "    dataset = dataset.shuffle(10000)\n",
         "    dataset = dataset.repeat()\n",
         "\n",
-        "  dataset = dataset.batch(batch_size)\n",
+        "  dataset = dataset.batch(batch_size, drop_remainder = True)\n",
         "\n",
         "  return dataset"
       ]


### PR DESCRIPTION
drop_remainder = True at tf.dataset.batch is necessary in TPU as it requires fixed dims, otherwise it may cause some op failed to compile such as dilation conv