### PR TITLE
Update TensorFlow Java installation instructions

### DIFF
--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -32,22 +32,22 @@ and their mapping with the TensorFlow runtime.
 ## Artifacts
 
 There are [several ways](https://github.com/tensorflow/java/#using-maven-artifacts) to add TensorFlow Java to your project. 
-The easiest one is to add a dependency to the `tensorflow-core-platform` artifact, which not only include the
-TensorFlow Java Core API but also the native depencendies it requires to run on all supported platforms.
+The easiest one is to add a dependency on the `tensorflow-core-platform` artifact, which includes both the TensorFlow Java 
+Core API and the native dependencies it requires to run on all supported platforms.
 
-You can also select one of the following extension instead of the pure CPU version:
+You can also select one of the following extensions instead of the pure CPU version:
 
 * `tensorflow-core-platform-mkl`: Support for Intel® MKL-DNN on all platforms
 * `tensorflow-core-platform-gpu`: Support for CUDA® on Linux and Windows platforms
 * `tensorflow-core-platform-mkl-gpu`: Support for Intel® MKL-DNN and CUDA® on Linux and Windows platforms.
 
-In addition, a separate dependency to the `tensorflow-framework` library can be added to benefit from a rich set of 
+In addition, a separate dependency on the `tensorflow-framework` library can be added to benefit from a rich set of 
 utilities for TensorFlow-based machine learning on the JVM. 
 
 
 ## Installing with Maven
 
-To include TensorFlow in your [Maven](http://maven.apache.org) application, add a dependency to its [artifacts](#artifacts)
+To include TensorFlow in your [Maven](http://maven.apache.org) application, add a dependency on its [artifacts](#artifacts)
 to your project's `pom.xml` file. For example,
 
 ```xml
@@ -60,7 +60,7 @@ to your project's `pom.xml` file. For example,
 
 ### Reducing Number of Dependencies
 
-It is important to note that adding a dependency to a `tensorflow-core-platform` artifact will import native 
+It is important to note that adding a dependency on a `tensorflow-core-platform` artifact will import native 
 libraries for all supported platforms, which can significantly increase the size of your project.
 
 If you wish to target a subset of the available platforms then you can exclude the unnecessary artifacts from 
@@ -99,7 +99,7 @@ the OSS snapshots repository in your `pom.xml`.
 
 ## Installing with Gradle
 
-To include TensorFlow in your [Gradle](https://gradle.org) application, add a dependency to its [artifacts](#artifacts)
+To include TensorFlow in your [Gradle](https://gradle.org) application, add a dependency on its [artifacts](#artifacts)
 to your project's `build.gradle` file. For example,
 
 ```groovy

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -116,8 +116,9 @@ Please read the [Maven](#installing-with-maven) section for more details on the 
 ### Reducing Number of Dependencies
 
 Excluding native artifacts from TensorFlow Java with Gradle is not as easy as with Maven. We recommend that you use 
-Gradle JavaCPP plugins to reduce this number of dependencies. Please read at Gradle JavaCPP 
-[documentation](https://github.com/bytedeco/gradle-javacpp) for more details.
+Gradle JavaCPP plugins to reduce this number of dependencies. 
+
+Please read at Gradle JavaCPP [documentation](https://github.com/bytedeco/gradle-javacpp) for more details.
 
 
 ## Installing from Sources

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -1,60 +1,58 @@
-# Install TensorFlow for Java
+# Install TensorFlow Java
 
-TensorFlow provides a
-[Java API](https://www.tensorflow.org/api_docs/java/reference/org/tensorflow/package-summary)—
-particularly useful for loading models created with Python and running them
-within a Java application.
+[TensorFlow Java](https://github.com/tensorflow/java) can run on any JVM for building, training and 
+running machine learning models. It comes with a series of utilities and frameworks that help achieve 
+most of the tasks common to data scientists and developers working in this domain. Java and other JVM 
+languages, such as Scala or Kotlin, are frequently used in small-to-large enterprises all over the world, 
+which makes TensorFlow a strategic choice for adopting machine learning at a large scale.
 
 Caution: The TensorFlow Java API is *not* covered by the TensorFlow
 [API stability guarantees](../guide/versions.md).
 
-## Nightly Libtensorflow Java packages
-
-Libtensorflow JNI packages are built nightly and uploaded to GCS for all
-supported platforms. They are uploaded to the
-[libtensorflow-nightly GCS bucket](https://storage.googleapis.com/libtensorflow-nightly)
-and are indexed by operating system and date built.
-
 ## Supported Platforms
 
-TensorFlow for Java is supported on the following systems:
+TensorFlow Java is supported on the following systems:
 
 * Ubuntu 16.04 or higher; 64-bit, x86
 * macOS 10.12.6 (Sierra) or higher
 * Windows 7 or higher; 64-bit, x86
 
-To use TensorFlow on Android see [TensorFlow Lite](https://tensorflow.org/lite)
+*Note: To use TensorFlow on Android, see [TensorFlow Lite](https://tensorflow.org/lite)*
 
-## TensorFlow with Apache Maven
+## Using Apache Maven
 
-To use TensorFlow with [Apache Maven](https://maven.apache.org){:.external},
-add the dependency to the project's `pom.xml` file:
-
+To include TensorFlow in your [Maven](http://maven.apache.org) application, you first need to add in
+your project's `pom.xml` file a dependency on a `tensorflow-core-platform` artifact.
 ```xml
 <dependency>
   <groupId>org.tensorflow</groupId>
-  <artifactId>tensorflow</artifactId>
-  <version>2.3.0</version>
+  <artifactId>tensorflow-core-platform${extension}</artifactId>
+  <version>0.2.0</version>
 </dependency>
 ```
+You can leave the `extension` variable empty to use a vanilla version of TensorFlow or set it to one
+of the supported variant:
+* `-mkl`: Support for Intel® MKL-DNN on all platforms
+* `-gpu`: Support for CUDA® on Linux and Windows platforms
+* `-mkl-gpu`: Support for Intel® MKL-DNN and CUDA® on Linux and Windows platforms.
 
-### GPU support
-
-If your system has [GPU support](./gpu.md), add the following TensorFlow
-dependencies to the project's `pom.xml` file:
-
+Optionally, you can also add a dependency to the `tensorflow-framework` library, which provides a rich
+set of high-level utilities to improve the developer experience with machine learning on the JVM.
 ```xml
 <dependency>
   <groupId>org.tensorflow</groupId>
-  <artifactId>libtensorflow</artifactId>
-  <version>2.3.0</version>
-</dependency>
-<dependency>
-  <groupId>org.tensorflow</groupId>
-  <artifactId>libtensorflow_jni_gpu</artifactId>
-  <version>2.3.0</version>
+  <artifactId>tensorflow-framework</artifactId>
+  <version>0.2.0</version>
 </dependency>
 ```
+
+### Reducing Dependencies
+
+It is important to note that adding a dependency to a `tensorflow-core-platform` artifact will import native 
+libraries for all supported platforms, which can increase significantly the size of your project.
+
+When it is already known that your project will only run on a subset of the supported platforms, it is possible
+to exclude the artifacts of other platforms using the [Maven Dependency Exclusion](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html#dependency-exclusions) feature.
 
 ### Example program
 
@@ -63,55 +61,53 @@ add the TensorFlow dependency to the project's `pom.xml` file:
 
 ```xml
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.myorg</groupId>
-  <artifactId>hellotensorflow</artifactId>
-  <version>1.0-SNAPSHOT</version>
-  <properties>
-    <exec.mainClass>HelloTensorFlow</exec.mainClass>
-	<!-- The sample code requires at least JDK 1.7. -->
-	<!-- The maven compiler plugin defaults to a lower version -->
-	<maven.compiler.source>1.7</maven.compiler.source>
-	<maven.compiler.target>1.7</maven.compiler.target>
-  </properties>
-  <dependencies>
-    <dependency>
-	  <groupId>org.tensorflow</groupId>
-	  <artifactId>tensorflow</artifactId>
-	  <version>1.14.0</version>
-	</dependency>
-  </dependencies>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.myorg</groupId>
+    <artifactId>hellotensorflow</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+	<!-- Minimal version for compiling with TensorFlow Java is JDK 8 -->
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.tensorflow</groupId>
+            <artifactId>tensorflow-core-platform</artifactId>
+            <version>0.2.0</version>
+        </dependency>
+    </dependencies>
 </project>
 ```
 
 Create the source file (`src/main/java/HelloTensorFlow.java`):
 
 ```java
-import org.tensorflow.Graph;
-import org.tensorflow.Session;
+import org.tensorflow.ConcreteFunction;
+import org.tensorflow.Signature;
 import org.tensorflow.Tensor;
 import org.tensorflow.TensorFlow;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.core.Placeholder;
+import org.tensorflow.op.math.Add;
+import org.tensorflow.types.TInt32;
 
 public class HelloTensorFlow {
+
   public static void main(String[] args) throws Exception {
-	try (Graph g = new Graph()) {
-	  final String value = "Hello from " + TensorFlow.version();
+    System.out.println("Running on TensorFlow " + TensorFlow.version());
 
-	  // Construct the computation graph with a single operation, a constant
-	  // named "MyConst" with a value "value".
-	  try (Tensor t = Tensor.create(value.getBytes("UTF-8"))) {
-	    // The Java API doesn't yet include convenience functions for adding operations.
-		g.opBuilder("Const", "MyConst").setAttr("dtype", t.dataType()).setAttr("value", t).build();
-	  }
-
-	  // Execute the "MyConst" operation in a Session.
-	  try (Session s = new Session(g);
-	      // Generally, there may be multiple output tensors,
-		  // all of them must be closed to prevent resource leaks.
-		  Tensor output = s.runner().fetch("MyConst").run().get(0)) {
-	    System.out.println(new String(output.bytesValue(), "UTF-8"));
-	  }
+    try (ConcreteFunction dbl = ConcreteFunction.create(HelloTensorFlow::dbl);
+        Tensor<TInt32> x = TInt32.scalarOf(10);
+        Tensor<TInt32> dblX = dbl.call(x).expect(TInt32.DTYPE)) {
+      System.out.println("Double of " + x.data().getInt() + " is " + dblX.data().getInt());
     }
+  }
+
+  private static Signature dbl(Ops tf) {
+    Placeholder<TInt32> x = tf.placeholder(TInt32.DTYPE);
+    Add<TInt32> dblX = tf.math.add(x, x);
+    return Signature.builder().input("x", x).output("dbl", dblX).build();
   }
 }
 ```
@@ -122,9 +118,13 @@ Compile and execute:
 mvn -q compile exec:java  # Use -q to hide logging
 </pre>
 
-The command outputs: <code>Hello from <em>version</em></code>
+The command outputs: 
+```
+Running on TensorFlow 2.3.1
+Double of 10 is 20
+```
 
-Success: TensorFlow for Java is configured.
+Success: TensorFlow Java is configured.
 
 
 ## TensorFlow with the JDK

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -1,13 +1,14 @@
 # Install TensorFlow Java
 
 [TensorFlow Java](https://github.com/tensorflow/java) can run on any JVM for building, training and 
-running machine learning models. It comes with a series of utilities and frameworks that help achieve 
+running machine learning models. It comes with a series of utilities and a framework that help achieve 
 most of the tasks common to data scientists and developers working in this domain. Java and other JVM 
 languages, such as Scala or Kotlin, are frequently used in small-to-large enterprises all over the world, 
 which makes TensorFlow a strategic choice for adopting machine learning at a large scale.
 
 Caution: The TensorFlow Java API is *not* covered by the TensorFlow
 [API stability guarantees](../guide/versions.md).
+
 
 ## Requirements
 
@@ -19,10 +20,20 @@ TensorFlow Java runs on Java 8 and above, and supports out-of-the-box the follow
 
 *Note: To use TensorFlow on Android, see [TensorFlow Lite](https://tensorflow.org/lite)*
 
+
+## Versions
+
+TensorFlow Java has its own release cycle, independent from the [TensorFlow runtime](https://github.com/tensorflow/tensorflow).
+In consequence, its version does not match the version of TensorFlow runtime it runs on. Consult the TensorFlow Java 
+[versioning table](https://github.com/tensorflow/java/#tensorflow-version-support) to list all versions available 
+and their mapping with the TensorFlow runtime.
+
+
 ## Installing with Maven
 
 To include TensorFlow in your [Maven](http://maven.apache.org) application, you first need to add in
-your project's `pom.xml` file a dependency on a `tensorflow-core-platform` artifact.
+your project's `pom.xml` file a dependency on one of the `tensorflow-core-platform` artifact.
+
 ```xml
 <dependency>
   <groupId>org.tensorflow</groupId>
@@ -30,6 +41,7 @@ your project's `pom.xml` file a dependency on a `tensorflow-core-platform` artif
   <version>0.2.0</version>
 </dependency>
 ```
+
 You can leave the `extension` variable empty to use a vanilla version of TensorFlow or set it to one
 of the supported variant:
 * `-mkl`: Support for Intel® MKL-DNN on all platforms
@@ -38,6 +50,7 @@ of the supported variant:
 
 Optionally, you can also add a dependency to the `tensorflow-framework` library, which provides a rich
 set of high-level utilities to improve the developer experience with machine learning on the JVM.
+
 ```xml
 <dependency>
   <groupId>org.tensorflow</groupId>
@@ -51,20 +64,20 @@ set of high-level utilities to improve the developer experience with machine lea
 It is important to note that adding a dependency to a `tensorflow-core-platform` artifact will import native 
 libraries for all supported platforms, which can increase significantly the size of your project.
 
-When it is already known that your project will only run on a subset of the supported platforms, it is possible
-to exclude the artifacts of other platforms using the [Maven Dependency Exclusion](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html#dependency-exclusions) feature.
+When it has already been established that your project will only run on a subset of these platforms, it is possible
+to exclude the artifacts of the other platforms using the 
+[Maven Dependency Exclusion](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html#dependency-exclusions) 
+feature.
 
-Another way to specify which platform you want to include is to use JavaCPP platforms properties directly
-in your Maven command line. Please see JavaCPP [documentation](https://github.com/bytedeco/javacpp-presets/wiki/Reducing-the-Number-of-Dependencies)
-for more details.
-
+Another way to select which platforms you want to include in your application is to set JavaCPP system properties,
+in your Maven command line or in your `pom.xml`. Please see JavaCPP 
+[documentation](https://github.com/bytedeco/javacpp-presets/wiki/Reducing-the-Number-of-Dependencies) for more details.
 
 ### Using Snapshots
 
-TensorFlow Java is also available as snapshots, which reflects that latest changes of the 
-[TensorFlow Java Repository](https://github.com/tensorflow/java). To depend on these artifacts, 
-you need to make sure that [OSS Sonatype](https://oss.sonatype.org/) Snapshots repository is 
-configured in your `pom.xml` as well:
+TensorFlow Java snapshots that reflect that latest version of the source code
+in [TensorFlow Java Repository](https://github.com/tensorflow/java) are available on [OSS Sonatype](https://oss.sonatype.org). 
+To depend on these artifacts, make sure to configure the OSS snapshots repository in your `pom.xml`.
 
 ```xml
 <repositories>
@@ -103,15 +116,18 @@ Please read the [Maven](#installing-with-maven) section for more details on the 
 ### Reducing Number of Dependencies
 
 Excluding native artifacts from TensorFlow Java with Gradle is not as easy as with Maven. We recommend that you use 
-Gradle JavaCPP plugins to reduce the number of dependencies. Please read at Gradle JavaCPP 
+Gradle JavaCPP plugins to reduce this number of dependencies. Please read at Gradle JavaCPP 
 [documentation](https://github.com/bytedeco/gradle-javacpp) for more details.
+
 
 ## Installing from Sources
 
-To build TensorFlow Java from sources and possibly customize it, please read the following 
+To build TensorFlow Java from sources, and possibly customize it, please read the following 
 [instructions](https://github.com/tensorflow/java/blob/master/README.md#building-sources). 
 
-Please also note that only official builds distributed by TensorFlow are supported by its maintainers and custom builds should be used at the user's risk.
+Note that only official builds distributed by TensorFlow are supported by its maintainers and custom builds 
+should be used at the user's risk.
+
 
 # Example Program
 
@@ -124,12 +140,15 @@ add the TensorFlow dependency to the project's `pom.xml` file:
     <groupId>org.myorg</groupId>
     <artifactId>hellotensorflow</artifactId>
     <version>1.0-SNAPSHOT</version>
+	
     <properties>
 	<!-- Minimal version for compiling TensorFlow Java is JDK 8 -->
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+	
     <dependencies>
+	<!-- Includes vanilla TensorFlow for all platforms -->
         <dependency>
             <groupId>org.tensorflow</groupId>
             <artifactId>tensorflow-core-platform</artifactId>

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -86,7 +86,7 @@ configured in your `pom.xml` as well:
 
 To build TensorFlow Java from sources and possibly customize it, please read the following [instructions](https://github.com/tensorflow/java/blob/master/README.md#building-sources). 
 
-Please also note that custom builds are not supported by TensorFlow Java maintainers.
+Please also note that only official builds distributed by TensorFlow are supported by its maintainers and custom builds should be used at the user's risk.
 
 ## Example Program
 

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -3,8 +3,8 @@
 [TensorFlow Java](https://github.com/tensorflow/java) can run on any JVM for building, training and 
 deploying machine learning models. It supports both CPU and GPU execution, in graph or eager mode, and
 presents a rich API for using TensorFlow in a JVM environment. Java and other JVM languages, like Scala
-and Kotlin, are frequently used in small-to-large enterprises all over the world, which makes TensorFlow 
-a strategic choice for adopting machine learning at a large scale.
+and Kotlin, are frequently used in large and small enterprises all over the world, which makes TensorFlow 
+Java a strategic choice for adopting machine learning at a large scale.
 
 Caution: The TensorFlow Java API is *not* covered by the TensorFlow
 [API stability guarantees](../guide/versions.md).
@@ -24,7 +24,7 @@ TensorFlow Java runs on Java 8 and above, and supports out-of-the-box the follow
 ## Versions
 
 TensorFlow Java has its own release cycle, independent from the [TensorFlow runtime](https://github.com/tensorflow/tensorflow).
-In consequence, its version does not match the version of TensorFlow runtime it runs on. Consult the TensorFlow Java 
+Consequently, its version does not match the version of TensorFlow runtime it runs on. Consult the TensorFlow Java 
 [versioning table](https://github.com/tensorflow/java/#tensorflow-version-support) to list all versions available 
 and their mapping with the TensorFlow runtime.
 
@@ -42,13 +42,13 @@ your project's `pom.xml` file a dependency on one of the `tensorflow-core-platfo
 </dependency>
 ```
 
-You can leave the `extension` variable empty to use a vanilla version of TensorFlow or set it to one
+You can leave the `extension` variable empty to use a pure CPU version of TensorFlow or set it to one
 of the supported variant:
 * `-mkl`: Support for Intel® MKL-DNN on all platforms
 * `-gpu`: Support for CUDA® on Linux and Windows platforms
 * `-mkl-gpu`: Support for Intel® MKL-DNN and CUDA® on Linux and Windows platforms.
 
-Optionally, you can also add a dependency to the `tensorflow-framework` library, which provides a rich
+Optionally, you can also add a dependency on the `tensorflow-framework` library, which provides a rich
 set of high-level utilities to improve the developer experience with with TensorFlow-based machine learning
 on the JVM.
 
@@ -63,12 +63,10 @@ on the JVM.
 ### Reducing Number of Dependencies
 
 It is important to note that adding a dependency to a `tensorflow-core-platform` artifact will import native 
-libraries for all supported platforms, which can increase significantly the size of your project.
+libraries for all supported platforms, which can significantly increase the size of your project.
 
-When it has already been established that your project will only run on a subset of these platforms, it is possible
-to exclude the artifacts of the other platforms using the 
-[Maven Dependency Exclusion](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html#dependency-exclusions) 
-feature.
+If you wish to target a subset of the available platforms then you can exclude the unnecessary artifacts from 
+the other platforms using the [Maven Dependency Exclusion](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html#dependency-exclusions) feature.
 
 Another way to select which platforms you want to include in your application is to set JavaCPP system properties,
 in your Maven command line or in your `pom.xml`. Please see JavaCPP 
@@ -76,9 +74,9 @@ in your Maven command line or in your `pom.xml`. Please see JavaCPP
 
 ### Using Snapshots
 
-TensorFlow Java snapshots that reflect that latest version of the source code
-in [TensorFlow Java Repository](https://github.com/tensorflow/java) are available on [OSS Sonatype](https://oss.sonatype.org). 
-To depend on these artifacts, make sure to configure the OSS snapshots repository in your `pom.xml`.
+The latest TensorFlow Java development snapshots from the TensorFlow Java source repository are available on the 
+[OSS Sonatype](https://oss.sonatype.org) Nexus repository. To depend on these artifacts, make sure to configure 
+the OSS snapshots repository in your `pom.xml`.
 
 ```xml
 <repositories>
@@ -102,7 +100,7 @@ To depend on these artifacts, make sure to configure the OSS snapshots repositor
 
 ## Installing with Gradle
 
-Same dependencies as with Maven can be added to your Gradle project to run TensorFlow. 
+To use TensorFlow Java with Gradle you can include the following snippet in your `build.gradle`:
 ```groovy
 repositories {
     mavenCentral()
@@ -150,7 +148,7 @@ add the TensorFlow dependency to the project's `pom.xml` file:
     </properties>
 	
     <dependencies>
-	<!-- Includes vanilla TensorFlow for all platforms -->
+	<!-- Includes pure CPU TensorFlow for all platforms -->
         <dependency>
             <groupId>org.tensorflow</groupId>
             <artifactId>tensorflow-core-platform</artifactId>
@@ -166,6 +164,7 @@ Create the source file `src/main/java/HelloTensorFlow.java`:
 import org.tensorflow.ConcreteFunction;
 import org.tensorflow.Signature;
 import org.tensorflow.Tensor;
+import org.tensorflow.TensorFlow;
 import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Placeholder;
 import org.tensorflow.op.math.Add;
@@ -174,10 +173,12 @@ import org.tensorflow.types.TInt32;
 public class HelloTensorFlow {
 
   public static void main(String[] args) throws Exception {
+    System.out.println("Hello TensorFlow " + TensorFlow.version());
+
     try (ConcreteFunction dbl = ConcreteFunction.create(HelloTensorFlow::dbl);
         Tensor<TInt32> x = TInt32.scalarOf(10);
         Tensor<TInt32> dblX = dbl.call(x).expect(TInt32.DTYPE)) {
-      System.out.println("Double of " + x.data().getInt() + " is " + dblX.data().getInt());
+      System.out.println(x.data().getInt() + " doubled is " + dblX.data().getInt());
     }
   }
 
@@ -197,7 +198,8 @@ mvn -q compile exec:java
 
 The command outputs: 
 ```
-Double of 10 is 20
+Hello TensorFlow 2.3.1
+10 doubled is 20
 ```
 
 Success! TensorFlow Java is configured.

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -1,10 +1,10 @@
 # Install TensorFlow Java
 
 [TensorFlow Java](https://github.com/tensorflow/java) can run on any JVM for building, training and 
-running machine learning models. It comes with a series of utilities and a framework that help achieve 
-most of the tasks common to data scientists and developers working in this domain. Java and other JVM 
-languages, such as Scala or Kotlin, are frequently used in small-to-large enterprises all over the world, 
-which makes TensorFlow a strategic choice for adopting machine learning at a large scale.
+deploying machine learning models. It supports both CPU and GPU execution, in graph or eager mode, and
+presents a rich API for using TensorFlow in a JVM environment. Java and other JVM languages, like Scala
+and Kotlin, are frequently used in small-to-large enterprises all over the world, which makes TensorFlow 
+a strategic choice for adopting machine learning at a large scale.
 
 Caution: The TensorFlow Java API is *not* covered by the TensorFlow
 [API stability guarantees](../guide/versions.md).
@@ -49,7 +49,8 @@ of the supported variant:
 * `-mkl-gpu`: Support for Intel® MKL-DNN and CUDA® on Linux and Windows platforms.
 
 Optionally, you can also add a dependency to the `tensorflow-framework` library, which provides a rich
-set of high-level utilities to improve the developer experience with machine learning on the JVM.
+set of high-level utilities to improve the developer experience with with TensorFlow-based machine learning
+on the JVM.
 
 ```xml
 <dependency>

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -29,33 +29,31 @@ Consequently, its version does not match the version of TensorFlow runtime it ru
 and their mapping with the TensorFlow runtime.
 
 
-## Installing with Maven
+## Artifacts
 
-To include TensorFlow in your [Maven](http://maven.apache.org) application, add the following dependency
-to your project's `pom.xml` file:
+There are [several ways](https://github.com/tensorflow/java/#using-maven-artifacts) to add TensorFlow Java to your project. 
+The easiest one is to add a dependency to the `tensorflow-core-platform` artifact, which not only include the
+TensorFlow Java Core API but also the native depencendies it requires to run on all supported platforms.
 
-```xml
-<dependency>
-  <groupId>org.tensorflow</groupId>
-  <artifactId>tensorflow-core-platform</artifactId>
-  <version>0.2.0</version>
-</dependency>
-```
-
-or alternatively select one of the supported variant:
+You can also select one of the following extension instead of the pure CPU version:
 
 * `tensorflow-core-platform-mkl`: Support for Intel® MKL-DNN on all platforms
 * `tensorflow-core-platform-gpu`: Support for CUDA® on Linux and Windows platforms
 * `tensorflow-core-platform-mkl-gpu`: Support for Intel® MKL-DNN and CUDA® on Linux and Windows platforms.
 
-In addition, you can include a dependency to the `tensorflow-framework` library, which provides a rich
-set of high-level utilities to improve the developer experience with with TensorFlow-based machine learning
-on the JVM.
+In addition, a separate dependency to the `tensorflow-framework` library can be added to benefit from a rich set of 
+utilities for TensorFlow-based machine learning on the JVM. 
+
+
+## Installing with Maven
+
+To include TensorFlow in your [Maven](http://maven.apache.org) application, add a dependency to its [artifacts](#artifacts)
+to your project's `pom.xml` file. For example,
 
 ```xml
 <dependency>
   <groupId>org.tensorflow</groupId>
-  <artifactId>tensorflow-framework</artifactId>
+  <artifactId>tensorflow-core-platform</artifactId>
   <version>0.2.0</version>
 </dependency>
 ```
@@ -98,9 +96,12 @@ the OSS snapshots repository in your `pom.xml`.
 </dependencies>
 ```
 
+
 ## Installing with Gradle
 
-To use TensorFlow Java with Gradle you can include the following snippet in your `build.gradle`:
+To include TensorFlow in your [Gradle](https://gradle.org) application, add a dependency to its [artifacts](#artifacts)
+to your project's `build.gradle` file. For example,
+
 ```groovy
 repositories {
     mavenCentral()
@@ -110,7 +111,6 @@ dependencies {
     compile group: 'org.tensorflow', name: 'tensorflow-core-platform', version: '0.2.0'
 }
 ```
-Please read the [Maven](#installing-with-maven) section for more details on the different artifacts that can be included.
 
 ### Reducing Number of Dependencies
 

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -19,7 +19,7 @@ TensorFlow Java is supported on the following systems:
 
 *Note: To use TensorFlow on Android, see [TensorFlow Lite](https://tensorflow.org/lite)*
 
-## Using Apache Maven
+## Maven Dependencies
 
 To include TensorFlow in your [Maven](http://maven.apache.org) application, you first need to add in
 your project's `pom.xml` file a dependency on a `tensorflow-core-platform` artifact.
@@ -46,7 +46,7 @@ set of high-level utilities to improve the developer experience with machine lea
 </dependency>
 ```
 
-### Reducing Dependencies
+### Reducing Number of Dependencies
 
 It is important to note that adding a dependency to a `tensorflow-core-platform` artifact will import native 
 libraries for all supported platforms, which can increase significantly the size of your project.
@@ -54,7 +54,39 @@ libraries for all supported platforms, which can increase significantly the size
 When it is already known that your project will only run on a subset of the supported platforms, it is possible
 to exclude the artifacts of other platforms using the [Maven Dependency Exclusion](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html#dependency-exclusions) feature.
 
-## Example program
+
+### Using Snapshots
+
+TensorFlow Java is also available as snapshots, which reflects that latest changes of the 
+[TensorFlow Java Repository](https://github.com/tensorflow/java). To depend on these artifacts, 
+you need to make sure that [OSS Sonatype](https://oss.sonatype.org/) Snapshots repository is 
+configured in your `pom.xml` as well:
+
+```xml
+<repositories>
+    <repository>
+        <id>tensorflow-snapshots</id>
+        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+</repositories>
+
+<dependencies>
+    <dependency>
+        <groupId>org.tensorflow</groupId>
+        <artifactId>tensorflow-core-platform</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+    </dependency>
+</dependencies>
+```
+
+## Building from Source
+
+To build TensorFlow Java from source and possibly customize it, please read the following [instructions](https://github.com/tensorflow/java/blob/master/README.md#building-sources).
+
+## Example Program
 
 This example shows how to build an Apache Maven project with TensorFlow. First,
 add the TensorFlow dependency to the project's `pom.xml` file:
@@ -125,10 +157,3 @@ Double of 10 is 20
 ```
 
 Success: TensorFlow Java is configured.
-
-
-## Build from source
-
-TensorFlow is open source. Read
-[the instructions](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/java/README.md){:.external}
-to build TensorFlow's Java and native libraries from source code.

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -19,7 +19,7 @@ TensorFlow Java runs on Java 8 and above, and supports out-of-the-box the follow
 
 *Note: To use TensorFlow on Android, see [TensorFlow Lite](https://tensorflow.org/lite)*
 
-## Maven Dependencies
+## Installing with Maven
 
 To include TensorFlow in your [Maven](http://maven.apache.org) application, you first need to add in
 your project's `pom.xml` file a dependency on a `tensorflow-core-platform` artifact.
@@ -46,13 +46,17 @@ set of high-level utilities to improve the developer experience with machine lea
 </dependency>
 ```
 
-### Reducing Number of Dependencies
+### Reducing Number of Dependencies with Maven
 
 It is important to note that adding a dependency to a `tensorflow-core-platform` artifact will import native 
 libraries for all supported platforms, which can increase significantly the size of your project.
 
 When it is already known that your project will only run on a subset of the supported platforms, it is possible
 to exclude the artifacts of other platforms using the [Maven Dependency Exclusion](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html#dependency-exclusions) feature.
+
+Another way to specify which platform you want to include is to use JavaCPP platforms properties directly
+in your Maven command line. Please see JavaCPP [documentation](https://github.com/bytedeco/javacpp-presets/wiki/Reducing-the-Number-of-Dependencies)
+for more details.
 
 
 ### Using Snapshots
@@ -82,13 +86,34 @@ configured in your `pom.xml` as well:
 </dependencies>
 ```
 
-## Building from Source
+## Installing with Gradle
 
-To build TensorFlow Java from sources and possibly customize it, please read the following [instructions](https://github.com/tensorflow/java/blob/master/README.md#building-sources). 
+Same dependencies as with Maven can be added to your Gradle project to run TensorFlow. 
+```groovy
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile group: 'org.tensorflow', name: 'tensorflow-core-platform', version: '0.2.0'
+}
+```
+Please read the [Maven](#installing-with-maven) section for more details on the different artifacts that can be included.
+
+### Reducing Number of Dependencies
+
+Excluding native artifacts from TensorFlow Java with Gradle is not as easy as with Maven. We recommend that you use 
+Gradle JavaCPP plugins to reduce the number of dependencies. Please read at Gradle JavaCPP 
+[documentation](https://github.com/bytedeco/gradle-javacpp) for more details.
+
+## Installing from Sources
+
+To build TensorFlow Java from sources and possibly customize it, please read the following 
+[instructions](https://github.com/tensorflow/java/blob/master/README.md#building-sources). 
 
 Please also note that only official builds distributed by TensorFlow are supported by its maintainers and custom builds should be used at the user's risk.
 
-## Example Program
+# Example Program
 
 This example shows how to build an Apache Maven project with TensorFlow. First,
 add the TensorFlow dependency to the project's `pom.xml` file:

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -11,7 +11,7 @@ Caution: The TensorFlow Java API is *not* covered by the TensorFlow
 
 ## Requirements
 
-TensorFlow Java runs on Java 8 and above, and is supported on the following platforms:
+TensorFlow Java runs on Java 8 and above, and supports out-of-the-box the following platforms:
 
 * Ubuntu 16.04 or higher; 64-bit, x86
 * macOS 10.12.6 (Sierra) or higher; 64-bit, x86
@@ -84,7 +84,9 @@ configured in your `pom.xml` as well:
 
 ## Building from Source
 
-To build TensorFlow Java from source and possibly customize it, please read the following [instructions](https://github.com/tensorflow/java/blob/master/README.md#building-sources).
+To build TensorFlow Java from sources and possibly customize it, please read the following [instructions](https://github.com/tensorflow/java/blob/master/README.md#building-sources). 
+
+Please also note that custom builds are not supported by TensorFlow Java maintainers.
 
 ## Example Program
 

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -166,7 +166,6 @@ Create the source file `src/main/java/HelloTensorFlow.java`:
 import org.tensorflow.ConcreteFunction;
 import org.tensorflow.Signature;
 import org.tensorflow.Tensor;
-import org.tensorflow.TensorFlow;
 import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Placeholder;
 import org.tensorflow.op.math.Add;
@@ -175,8 +174,6 @@ import org.tensorflow.types.TInt32;
 public class HelloTensorFlow {
 
   public static void main(String[] args) throws Exception {
-    System.out.println("Running on TensorFlow " + TensorFlow.version());
-
     try (ConcreteFunction dbl = ConcreteFunction.create(HelloTensorFlow::dbl);
         Tensor<TInt32> x = TInt32.scalarOf(10);
         Tensor<TInt32> dblX = dbl.call(x).expect(TInt32.DTYPE)) {
@@ -200,7 +197,6 @@ mvn -q compile exec:java
 
 The command outputs: 
 ```
-Running on TensorFlow 2.3.1
 Double of 10 is 20
 ```
 

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -9,12 +9,12 @@ which makes TensorFlow a strategic choice for adopting machine learning at a lar
 Caution: The TensorFlow Java API is *not* covered by the TensorFlow
 [API stability guarantees](../guide/versions.md).
 
-## Supported Platforms
+## Requirements
 
-TensorFlow Java is supported on the following systems:
+TensorFlow Java runs on JRE 8 and above, and is supported on the following platforms:
 
 * Ubuntu 16.04 or higher; 64-bit, x86
-* macOS 10.12.6 (Sierra) or higher
+* macOS 10.12.6 (Sierra) or higher; 64-bit, x86
 * Windows 7 or higher; 64-bit, x86
 
 *Note: To use TensorFlow on Android, see [TensorFlow Lite](https://tensorflow.org/lite)*

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -42,13 +42,13 @@ to your project's `pom.xml` file:
 </dependency>
 ```
 
-or select one of the supported variant of TensorFlow instead of the pure CPU version:
+or alternatively, select one of the supported variant:
 
 * `tensorflow-core-platform-mkl`: Support for Intel® MKL-DNN on all platforms
 * `tensorflow-core-platform-gpu`: Support for CUDA® on Linux and Windows platforms
 * `tensorflow-core-platform-mkl-gpu`: Support for Intel® MKL-DNN and CUDA® on Linux and Windows platforms.
 
-In addition, you can add a dependency to the `tensorflow-framework` library, which provides a rich
+You can also include a dependency to the `tensorflow-framework` library, which provides a rich
 set of high-level utilities to improve the developer experience with with TensorFlow-based machine learning
 on the JVM.
 

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -126,8 +126,8 @@ Please read at Gradle JavaCPP [documentation](https://github.com/bytedeco/gradle
 To build TensorFlow Java from sources, and possibly customize it, please read the following 
 [instructions](https://github.com/tensorflow/java/blob/master/README.md#building-sources). 
 
-Note that only official builds distributed by TensorFlow are supported by its maintainers and custom builds 
-should be used at the user's risk.
+*Note: Only official builds distributed by TensorFlow are supported by its maintainers and custom builds 
+should be used at the user's risk.*
 
 
 # Example Program

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -94,7 +94,7 @@ add the TensorFlow dependency to the project's `pom.xml` file:
     <artifactId>hellotensorflow</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-	<!-- Minimal version for compiling with TensorFlow Java is JDK 8 -->
+	<!-- Minimal version for compiling TensorFlow Java is JDK 8 -->
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
@@ -108,7 +108,7 @@ add the TensorFlow dependency to the project's `pom.xml` file:
 </project>
 ```
 
-Create the source file (`src/main/java/HelloTensorFlow.java`):
+Create the source file `src/main/java/HelloTensorFlow.java`:
 
 ```java
 import org.tensorflow.ConcreteFunction;

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -142,7 +142,8 @@ add the TensorFlow dependency to the project's `pom.xml` file:
     <version>1.0-SNAPSHOT</version>
 	
     <properties>
-	<!-- Minimal version for compiling TensorFlow Java is JDK 8 -->
+        <exec.mainClass>HelloTensorFlow</exec.mainClass>
+	<!-- Minimal version for compiling TensorFlow Java is JDK 8 -->   
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -82,10 +82,6 @@ configured in your `pom.xml` as well:
 </dependencies>
 ```
 
-## Building from Source
-
-To build TensorFlow Java from source and possibly customize it, please read the following [instructions](https://github.com/tensorflow/java/blob/master/README.md#building-sources).
-
 ## Example Program
 
 This example shows how to build an Apache Maven project with TensorFlow. First,
@@ -157,3 +153,7 @@ Double of 10 is 20
 ```
 
 Success: TensorFlow Java is configured.
+
+## Building from Source
+
+To build TensorFlow Java from source and possibly customize it, please read the following [instructions](https://github.com/tensorflow/java/blob/master/README.md#building-sources).

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -59,7 +59,7 @@ set of high-level utilities to improve the developer experience with machine lea
 </dependency>
 ```
 
-### Reducing Number of Dependencies with Maven
+### Reducing Number of Dependencies
 
 It is important to note that adding a dependency to a `tensorflow-core-platform` artifact will import native 
 libraries for all supported platforms, which can increase significantly the size of your project.

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -11,7 +11,7 @@ Caution: The TensorFlow Java API is *not* covered by the TensorFlow
 
 ## Requirements
 
-TensorFlow Java runs on JRE 8 and above, and is supported on the following platforms:
+TensorFlow Java runs on Java 8 and above, and is supported on the following platforms:
 
 * Ubuntu 16.04 or higher; 64-bit, x86
 * macOS 10.12.6 (Sierra) or higher; 64-bit, x86

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -42,13 +42,13 @@ to your project's `pom.xml` file:
 </dependency>
 ```
 
-or alternatively, select one of the supported variant:
+or alternatively select one of the supported variant:
 
 * `tensorflow-core-platform-mkl`: Support for Intel® MKL-DNN on all platforms
 * `tensorflow-core-platform-gpu`: Support for CUDA® on Linux and Windows platforms
 * `tensorflow-core-platform-mkl-gpu`: Support for Intel® MKL-DNN and CUDA® on Linux and Windows platforms.
 
-You can also include a dependency to the `tensorflow-framework` library, which provides a rich
+In addition, you can include a dependency to the `tensorflow-framework` library, which provides a rich
 set of high-level utilities to improve the developer experience with with TensorFlow-based machine learning
 on the JVM.
 
@@ -149,7 +149,7 @@ add the TensorFlow dependency to the project's `pom.xml` file:
     </properties>
 	
     <dependencies>
-	<!-- Includes pure CPU TensorFlow for all platforms -->
+	<!-- Include TensorFlow (pure CPU only) for all supported platforms -->
         <dependency>
             <groupId>org.tensorflow</groupId>
             <artifactId>tensorflow-core-platform</artifactId>

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -31,8 +31,8 @@ and their mapping with the TensorFlow runtime.
 
 ## Installing with Maven
 
-To include TensorFlow in your [Maven](http://maven.apache.org) application, you first need to add in
-your project's `pom.xml` file a dependency on one of the `tensorflow-core-platform` artifact.
+To include TensorFlow in your [Maven](http://maven.apache.org) application, add a dependency to
+a `tensorflow-core-platform` artifact to your project's `pom.xml` file.
 
 ```xml
 <dependency>
@@ -44,6 +44,7 @@ your project's `pom.xml` file a dependency on one of the `tensorflow-core-platfo
 
 You can leave the `extension` variable empty to use a pure CPU version of TensorFlow or set it to one
 of the supported variant:
+
 * `-mkl`: Support for Intel® MKL-DNN on all platforms
 * `-gpu`: Support for CUDA® on Linux and Windows platforms
 * `-mkl-gpu`: Support for Intel® MKL-DNN and CUDA® on Linux and Windows platforms.

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -54,7 +54,7 @@ libraries for all supported platforms, which can increase significantly the size
 When it is already known that your project will only run on a subset of the supported platforms, it is possible
 to exclude the artifacts of other platforms using the [Maven Dependency Exclusion](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html#dependency-exclusions) feature.
 
-### Example program
+## Example program
 
 This example shows how to build an Apache Maven project with TensorFlow. First,
 add the TensorFlow dependency to the project's `pom.xml` file:
@@ -125,79 +125,6 @@ Double of 10 is 20
 ```
 
 Success: TensorFlow Java is configured.
-
-
-## TensorFlow with the JDK
-
-TensorFlow can be used with the JDK through the Java Native Interface (JNI).
-
-### Download
-
-1. Download the TensorFlow Jar Archive (JAR): [libtensorflow.jar](https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-1.14.0.jar)
-2. Download and extract the Java Native Interface (JNI) file for your operating
-system and processor support:
-
-<table>
-  <tr><th>JNI version</th><th>URL</th></tr>
-  <tr class="alt"><td colspan="2">Linux</td></tr>
-  <tr>
-    <td>Linux CPU only</td>
-    <td class="devsite-click-to-copy"><a href="https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-2.3.0.tar.gz">https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-2.3.0.tar.gz</a></td>
-  </tr>
-  <tr>
-    <td>Linux GPU support</td>
-    <td class="devsite-click-to-copy"><a href="https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-2.3.0.tar.gz">https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-2.3.0.tar.gz</a></td>
-  </tr>
-  <tr class="alt"><td colspan="2">macOS</td></tr>
-  <tr>
-    <td>macOS CPU only</td>
-    <td class="devsite-click-to-copy"><a href="https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-2.3.0.tar.gz">https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-2.3.0.tar.gz</a></td>
-  </tr>
-  <tr class="alt"><td colspan="2">Windows</td></tr>
-  <tr>
-    <td>Windows CPU only</td>
-    <td class="devsite-click-to-copy"><a href="https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-2.3.0.zip">https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-2.3.0.zip</a></td>
-  </tr>
-  <tr>
-    <td>Windows GPU support</td>
-    <td class="devsite-click-to-copy"><a href="https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-windows-x86_64-2.3.0.zip">https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-windows-x86_64-2.3.0.zip</a></td>
-  </tr>
-</table>
-
-Note: On Windows, the native library (`tensorflow_jni.dll`) requires
-`msvcp140.dll` at runtime. See the
-[Windows build from source](./source_windows.md) guide to install the
-[Visual C++ 2019 Redistributable](https://visualstudio.microsoft.com/vs/){:.external}.
-
-### Compile
-
-Using the `HelloTensorFlow.java` file from the [previous example](#example),
-compile a program that uses TensorFlow. Make sure the `libtensorflow.jar` is
-accessible to your `classpath`:
-
-<pre class="devsite-terminal devsite-click-to-copy">
-javac -cp libtensorflow-2.3.0.jar HelloTensorFlow.java
-</pre>
-
-### Run
-
-To execute a TensorFlow Java program, the JVM must access `libtensorflow.jar` and
-the extracted JNI library.
-
-<div class="ds-selector-tabs">
-<section>
-<h3>Linux / macOS</h3>
-<pre class="devsite-terminal devsite-click-to-copy">java -cp libtensorflow-2.3.0.jar:. -Djava.library.path=./jni HelloTensorFlow</pre>
-</section>
-<section>
-<h3>Windows</h3>
-<pre class="devsite-terminal tfo-terminal-windows devsite-click-to-copy">java -cp libtensorflow-2.3.0.jar;. -Djava.library.path=jni HelloTensorFlow</pre>
-</section>
-</div><!--/ds-selector-tabs-->
-
-The command outputs: <code>Hello from <em>version</em></code>
-
-Success: TensorFlow for Java is configured.
 
 
 ## Build from source

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -82,6 +82,10 @@ configured in your `pom.xml` as well:
 </dependencies>
 ```
 
+## Building from Source
+
+To build TensorFlow Java from source and possibly customize it, please read the following [instructions](https://github.com/tensorflow/java/blob/master/README.md#building-sources).
+
 ## Example Program
 
 This example shows how to build an Apache Maven project with TensorFlow. First,
@@ -153,7 +157,3 @@ Double of 10 is 20
 ```
 
 Success: TensorFlow Java is configured.
-
-## Building from Source
-
-To build TensorFlow Java from source and possibly customize it, please read the following [instructions](https://github.com/tensorflow/java/blob/master/README.md#building-sources).

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -143,7 +143,7 @@ public class HelloTensorFlow {
 Compile and execute:
 
 <pre class="devsite-terminal prettyprint lang-bsh">
-mvn -q compile exec:java  # Use -q to hide logging
+mvn -q compile exec:java
 </pre>
 
 The command outputs: 

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -31,25 +31,24 @@ and their mapping with the TensorFlow runtime.
 
 ## Installing with Maven
 
-To include TensorFlow in your [Maven](http://maven.apache.org) application, add a dependency to
-a `tensorflow-core-platform` artifact to your project's `pom.xml` file.
+To include TensorFlow in your [Maven](http://maven.apache.org) application, add the following dependency
+to your project's `pom.xml` file:
 
 ```xml
 <dependency>
   <groupId>org.tensorflow</groupId>
-  <artifactId>tensorflow-core-platform${extension}</artifactId>
+  <artifactId>tensorflow-core-platform</artifactId>
   <version>0.2.0</version>
 </dependency>
 ```
 
-You can leave the `extension` variable empty to use a pure CPU version of TensorFlow or set it to one
-of the supported variant:
+or select one of the supported variant of TensorFlow instead of the pure CPU version:
 
-* `-mkl`: Support for Intel® MKL-DNN on all platforms
-* `-gpu`: Support for CUDA® on Linux and Windows platforms
-* `-mkl-gpu`: Support for Intel® MKL-DNN and CUDA® on Linux and Windows platforms.
+* `tensorflow-core-platform-mkl`: Support for Intel® MKL-DNN on all platforms
+* `tensorflow-core-platform-gpu`: Support for CUDA® on Linux and Windows platforms
+* `tensorflow-core-platform-mkl-gpu`: Support for Intel® MKL-DNN and CUDA® on Linux and Windows platforms.
 
-Optionally, you can also add a dependency on the `tensorflow-framework` library, which provides a rich
+In addition, you can add a dependency to the `tensorflow-framework` library, which provides a rich
 set of high-level utilities to improve the developer experience with with TensorFlow-based machine learning
 on the JVM.
 

--- a/site/en/install/lang_java.md
+++ b/site/en/install/lang_java.md
@@ -203,4 +203,4 @@ Running on TensorFlow 2.3.1
 Double of 10 is 20
 ```
 
-Success: TensorFlow Java is configured.
+Success! TensorFlow Java is configured.


### PR DESCRIPTION
Hi, this PR is to replace the actual install page for Java with instructions for the new [TensorFlow Java](https://github.com/tensorflow/java) maintained by SIG JVM and that has been released last week. Current TF Java from the main TF repository is now officially deprecated.

Note to the approvers: please can you squash all commits into a single one when merging? thank you.

CC\ @MarkDaoust , @martinwicke 