### PR TITLE
Update overfit_and_underfit.ipynb

### DIFF
--- a/site/en/tutorials/keras/overfit_and_underfit.ipynb
+++ b/site/en/tutorials/keras/overfit_and_underfit.ipynb
@@ -106,7 +106,7 @@
         "\n",
         "In other words, our model would *overfit* to the training data. Learning how to deal with overfitting is important. Although it's often possible to achieve high accuracy on the *training set*, what we really want is to develop models that generalize well to a *testing set* (or data they haven't seen before).\n",
         "\n",
-        "The opposite of overfitting is *underfitting*. Underfitting occurs when there is still room for improvement on the test data. This can happen for a number of reasons: If the model is not powerful enough, is over-regularized, or has simply not been trained long enough. This means the network has not learned the relevant patterns in the training data.\n",
+        "The opposite of overfitting is *underfitting*. Underfitting occurs when there is still room for improvement on the train data. This can happen for a number of reasons: If the model is not powerful enough, is over-regularized, or has simply not been trained long enough. This means the network has not learned the relevant patterns in the training data.\n",
         "\n",
         "If you train for too long though, the model will start to overfit and learn patterns from the training data that don't generalize to the test data. We need to strike a balance. Understanding how to train for an appropriate number of epochs as we'll explore below is a useful skill.\n",
         "\n",


### PR DESCRIPTION
"Underfitting occurs when there is still room for improvement on the **test** data." should read as "Underfitting occurs when there is still room for improvement on the **train** data.".

Reason being that underfitting fails to extract adequate structure from the train data (and not test data) and the "room for improvement" is dependent on the training data and not test data!

If we say "room for improvement over the test data", it sounds as if test data is to be operated upon for improvement (which is not the case).