### PR TITLE
Cleanup/simplify install from source instructions

### DIFF
--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -99,9 +99,9 @@ flags, for example).
 ./configure
 </pre>
 
-Note: If using a virtual environment `python configure.py` will give priority
-to paths from the environments, whereas `./configure` will give priority to
-paths outside the environment. In both cases you can change the default.
+If using a virtual environment, `python configure.py` prioritizes paths
+within the environment, whereas `./configure` prioritizes paths outside
+the environment. In both cases you can change the default.
 
 ### Sample session
 

--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -38,8 +38,7 @@ Install the TensorFlow *pip* package dependencies (if using a virtual environmen
 omit the `--user` argument):
 
 <pre class="prettyprint lang-bsh">
-<code class="devsite-terminal">pip install -U --user pip six 'numpy<1.19.0' wheel setuptools mock 'future>=0.17.1' 'gast==0.3.3' typing_extensions</code>
-<code class="devsite-terminal">pip install -U --user keras_applications --no-deps</code>
+<code class="devsite-terminal">pip install -U --user pip numpy wheel</code>
 <code class="devsite-terminal">pip install -U --user keras_preprocessing --no-deps</code>
 </pre>
 
@@ -85,7 +84,7 @@ The repo defaults to the `master` development branch. You can also checkout a
 to build:
 
 <pre class="devsite-terminal prettyprint lang-bsh">
-git checkout <em>branch_name</em>  # r1.9, r1.10, etc.
+git checkout <em>branch_name</em>  # r2.2, r2.3, etc.
 </pre>
 
 
@@ -99,6 +98,10 @@ flags, for example).
 <pre class="devsite-terminal devsite-click-to-copy">
 ./configure
 </pre>
+
+Note: If using a virtual environment `python configure.py` will give priority
+to paths from the environments, whereas `./configure` will give priority to
+paths outside the environment. In both cases you can change the default.
 
 ### Sample session
 


### PR DESCRIPTION
The install instruction require installing several packages which are no longer needed now that we only support Py3.6 and up. Hence, doing some cleanup.

Before installing the pip package, but after a successful build on a clean Python 3.8 environment:

```console
(venv) mihaimaruseac@ankh:/tmp/tf/cp/tf$ pip list
Package             Version
------------------- -------
Keras-Preprocessing 1.1.2
numpy               1.19.2
pip                 20.2.3
pkg-resources       0.0.0
setuptools          44.0.0
six                 1.15.0
wheel               0.35.1
```

After installing:
```console
(venv) mihaimaruseac@ankh:/tmp/tf/cp/tf$ pip list
Package                Version
---------------------- ---------
absl-py                0.10.0
astunparse             1.6.3
cachetools             4.1.1
certifi                2020.6.20
chardet                3.0.4
flatbuffers            1.12
gast                   0.4.0
google-auth            1.22.1
google-auth-oauthlib   0.4.1
google-pasta           0.2.0
grpcio                 1.32.0
h5py                   2.10.0
idna                   2.10
Keras-Preprocessing    1.1.2
Markdown               3.3.1
numpy                  1.19.2
oauthlib               3.1.0
opt-einsum             3.3.0
pip                    20.2.3
pkg-resources          0.0.0
protobuf               3.13.0
pyasn1                 0.4.8
pyasn1-modules         0.2.8
requests               2.24.0
requests-oauthlib      1.3.0
rsa                    4.6
setuptools             44.0.0
six                    1.15.0
tensorboard            2.3.0
tensorboard-plugin-wit 1.7.0
tensorflow             2.4.0
tensorflow-estimator   2.3.0
termcolor              1.1.0
typing-extensions      3.7.4.3
urllib3                1.25.10
Werkzeug               1.0.1
wheel                  0.35.1
wrapt                  1.12.1
```