### PR TITLE
Externally loading the tensorboard

### DIFF
--- a/site/en/tutorials/text/word_embeddings.ipynb
+++ b/site/en/tutorials/text/word_embeddings.ipynb
@@ -566,15 +566,16 @@
       ]
     },
     {
-      "cell_type": "markdown",
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "TNyLjcoRWEue"
+        "id": "_Uanp2YH8RzU"
       },
+      "outputs": [],
       "source": [
-        "```\n",
+        "#docs_infra: no_execute\n",
         "%load_ext tensorboard\n",
-        "%tensorboard --logdir logs\n",
-        "```"
+        "%tensorboard --logdir logs"
       ]
     },
     {

--- a/site/en/tutorials/text/word_embeddings.ipynb
+++ b/site/en/tutorials/text/word_embeddings.ipynb
@@ -572,6 +572,7 @@
       },
       "source": [
         "```\n",
+        "%load_ext tensorboard\n"
         "%tensorboard --logdir logs\n",
         "```"
       ]

--- a/site/en/tutorials/text/word_embeddings.ipynb
+++ b/site/en/tutorials/text/word_embeddings.ipynb
@@ -572,7 +572,7 @@
       },
       "source": [
         "```\n",
-        "%load_ext tensorboard\n"
+        "%load_ext tensorboard\n",
         "%tensorboard --logdir logs\n",
         "```"
       ]

--- a/site/en/tutorials/text/word_embeddings.ipynb
+++ b/site/en/tutorials/text/word_embeddings.ipynb
@@ -723,7 +723,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "word_embeddings.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
In the docs present
The tensorboard is not loaded with the `%load_ext tensorboard`. In my opinion tensorboard would run in colab after the tensorboard is externally loaded in the colab notebook first.

I have managed to add the same to first load and then host tensorboard.