### PR TITLE
process_path causes error if called twice

### DIFF
--- a/site/en/tutorials/load_data/images.ipynb
+++ b/site/en/tutorials/load_data/images.ipynb
@@ -751,7 +751,7 @@
       },
       "outputs": [],
       "source": [
-        "def process_path(file_path):\n",
+        "def process_path(file_path, *args, **kwargs):\n",
         "  label = get_label(file_path)\n",
         "  # load the raw data from the file as a string\n",
         "  img = tf.io.read_file(file_path)\n",


### PR DESCRIPTION
The first time I run the cell changed as it is upstream the code works fine
but If i go back and re run the cell in question as it is upstream unchanged
this error shows up, so i added *args, **kwargs


```
TypeError                                 Traceback (most recent call last)

<ipython-input-47-dba8deef1356> in <module>()
      1 # Set `num_parallel_calls` so multiple images are loaded/processed in parallel.
----> 2 train_ds = train_ds.map(process_path, num_parallel_calls=AUTOTUNE)
      3 val_ds = val_ds.map(process_path, num_parallel_calls=AUTOTUNE)

10 frames

/usr/local/lib/python3.6/dist-packages/tensorflow/python/autograph/impl/api.py in wrapper(*args, **kwargs)
    256       except Exception as e:  # pylint:disable=broad-except
    257         if hasattr(e, 'ag_error_metadata'):
--> 258           raise e.ag_error_metadata.to_exception(e)
    259         else:
    260           raise

TypeError: in user code:


    TypeError: tf__process_path() takes 1 positional argument but 2 were given

```

The change when run again results in this error.

```
ValueError                                Traceback (most recent call last)

<ipython-input-39-dba8deef1356> in <module>()
      1 # Set `num_parallel_calls` so multiple images are loaded/processed in parallel.
----> 2 train_ds = train_ds.map(process_path, num_parallel_calls=AUTOTUNE)
      3 val_ds = val_ds.map(process_path, num_parallel_calls=AUTOTUNE)

10 frames

/usr/local/lib/python3.6/dist-packages/tensorflow/python/autograph/impl/api.py in wrapper(*args, **kwargs)
    256       except Exception as e:  # pylint:disable=broad-except
    257         if hasattr(e, 'ag_error_metadata'):
--> 258           raise e.ag_error_metadata.to_exception(e)
    259         else:
    260           raise

ValueError: in user code:

    <ipython-input-38-5c48189a888e>:2 process_path  *
        label = get_label(file_path)
    <ipython-input-24-dfe3c4e7afec>:3 get_label  *
        parts = tf.strings.split(file_path, os.path.sep)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/util/dispatch.py:201 wrapper  **
        return target(*args, **kwargs)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/ops/ragged/ragged_string_ops.py:511 string_split_v2
        input, dtype=dtypes.string, name="input")
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/ops/ragged/ragged_tensor.py:2347 convert_to_tensor_or_ragged_tensor
        value=value, dtype=dtype, preferred_dtype=preferred_dtype, name=name)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/ops.py:1475 convert_to_tensor
        (dtype.name, value.dtype.name, value))

    ValueError: Tensor conversion requested dtype string for Tensor with dtype uint8: <tf.Tensor 'args_0:0' shape=(None, None, None, 3) dtype=uint8>
```

admittedly, this push request could use more eyes.