### PR TITLE
Update data.ipynb

### DIFF
--- a/site/en/guide/data.ipynb
+++ b/site/en/guide/data.ipynb
@@ -2242,14 +2242,14 @@
       "outputs": [],
       "source": [
         "feature_length = 10\n",
-        "label_length = 5\n",
+        "label_length = 3\n",
         "\n",
         "features = range_ds.batch(feature_length, drop_remainder=True)\n",
-        "labels = range_ds.batch(feature_length).skip(1).map(lambda labels: labels[:-5])\n",
+        "labels = range_ds.batch(feature_length).skip(1).map(lambda labels: labels[:label_length])\n",
         "\n",
-        "predict_5_steps = tf.data.Dataset.zip((features, labels))\n",
+        "predicted_steps = tf.data.Dataset.zip((features, labels))\n",
         "\n",
-        "for features, label in predict_5_steps.take(3):\n",
+        "for features, label in predicted_steps.take(5):\n",
         "  print(features.numpy(), \" => \", label.numpy())"
       ]
     },


### PR DESCRIPTION
The modified section had a defect. The only reason the defect was not visible in the output was because the label width of 5 is exactly half of the feature length of 10. In that case the index ``[:-label_length]`` will be same as ``[:label_length]``. The correct index is ``[:label_length]``.

I have changed the label length to 3 so that any problem with the code shows up.

On a related note, I see that a label length of 5 is used throughout this notebook. I do not have the time right now to see if similar defect exists elsewhere.