### PR TITLE
Fix some typos in TF NumPy guide

### DIFF
--- a/site/en/guide/tf_numpy.ipynb
+++ b/site/en/guide/tf_numpy.ipynb
@@ -70,7 +70,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "TensorFlow implements a subset of the [NumPy API](https://numpy.org/doc/stable), available as `tf.experimental.numpy`. This allows running NumPy code, accelerated by TensorFlow, while also allowing access to all of TensorFlow's APIs."
+        "TensorFlow implements a subset of the [NumPy API](https://numpy.org/doc/1.16), available as `tf.experimental.numpy`. This allows running NumPy code, accelerated by TensorFlow, while also allowing access to all of TensorFlow's APIs."
       ]
     },
     {
@@ -155,7 +155,7 @@
       "source": [
         "### Type promotion\n",
         "\n",
-        "TensorFlow NumPy APIs have well-defined semantics for converting literals to ND array, as well as for performing type promotion on ND array inputs. Please see [`np.result_type`](https://numpy.org/doc/stable/reference/generated/numpy.result_type.html) for more details. When converting literals to ND array, NumPy prefers wide types like `tnp.int64` and `tnp.float64`.\n",
+        "TensorFlow NumPy APIs have well-defined semantics for converting literals to ND array, as well as for performing type promotion on ND array inputs. Please see [`np.result_type`](https://numpy.org/doc/1.16/reference/generated/numpy.result_type.html) for more details. When converting literals to ND array, NumPy prefers wide types like `tnp.int64` and `tnp.float64`.\n",
         "\n",
         "In contrast, `tf.convert_to_tensor` prefers `tf.int32` and `tf.float32` types for converting constants to `tf.Tensor`. TensorFlow APIs leave `tf.Tensor` inputs unchanged and do not perform type promotion on them.\n",
         "\n",
@@ -192,7 +192,7 @@
         "### Broadcasting\n",
         "\n",
         "Similar to TensorFlow, NumPy defines rich semantics for \"broadcasting\" values.\n",
-        "You can check out the [NumPy broadcasting guide](https://numpy.org/doc/stable/user/basics.broadcasting.html) for more information and compare this with [TensorFlow broadcasting semantics](https://www.tensorflow.org/guide/tensor#broadcasting)."
+        "You can check out the [NumPy broadcasting guide](https://numpy.org/doc/1.16/user/basics.broadcasting.html) for more information and compare this with [TensorFlow broadcasting semantics](https://www.tensorflow.org/guide/tensor#broadcasting)."
       ]
     },
     {
@@ -218,7 +218,7 @@
       "source": [
         "### Indexing\n",
         "\n",
-        "NumPy defines very sophisticated indexing rules. See the [NumPy Indexing guide](https://numpy.org/doc/stable/reference/arrays.indexing.html). Note the use of ND arrays as indices below."
+        "NumPy defines very sophisticated indexing rules. See the [NumPy Indexing guide](https://numpy.org/doc/1.16/reference/arrays.indexing.html). Note the use of ND arrays as indices below."
       ]
     },
     {

--- a/site/en/guide/tf_numpy.ipynb
+++ b/site/en/guide/tf_numpy.ipynb
@@ -155,12 +155,12 @@
       "source": [
         "### Type promotion\n",
         "\n",
-        "TensorFlow NumPy APIs have well-defined semantics for converting literals to ND array, as well as for performing type promotion on ND array inputs. Please see [`np.result_type`](https://numpy.org/doc/stable/reference/generated/numpy.result_type.html) for more details. . When converting literals to ND array, NumPy prefers wide types like `tnp.int64` and `tnp.float64`.\n",
+        "TensorFlow NumPy APIs have well-defined semantics for converting literals to ND array, as well as for performing type promotion on ND array inputs. Please see [`np.result_type`](https://numpy.org/doc/1.16/reference/generated/numpy.result_type.html) for more details. When converting literals to ND array, NumPy prefers wide types like `tnp.int64` and `tnp.float64`.\n",
         "\n",
         "In contrast, `tf.convert_to_tensor` prefers `tf.int32` and `tf.float32` types for converting constants to `tf.Tensor`. TensorFlow APIs leave `tf.Tensor` inputs unchanged and do not perform type promotion on them.\n",
         "\n",
         "In the next example, you will perform type promotion. First, run addition on ND array inputs of different types and note the output types. None of these type promotions would be allowed on straight `tf.Tensor` objects. Finally,\n",
-        "convert literals to ND array using `ndarray.asarrray` and note the resulting type."
+        "convert literals to ND array using `ndarray.asarray` and note the resulting type."
       ]
     },
     {
@@ -175,12 +175,12 @@
         "values = [tnp.asarray(1, dtype=d) for d in\n",
         "          (tnp.int32, tnp.int64, tnp.float32, tnp.float64)]\n",
         "for i, v1 in enumerate(values):\n",
-        "  for v2 in values[i+1:]:\n",
+        "  for v2 in values[i + 1:]:\n",
         "    print(\"%s + %s => %s\" % (v1.dtype, v2.dtype, (v1 + v2).dtype))\n",
         "\n",
         "print(\"Type inference during array creation\")\n",
         "print(\"tnp.asarray(1).dtype == tnp.%s\" % tnp.asarray(1).dtype)\n",
-        "print(\"tnp.asarray(1.).dtype == tnp.%s\\n\" % tnp.asarray(1.).dtype)\n"
+        "print(\"tnp.asarray(1.).dtype == tnp.%s\\n\" % tnp.asarray(1.).dtype)"
       ]
     },
     {
@@ -192,7 +192,7 @@
         "### Broadcasting\n",
         "\n",
         "Similar to TensorFlow, NumPy defines rich semantics for \"broadcasting\" values.\n",
-        "You can check out the [NumPy broadcasting guide](https://numpy.org/doc/stable/user/basics.broadcasting.html) for more information and compare this with [TensorFlow broadcasting semantics](https://www.tensorflow.org/guide/tensor#broadcasting)."
+        "You can check out the [NumPy broadcasting guide](https://numpy.org/doc/1.16/user/basics.broadcasting.html) for more information and compare this with [TensorFlow broadcasting semantics](https://www.tensorflow.org/guide/tensor#broadcasting)."
       ]
     },
     {
@@ -218,7 +218,7 @@
       "source": [
         "### Indexing\n",
         "\n",
-        "NumPy defines very sophisticated indexing rules. See the [NumPy Indexing guide](https://numpy.org/doc/stable/reference/arrays.indexing.html). Note the use of ND arrays as indices below."
+        "NumPy defines very sophisticated indexing rules. See the [NumPy Indexing guide](https://numpy.org/doc/1.16/reference/arrays.indexing.html). Note the use of ND arrays as indices below."
       ]
     },
     {
@@ -324,7 +324,7 @@
         "\n",
         "Similarly, TensorFlow NumPy functions can accept inputs of different types including `tf.Tensor` and `np.ndarray`. These inputs are converted to an ND array by calling `ndarray.asarray` on them. \n",
         "\n",
-        "Conversion of the ND array to and from `np.ndarray` may trigger actual data copies. Please see the section on [buffer copies](#Buffer-copies) for more details."
+        "Conversion of the ND array to and from `np.ndarray` may trigger actual data copies. Please see the section on [buffer copies](#buffer-copies) for more details."
       ]
     },
     {
@@ -367,11 +367,11 @@
         "\n",
         "Intermixing TensorFlow NumPy with NumPy code may trigger data copies. This is because TensorFlow NumPy has stricter requirements on memory alignment than those of NumPy.\n",
         "\n",
-        "When a `np.ndarray` is passed to TensorFlow Numpy, it will check for alignment requirements and trigger a copy if needed. When passing an ND array CPU buffer to NumPy, generally the buffer will satisfy alignment requirements and NumPy will not need to create a copy.\n",
+        "When a `np.ndarray` is passed to TensorFlow NumPy, it will check for alignment requirements and trigger a copy if needed. When passing an ND array CPU buffer to NumPy, generally the buffer will satisfy alignment requirements and NumPy will not need to create a copy.\n",
         "\n",
         "ND arrays can refer to buffers placed on devices other than the local CPU memory. In such cases, invoking a NumPy function will trigger copies across the network or device as needed.\n",
         "\n",
-        "Given this, intermixing with NumPy API calls should generally be done with caution and the user should watch out for overheads of copying data. Interleaving TensorFlow NumPy calls with TensorFlow calls is generally safe and avoids copying data. See the section on [tensorflow interoperability](#Tensorflow-interoperability) for more details."
+        "Given this, intermixing with NumPy API calls should generally be done with caution and the user should watch out for overheads of copying data. Interleaving TensorFlow NumPy calls with TensorFlow calls is generally safe and avoids copying data. See the section on [TensorFlow interoperability](#tensorflow-interoperability) for more details."
       ]
     },
     {
@@ -559,7 +559,7 @@
       "outputs": [],
       "source": [
         "# Computes a batch of jacobians. Each row is the jacobian of an element in the\n",
-        "# batch of outputs w.r.t the corresponding input batch element.\n",
+        "# batch of outputs w.r.t. the corresponding input batch element.\n",
         "def prediction_batch_jacobian(inputs):\n",
         "  with tf.GradientTape() as tape:\n",
         "    tape.watch(inputs)\n",
@@ -581,7 +581,7 @@
       "source": [
         "### Trace compilation: tf.function\n",
         "\n",
-        "Tensorflow's `tf.function` works by \"trace compiling\" the code and then optimizing these traces for much faster performance. See the [Introduction to Graphs and Functions](./intro_to_graphs.ipynb).\n",
+        "TensorFlow's `tf.function` works by \"trace compiling\" the code and then optimizing these traces for much faster performance. See the [Introduction to Graphs and Functions](./intro_to_graphs.ipynb).\n",
         "\n",
         "`tf.function` can be used to optimize TensorFlow NumPy code as well. Here is a simple example to demonstrate the speedups. Note that the body of `tf.function` code includes calls to TensorFlow NumPy APIs, and the inputs and output are ND arrays.\n"
       ]
@@ -598,7 +598,7 @@
         "print(\"Eager performance\")\n",
         "compute_gradients(model, inputs, labels)\n",
         "print(timeit.timeit(lambda: compute_gradients(model, inputs, labels),\n",
-        "                    number=10)* 100, \"ms\")\n",
+        "                    number=10) * 100, \"ms\")\n",
         "\n",
         "print(\"\\ntf.function compiled performance\")\n",
         "compiled_compute_gradients = tf.function(compute_gradients)\n",
@@ -665,22 +665,21 @@
         "def unvectorized_per_example_gradients(inputs, labels):\n",
         "  def single_example_gradient(arg):\n",
         "    inp, label = arg\n",
-        "    output = compute_gradients(model,\n",
-        "                               tnp.expand_dims(inp, 0),\n",
-        "                               tnp.expand_dims(label, 0))\n",
-        "    return output\n",
+        "    return compute_gradients(model,\n",
+        "                             tnp.expand_dims(inp, 0),\n",
+        "                             tnp.expand_dims(label, 0))\n",
         "\n",
         "  return tf.map_fn(single_example_gradient, (inputs, labels),\n",
         "                   fn_output_signature=(tf.float32, tf.float32, tf.float32))\n",
         "\n",
-        "print(\"Running vectorized computaton\")\n",
+        "print(\"Running vectorized computation\")\n",
         "print(timeit.timeit(lambda: vectorized_per_example_gradients(inputs, labels),\n",
         "                    number=10) * 100, \"ms\")\n",
         "\n",
         "print(\"\\nRunning unvectorized computation\")\n",
         "per_example_gradients = unvectorized_per_example_gradients(inputs, labels)\n",
         "print(timeit.timeit(lambda: unvectorized_per_example_gradients(inputs, labels),\n",
-        "                    number=5) * 200, \"ms\")"
+        "                    number=10) * 100, \"ms\")"
       ]
     },
     {
@@ -791,7 +790,7 @@
         "\n",
         "However TensorFlow has higher overheads for dispatching operations compared to NumPy. For workloads composed of small operations (less than about 10 microseconds), these overheads can dominate the runtime and NumPy could provide better performance. For other cases, TensorFlow should generally provide better performance.\n",
         "\n",
-        "Run the benchmark below to compare NumPy and TensorFlow Numpy performance for different input sizes."
+        "Run the benchmark below to compare NumPy and TensorFlow NumPy performance for different input sizes."
       ]
     },
     {
@@ -855,7 +854,7 @@
         "def compiled_tnp_sigmoid(y):\n",
         "  return tnp_sigmoid(y)\n",
         "\n",
-        "sizes = (2**0, 2 ** 5, 2 ** 10, 2 ** 15, 2 ** 20)\n",
+        "sizes = (2 ** 0, 2 ** 5, 2 ** 10, 2 ** 15, 2 ** 20)\n",
         "np_inputs = [np.random.randn(size).astype(np.float32) for size in sizes]\n",
         "np_times = benchmark(np_sigmoid, np_inputs)\n",
         "\n",
@@ -885,7 +884,7 @@
         "- [TensorFlow NumPy: Distributed Image Classification Tutorial](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/numpy_ops/g3doc/TensorFlow_Numpy_Distributed_Image_Classification.ipynb)\n",
         "- [TensorFlow NumPy: Keras and Distribution Strategy](\n",
         "  https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/numpy_ops/g3doc/TensorFlow_NumPy_Keras_and_Distribution_Strategy.ipynb)\n",
-        "- [Sentiment Analysis with Trax and TensorFlow Numpy](\n",
+        "- [Sentiment Analysis with Trax and TensorFlow NumPy](\n",
         "  https://github.com/google/trax/blob/master/trax/tf_numpy_and_keras.ipynb)"
       ]
     }

--- a/site/en/guide/tf_numpy.ipynb
+++ b/site/en/guide/tf_numpy.ipynb
@@ -70,7 +70,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "TensorFlow implements a subset of the [NumPy API](https://numpy.org/doc/1.16), available as `tf.experimental.numpy`. This allows running NumPy code, accelerated by TensorFlow, while also allowing access to all of TensorFlow's APIs."
+        "TensorFlow implements a subset of the [NumPy API](https://numpy.org/doc/stable), available as `tf.experimental.numpy`. This allows running NumPy code, accelerated by TensorFlow, while also allowing access to all of TensorFlow's APIs."
       ]
     },
     {
@@ -155,7 +155,7 @@
       "source": [
         "### Type promotion\n",
         "\n",
-        "TensorFlow NumPy APIs have well-defined semantics for converting literals to ND array, as well as for performing type promotion on ND array inputs. Please see [`np.result_type`](https://numpy.org/doc/1.16/reference/generated/numpy.result_type.html) for more details. When converting literals to ND array, NumPy prefers wide types like `tnp.int64` and `tnp.float64`.\n",
+        "TensorFlow NumPy APIs have well-defined semantics for converting literals to ND array, as well as for performing type promotion on ND array inputs. Please see [`np.result_type`](https://numpy.org/doc/stable/reference/generated/numpy.result_type.html) for more details. When converting literals to ND array, NumPy prefers wide types like `tnp.int64` and `tnp.float64`.\n",
         "\n",
         "In contrast, `tf.convert_to_tensor` prefers `tf.int32` and `tf.float32` types for converting constants to `tf.Tensor`. TensorFlow APIs leave `tf.Tensor` inputs unchanged and do not perform type promotion on them.\n",
         "\n",
@@ -192,7 +192,7 @@
         "### Broadcasting\n",
         "\n",
         "Similar to TensorFlow, NumPy defines rich semantics for \"broadcasting\" values.\n",
-        "You can check out the [NumPy broadcasting guide](https://numpy.org/doc/1.16/user/basics.broadcasting.html) for more information and compare this with [TensorFlow broadcasting semantics](https://www.tensorflow.org/guide/tensor#broadcasting)."
+        "You can check out the [NumPy broadcasting guide](https://numpy.org/doc/stable/user/basics.broadcasting.html) for more information and compare this with [TensorFlow broadcasting semantics](https://www.tensorflow.org/guide/tensor#broadcasting)."
       ]
     },
     {
@@ -218,7 +218,7 @@
       "source": [
         "### Indexing\n",
         "\n",
-        "NumPy defines very sophisticated indexing rules. See the [NumPy Indexing guide](https://numpy.org/doc/1.16/reference/arrays.indexing.html). Note the use of ND arrays as indices below."
+        "NumPy defines very sophisticated indexing rules. See the [NumPy Indexing guide](https://numpy.org/doc/stable/reference/arrays.indexing.html). Note the use of ND arrays as indices below."
       ]
     },
     {


### PR DESCRIPTION
Fix section links (it doesn't work when first letter is in upper case).
Measure vectorized/unvectorized code the same number of times.