### PR TITLE
Enhance the TensorFlow audio recognition tutorial

### DIFF
--- a/site/en/tutorials/audio/simple_audio.ipynb
+++ b/site/en/tutorials/audio/simple_audio.ipynb
@@ -37,7 +37,7 @@
         "id": "jYysdyb-CaWM"
       },
       "source": [
-        "# Simple audio recognition: Recognizing key words"
+        "# Simple audio recognition: Recognizing keywords"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "source": [
         "## Setup\n",
         "\n",
-        "Let's install TensorFlow to get started."
+        "Import necessary modules and dependencies."
       ]
     },
     {
@@ -124,9 +124,9 @@
       "source": [
         "## Import the Speech Commands dataset\n",
         "\n",
-        "The script will start off by downloading a portion of the [Speech Commands dataset](https://www.tensorflow.org/datasets/catalog/speech_commands). The original dataset consists of over 105,000 WAVE audio files of people saying thirty different words. This data was collected by Google and released under a CC BY license, and you can help improve it by [contributing five minutes of your own voice](https://aiyprojects.withgoogle.com/open_speech_recording).\n",
+        "You'll write a script to download a portion of the [Speech Commands dataset](https://www.tensorflow.org/datasets/catalog/speech_commands). The original dataset consists of over 105,000 WAV audio files of people saying thirty different words. This data was collected by Google and released under a CC BY license, and you can help improve it by [contributing five minutes of your own voice](https://aiyprojects.withgoogle.com/open_speech_recording).\n",
         "\n",
-        "You'll be using a portion of the dataset to save time with dataloading. Unzip the `mini_speech_commands.zip` and load it in using the `tf.data` API."
+        "You'll be using a portion of the dataset to save time with data loading. Extract the `mini_speech_commands.zip` and load it in using the `tf.data` API."
       ]
     },
     {
@@ -174,7 +174,7 @@
         "id": "aMvdU9SY8WXN"
       },
       "source": [
-        "Extract the audio files into a list and shuffle the list."
+        "Extract the audio files into a list and shuffle it."
       ]
     },
     {
@@ -200,7 +200,7 @@
         "id": "9vK3ymy23MCP"
       },
       "source": [
-        "Split the files into training, validation and test sets using a 80:10:10 ratio respectively."
+        "Split the files into training, validation and test sets using a 80:10:10 ratio, respectively."
       ]
     },
     {
@@ -239,7 +239,7 @@
         "\n",
         "To load an audio file, you will use [`tf.audio.decode_wav`](https://www.tensorflow.org/api_docs/python/tf/audio/decode_wav), which returns the WAV-encoded audio as a Tensor and the sample rate.\n",
         "\n",
-        "A WAV file contains timeseries data with a set number of samples per second. \n",
+        "A WAV file contains time series data with a set number of samples per second. \n",
         "Each sample represents the amplitude of the audio signal at that specific time. In a 16-bit system, like the files in `mini_speech_commands`, the values range from -32768 to 32767. \n",
         "The sample rate for this dataset is 16kHz.\n",
         "Note that `tf.audio.decode_wav` will normalize the values to the range [-1.0, 1.0]."
@@ -264,7 +264,7 @@
         "id": "GPQseZElOjVN"
       },
       "source": [
-        "The label for the wav file is its parent directory."
+        "The label for each WAV file is its parent directory."
       ]
     },
     {
@@ -289,7 +289,7 @@
         "id": "E8Y9w_5MOsr-"
       },
       "source": [
-        "Let's define a method that will take in the filename of the wav file and output an audio, label tuple for supervised training."
+        "Let's define a method that will take in the filename of the WAV file and output a tuple containing the audio and labels for supervised training."
       ]
     },
     {
@@ -313,7 +313,7 @@
         "id": "nvN8W_dDjYjc"
       },
       "source": [
-        "You will now apply `process_path` to build our training set to extract audio, label pairs and check the results. You'll build the validation and test sets using a similar procedure later on."
+        "You will now apply `process_path` to build your training set to extract the audio-label pairs and check the results. You'll build the validation and test sets using a similar procedure later on."
       ]
     },
     {
@@ -370,15 +370,15 @@
       "source": [
         "## Spectrogram\n",
         "\n",
-        "You'll convert the waveform into a spectrogram, which shows frequency changes over time and can be represented as a 2D image. This can be done by applying short time fourier transform (STFT) to convert the audio into the time-frequency domain.\n",
+        "You'll convert the waveform into a spectrogram, which shows frequency changes over time and can be represented as a 2D image. This can be done by applying the short-time Fourier transform (STFT) to convert the audio into the time-frequency domain.\n",
         "\n",
-        "A fourier transform ([`tf.signal.fft`](https://www.tensorflow.org/api_docs/python/tf/signal/fft)) converts a signal to its component frequencies, but looses all time information. The STFT ([`tf.signal.stft`](https://www.tensorflow.org/api_docs/python/tf/signal/stft)) splits the signal into windows of time and runs a fourier transform on each window, preserving some time information, and returning a 2D tensor that you can run standard convolutions on.\n",
+        "A Fourier transform ([`tf.signal.fft`](https://www.tensorflow.org/api_docs/python/tf/signal/fft)) converts a signal to its component frequencies, but loses all time information. The STFT ([`tf.signal.stft`](https://www.tensorflow.org/api_docs/python/tf/signal/stft)) splits the signal into windows of time and runs a Fourier transform on each window, preserving some time information, and returning a 2D tensor that you can run standard convolutions on.\n",
         "\n",
         "STFT produces an array of complex numbers representing magnitude and phase. However, you'll only need the magnitude for this tutorial, which can be derived by applying `tf.abs` on the output of `tf.signal.stft`. \n",
         "\n",
-        "Choose `frame_length` and `frame_step` parameters such that the generated spectrogram \"image\" is almost square. For more info on STFT parameters choice, you can refer to [this video](https://www.coursera.org/lecture/audio-signal-processing/stft-2-tjEQe). \n",
+        "Choose `frame_length` and `frame_step` parameters such that the generated spectrogram \"image\" is almost square. For more information on STFT parameters choice, you can refer to [this video](https://www.coursera.org/lecture/audio-signal-processing/stft-2-tjEQe) on audio signal processing. \n",
         "\n",
-        "You also want to waveforms to have the same length so that when you convert it to a spectrogram image, the results will have similar dimensions. This can be done by simply zero padding the audio clips that are shorter than one second.\n",
+        "You also want the waveforms to have the same length, so that when you convert it to a spectrogram image, the results will have similar dimensions. This can be done by simply zero padding the audio clips that are shorter than one second.\n",
         "\n"
       ]
     },
@@ -538,7 +538,7 @@
       "source": [
         "## Build and train the model\n",
         "\n",
-        "Before you build and train our model, you would need apply the same data processing done on the training set with the validation and test sets."
+        "Now you can build and train your model. But before you do that, you'll need to repeat the training set preprocessing on the validation and test sets."
       ]
     },
     {
@@ -698,7 +698,7 @@
         "id": "gjpCDeQ4mUfS"
       },
       "source": [
-        "Let's check the training and validation loss curves to see how our model has improved during training."
+        "Let's check the training and validation loss curves to see how your model has improved during training."
       ]
     },
     {
@@ -796,7 +796,7 @@
       "source": [
         "## Run inference on an audio file\n",
         "\n",
-        "Finally, verify the model's prediction output using an input audio file of someone saying \"no.\" How well does our model perform?"
+        "Finally, verify the model's prediction output using an input audio file of someone saying \"no.\" How well does your model perform?"
       ]
     },
     {
@@ -824,7 +824,7 @@
         "id": "VgWICqdqQNaQ"
       },
       "source": [
-        "You can see that our model very clearly recognized the audio command as \"no.\""
+        "You can see that your model very clearly recognized the audio command as \"no.\""
       ]
     },
     {

--- a/site/en/tutorials/audio/simple_audio.ipynb
+++ b/site/en/tutorials/audio/simple_audio.ipynb
@@ -378,8 +378,7 @@
         "\n",
         "Choose `frame_length` and `frame_step` parameters such that the generated spectrogram \"image\" is almost square. For more information on STFT parameters choice, you can refer to [this video](https://www.coursera.org/lecture/audio-signal-processing/stft-2-tjEQe) on audio signal processing. \n",
         "\n",
-        "You also want the waveforms to have the same length, so that when you convert it to a spectrogram image, the results will have similar dimensions. This can be done by simply zero padding the audio clips that are shorter than one second.\n",
-        "\n"
+        "You also want the waveforms to have the same length, so that when you convert it to a spectrogram image, the results will have similar dimensions. This can be done by simply zero padding the audio clips that are shorter than one second.\n"
       ]
     },
     {
@@ -841,8 +840,7 @@
         "\n",
         "* To build your own interactive web app for audio classification, consider taking the [TensorFlow.js - Audio recognition using transfer learning codelab](https://codelabs.developers.google.com/codelabs/tensorflowjs-audio-codelab/index.html#0).\n",
         "\n",
-        "* TensorFlow also has additional support for [audio data preparation and augmentation](https://www.tensorflow.org/io/tutorials/audio) to help with your own audio-based projects.\n",
-        "\n"
+        "* TensorFlow also has additional support for [audio data preparation and augmentation](https://www.tensorflow.org/io/tutorials/audio) to help with your own audio-based projects.\n"
       ]
     }
   ],
@@ -851,8 +849,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "simple_audio.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
Hey @lamberta @MarkDaoust and team. Thanks for the new [Simple audio recognition tutorial](https://www.tensorflow.org/tutorials/audio/simple_audio).

I had a quick look and came up with a few alterations and suggestions that you may find useful.

Feel free to ignore any of these or edit the stuff directly.

---

- Change the language in the step where the reader is importing (not installing) TF and several other libraries/APIs, such as Seaborn, matplotlib, IPython, NumPy, and Keras modules:

```diff
- Let's install TensorFlow to get started.
+ Import necessary modules and dependencies.
```

or something like that.

---

- In the beginning of the _Import the…dataset_ section, the description of what the reader will be doing should probably explain what the user - not the script - will be doing by writing that script:

```diff
- The script will start off by downloading a portion …
+ You'll write a script to download a portion …
```

Also, in the same section:
- “Extract” <- “Unzip” (Google style guide, I think)
- “data loading” <- “dataloading” (checked with https://www.tensorflow.org/s/results?q=dataloading)

---

- There’s a section called _Build and train the model_ that starts with “Before you build and train our model, …”. How about we refactor as follows:

```diff
## Build and train the model

- Before you build and train our model,
+ Now you can build and train your model. But before you do that, …
```

- And in the same section, there is a sentence that sounded a bit “off”: “...need to apply…data processing done on the…set… with the … sets”. I think “with” should probably be replaced with “on”, but it’d also create a “…on the… on the…” scenario.

Proposed changes:

```diff
- … you would need to apply the same data processing done on the training set with the validation and test sets.
+ ... you'll need to repeat the training set preprocessing on the validation and test sets.
```

WDYT? It’s the best I could come up with.

---

- “WAV file” (instead of “wav” - it should be capitalized) + refactor the “tuple” statement (since it’s not in code font, so less Python and more English:

```diff
- The label for the wav file is its parent directory.
+ The label for each WAV file is its parent directory. 
…
- … in the filename of the wav file and output an audio, label tuple for supervised training.
+ … in the filename of the WAV file and output a tuple containing the audio and labels for supervised training.
```

Also here:

```diff
- …to extract audio, label pairs…
+ …to extract the audio-label pairs…
```

(I also noticed the audio (stored as `waveform`) is also referred to as “waveforms” in the tutorial.)

---

- Use “Fourier” with a capital “F” (I checked here: https://en.wikipedia.org/wiki/Short-time_Fourier_transform, https://ccrma.stanford.edu/~jos/sasp/Short_Time_Fourier_Transform.html and http://faculty.nps.edu/rcristi/EO3404/B-Discrete-Fourier-Transform/text/3-STFT.pdf)

```diff
- This can be done by applying short time fourier transform (STFT) to …
+ This can be done by applying the short-time Fourier transform (STFT) to …
```

(and 2x elsewhere).

---

- "a list ... the list" repetition:

```diff
- Extract the audio files into a list and shuffle the list.
+ Extract the audio files into a list and shuffle it.
```

---

- Add more context to “this video” - the more descriptive the better for UX (especially for a11y), I think:

```diff
…you can refer to [this video](https://www.coursera.org/lecture/audio-signal-processing/stft-2-tjEQe)
+ on audio signal processing.
```
---

- Use second person ("your" <- "our") x6.

---

- Small typo: the dataset has WAV files” instead of “WAVE” files. (I checked the paper - https://arxiv.org/pdf/1804.03209.pdf - just to make sure)
- “timeseries” -> “time series” (same as in https://www.tensorflow.org/tutorials/structured_data/time_series)
 - “key words” -> “keywords” (same as in https://www.tensorflow.org/s/results/?q=keyword)
- Fix small typos (“looses” -> “loses”; “want to waveforms to have” -> “want the waveforms to have…”)
- Use “information” - it's probably more formal than “info” (spoken)
- Fix a small syntactical thing (“Need to apply” with “to”)

---

LMKWYT. Again, feel free to ignore any of these or edit the PR directly.

Thank you all 👍