### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tools/tensorflow_docs/api_generator/parser_test.py
+++ b/tools/tensorflow_docs/api_generator/parser_test.py
@@ -610,7 +610,7 @@ class ParserTest(parameterized.TestCase):
     downgrader = parser._DowngradeH1Keywords()
     doc = downgrader(h1_docstring)
     self.assertIn('\n  ```\n  # comment\n  ```', doc)
-    self.assertIn('\nArguments:', doc)
+    self.assertIn('\nArgs:', doc)
     self.assertIn('\nExample:', doc)
     self.assertIn('\nReturns:', doc)
     self.assertIn('\nRaises:', doc)

--- a/tools/tensorflow_docs/api_generator/public_api.py
+++ b/tools/tensorflow_docs/api_generator/public_api.py
@@ -31,7 +31,7 @@ _TYPING = frozenset(
 def ignore_typing(path, parent, children):
   """Removes all children that are members of the typing module.
 
-  Arguments:
+  Args:
     path: A tuple or name parts forming the attribute-lookup path to this
       object. For `tf.keras.layers.Dense` path is:
         ("tf","keras","layers","Dense")
@@ -92,7 +92,7 @@ def local_definitions_filter(path, parent, children):
     subpackage
       from my_package._utils import *
   ```
-  Arguments:
+  Args:
     path: A tuple or name parts forming the attribute-lookup path to this
       object. For `tf.keras.layers.Dense` path is:
         ("tf","keras","layers","Dense")


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420