### PR TITLE
Fixed formula for violinplot diagram

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -572,7 +572,7 @@
       },
       "outputs": [],
       "source": [
-        "df_std = (df - train_mean) / train_std\n",
+        "df_std = (train_df - train_mean) / train_std\n",
         "df_std = df_std.melt(var_name='Column', value_name='Normalized')\n",
         "plt.figure(figsize=(12, 6))\n",
         "ax = sns.violinplot(x='Column', y='Normalized', data=df_std)\n",


### PR DESCRIPTION
The formula was, which is wrong in this context and messes up the violinplot diagram :
df_std = (df - train_mean) / train_std 
It must be : 
df_std = (train_df - train_mean) / train_std