### PR TITLE
Lint TensorFlow: Migrate your TensorFlow 1 code to TensorFlow 2

### DIFF
--- a/site/en/guide/migrate.ipynb
+++ b/site/en/guide/migrate.ipynb
@@ -37,7 +37,7 @@
         "id": "77z2OchJTk0l"
       },
       "source": [
-        "# Migrate your TensorFlow 1 code to TensorFlow 2\n",
+        "# Migrate your TensorFlow 1.x code to TensorFlow 2.x\n",
         "\n",
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
         "  <td>\n",
@@ -67,7 +67,7 @@
         "id": "meUTrR4I6m1C"
       },
       "source": [
-        "This guide is for users of low-level TensorFlow APIs. If you are using the high-level APIs (`tf.keras`) there may be little or no action you need to take to make your code fully TensorFlow 2.0 compatible: \n",
+        "This guide is for users of low-level TensorFlow APIs. If you are using the high-level APIs (`tf.keras`) there may be little or no action you need to take to make your code fully TensorFlow 2.x compatible: \n",
         " \n",
         "- Check your [optimizer's default learning rate](#keras_optimizer_lr). \n",
         "- Note that the \"name\" that metrics are logged to [may have changed](#keras_metric_names)."
@@ -79,14 +79,14 @@
         "id": "C0V10enS1_WU"
       },
       "source": [
-        "It is still possible to run 1.x code, unmodified ([except for contrib](https://github.com/tensorflow/community/blob/master/rfcs/20180907-contrib-sunset.md)), in TensorFlow 2.0:\n",
+        "It is still possible to run 1.x code, unmodified ([except for contrib](https://github.com/tensorflow/community/blob/master/rfcs/20180907-contrib-sunset.md)), in TensorFlow 2.x:\n",
         "\n",
         "```python\n",
         "import tensorflow.compat.v1 as tf\n",
         "tf.disable_v2_behavior()\n",
         "```\n",
         "\n",
-        "However, this does not let you take advantage of many of the improvements made in TensorFlow 2.0. This guide will help you upgrade your code, making it simpler, more performant, and easier to maintain."
+        "However, this does not let you take advantage of many of the improvements made in TensorFlow 2.x. This guide will help you upgrade your code, making it simpler, more performant, and easier to maintain."
       ]
     },
     {
@@ -99,7 +99,7 @@
         "\n",
         "The first step, before attempting to implement the changes described in this doc, is to try running the [upgrade script](./upgrade.md).\n",
         "\n",
-        "This will execute an initial pass at upgrading your code to TensorFlow 2.0 but it can't make your code idiomatic to 2.0. Your code may still make use of `tf.compat.v1` endpoints to access placeholders, sessions, collections, and other 1.x-style functionality."
+        "This will execute an initial pass at upgrading your code to TensorFlow 2.x but it can't make your code idiomatic to v2. Your code may still make use of `tf.compat.v1` endpoints to access placeholders, sessions, collections, and other 1.x-style functionality."
       ]
     },
     {
@@ -110,7 +110,7 @@
       "source": [
         "## Top-level behavioral changes\n",
         "\n",
-        "If your code works in TensorFlow 2.0 using `tf.compat.v1.disable_v2_behavior`, there are still global behavioral changes you may need to address. The major changes are:"
+        "If your code works in TensorFlow x using `tf.compat.v1.disable_v2_behavior`, there are still global behavioral changes you may need to address. The major changes are:"
       ]
     },
     {
@@ -121,16 +121,16 @@
       "source": [
         "- *Eager execution, `v1.enable_eager_execution()`* : Any code that implicitly uses a `tf.Graph` will fail. Be sure to wrap this code in a `with tf.Graph().as_default()` context. \n",
         "    \n",
-        "- *Resource variables, `v1.enable_resource_variables()`*: Some code may depends on non-deterministic behaviors enabled by TF reference variables. \n",
+        "- *Resource variables, `v1.enable_resource_variables()`*: Some code may depends on non-deterministic behaviors enabled by TensorFlow reference variables. \n",
         "Resource variables are locked while being written to, and so provide more intuitive consistency guarantees.\n",
         "\n",
         "  - This may change behavior in edge cases.\n",
         "  - This may create extra copies and can have higher memory usage.\n",
         "  - This can be disabled by passing `use_resource=False` to the `tf.Variable` constructor.\n",
         "\n",
-        "- *Tensor shapes, `v1.enable_v2_tensorshape()`*: TF 2.0 simplifies the behavior of tensor shapes. Instead of `t.shape[0].value` you can say `t.shape[0]`. These changes should be small, and it makes sense to fix them right away. Refer to the [TensorShape](#tensorshape) section for examples.\n",
+        "- *Tensor shapes, `v1.enable_v2_tensorshape()`*: TensorFlow 2.x simplifies the behavior of tensor shapes. Instead of `t.shape[0].value` you can say `t.shape[0]`. These changes should be small, and it makes sense to fix them right away. Refer to the [TensorShape](#tensorshape) section for examples.\n",
         "\n",
-        "* *Control flow, `v1.enable_control_flow_v2()`*: The TF 2.0 control flow implementation has been simplified, and so produces different graph representations. Please [file bugs](https://github.com/tensorflow/tensorflow/issues) for any issues."
+        "* *Control flow, `v1.enable_control_flow_v2()`*: The TensorFlow 2.x control flow implementation has been simplified, and so produces different graph representations. Please [file bugs](https://github.com/tensorflow/tensorflow/issues) for any issues."
       ]
     },
     {
@@ -139,9 +139,9 @@
         "id": "_Ni9zLLvwcOR"
       },
       "source": [
-        "## Make the code 2.0-native\n",
+        "## Make the code TensorFlow 2.x-native\n",
         "\n",
-        "This guide will walk through several examples of converting TensorFlow 1.x code to TensorFlow 2.0. These changes will let your code take advantage of performance optimizations and simplified API calls.\n",
+        "This guide will walk through several examples of converting TensorFlow 1.x code to TensorFlow 2.x. These changes will let your code take advantage of performance optimizations and simplified API calls.\n",
         "\n",
         "In each case, the pattern is:"
       ]
@@ -179,7 +179,7 @@
       "source": [
         "### 2. Use Python objects to track variables and losses\n",
         "\n",
-        "All name-based variable tracking is strongly discouraged in TF 2.0. Use Python objects to to track variables.\n",
+        "All name-based variable tracking is strongly discouraged in TensorFlow 2.x. Use Python objects to to track variables.\n",
         "\n",
         "Use `tf.Variable` instead of `v1.get_variable`.\n",
         "\n",
@@ -245,9 +245,9 @@
         "\n",
         "The `tf.compat.v1` module contains the complete TensorFlow 1.x API, with its original semantics.\n",
         "\n",
-        "The [TF2 upgrade script](upgrade.ipynb)  will convert symbols to their 2.0 equivalents if such a conversion is safe, i.e., if it can determine that the behavior of the 2.0 version is exactly equivalent (for instance, it will rename `v1.arg_max` to `tf.argmax`, since those are the same function). \n",
+        "The [TensorFlow 2.x upgrade script](upgrade.ipynb)  will convert symbols to their v2 equivalents if such a conversion is safe, i.e., if it can determine that the behavior of the TensorFlow 2.x version is exactly equivalent (for instance, it will rename `v1.arg_max` to `tf.argmax`, since those are the same function). \n",
         "\n",
-        "After the upgrade script is done with a piece of code, it is likely there are many mentions of `compat.v1`. It is worth going through the code and converting these manually to the 2.0 equivalent (it should be mentioned in the log if there is one)."
+        "After the upgrade script is done with a piece of code, it is likely there are many mentions of `compat.v1`. It is worth going through the code and converting these manually to the v2 equivalent (it should be mentioned in the log if there is one)."
       ]
     },
     {
@@ -586,7 +586,7 @@
         "id": "80DEsImmq6VX"
       },
       "source": [
-        "Existing code often mixes lower-level TF 1.x variables and operations with higher-level `v1.layers`."
+        "Existing code often mixes lower-level TensorFlow 1.x variables and operations with higher-level `v1.layers`."
       ]
     },
     {
@@ -752,16 +752,16 @@
       "source": [
         "### A note on Slim and contrib.layers\n",
         "\n",
-        "A large amount of older TensorFlow 1.x code uses the [Slim](https://ai.googleblog.com/2016/08/tf-slim-high-level-library-to-define.html) library, which was packaged with TensorFlow 1.x as `tf.contrib.layers`. As a `contrib` module, this is no longer available in TensorFlow 2.0, even in `tf.compat.v1`. Converting code using Slim to TensorFlow 2.0 is more involved than converting repositories that use `v1.layers`. In fact, it may make sense to convert your Slim code to `v1.layers` first, then convert to Keras.\n",
+        "A large amount of older TensorFlow 1.x code uses the [Slim](https://ai.googleblog.com/2016/08/tf-slim-high-level-library-to-define.html) library, which was packaged with TensorFlow 1.x as `tf.contrib.layers`. As a `contrib` module, this is no longer available in TensorFlow 2.x, even in `tf.compat.v1`. Converting code using Slim to TensorFlow 2.x is more involved than converting repositories that use `v1.layers`. In fact, it may make sense to convert your Slim code to `v1.layers` first, then convert to Keras.\n",
         "\n",
         "- Remove `arg_scopes`, all args need to be explicit.\n",
         "- If you use them, split `normalizer_fn` and `activation_fn` into their own layers.\n",
         "- Separable conv layers map to one or more different Keras layers (depthwise, pointwise, and separable Keras layers).\n",
         "- Slim and `v1.layers` have different argument names and default values.\n",
         "- Some args have different scales.\n",
-        "- If you use Slim pre-trained models, try out Keras's pre-traimed models from `tf.keras.applications` or [TF Hub](https://tfhub.dev/s?q=slim%20tf2)'s TensorFlow 2 SavedModels exported from the original Slim code.\n",
+        "- If you use Slim pre-trained models, try out Keras's pre-traimed models from `tf.keras.applications` or [TF Hub](https://tfhub.dev/s?q=slim%20tf2)'s TensorFlow 2.x SavedModels exported from the original Slim code.\n",
         "\n",
-        "Some `tf.contrib` layers might not have been moved to core TensorFlow but have instead been moved to the [TF add-ons package](https://github.com/tensorflow/addons).\n"
+        "Some `tf.contrib` layers might not have been moved to core TensorFlow but have instead been moved to the [TensorFlow Addons package](https://www.tensorflow.org/addons/overview).\n"
       ]
     },
     {
@@ -1072,7 +1072,7 @@
       "source": [
         "### New-style metrics and losses\n",
         "\n",
-        "In TensorFlow 2.0, metrics and losses are objects. These work both eagerly and in `tf.function`s. \n",
+        "In TensorFlow 2.x, metrics and losses are objects. These work both eagerly and in `tf.function`s. \n",
         "\n",
         "A loss object is callable, and expects the (y_true, y_pred) as arguments:\n"
       ]
@@ -1103,7 +1103,7 @@
         "\n",
         "The object itself is callable. Calling updates the state with new observations, as with `update_state`, and returns the new result of the metric.\n",
         "\n",
-        "You don't have to manually initialize a metric's variables, and because TensorFlow 2.0 has automatic control dependencies, you don't need to worry about those either.\n",
+        "You don't have to manually initialize a metric's variables, and because TensorFlow 2.x has automatic control dependencies, you don't need to worry about those either.\n",
         "\n",
         "The code below uses a metric to keep track of the mean loss observed within a custom training loop."
       ]
@@ -1168,7 +1168,7 @@
         "id": "SKMlNr7OsRdQ"
       },
       "source": [
-        "In TensorFlow 2.0  keras models are more consistent about handling metric names.\n",
+        "In TensorFlow 2.x, Keras models are more consistent about handling metric names.\n",
         "\n",
         "Now when you pass a string in the list of metrics, that _exact_ string is used as the metric's `name`. These names are visible in the history object returned by `model.fit`, and in the logs passed to `keras.callbacks`. is set to the string you passed in the metric list. "
       ]
@@ -1284,7 +1284,7 @@
         "id": "0tx7FyM_RHwJ"
       },
       "source": [
-        "TensorFlow 2 includes significant changes to the `tf.summary` API used to write summary data for visualization in TensorBoard. For a general introduction to the new `tf.summary`, there are [several tutorials available](https://www.tensorflow.org/tensorboard/get_started) that use the TensorFlow 2 API. This includes a [TensorBoard TensorFlow 2 migration guide](https://www.tensorflow.org/tensorboard/migrate)."
+        "TensorFlow 2.x includes significant changes to the `tf.summary` API used to write summary data for visualization in TensorBoard. For a general introduction to the new `tf.summary`, there are [several tutorials available](https://www.tensorflow.org/tensorboard/get_started) that use the TensorFlow 2.x API. This includes a [TensorBoard TensorFlow 2.x migration guide](https://www.tensorflow.org/tensorboard/migrate)."
       ]
     },
     {
@@ -1305,7 +1305,7 @@
         "<a id=\"checkpoints\"></a>\n",
         "### Checkpoint compatibility\n",
         "\n",
-        "TensorFlow 2.0 uses [object-based checkpoints](checkpoint.ipynb).\n",
+        "TensorFlow 2.x uses [object-based checkpoints](checkpoint.ipynb).\n",
         "\n",
         "Old-style name-based checkpoints can still be loaded, if you're careful.\n",
         "The code conversion process may result in variable name changes, but there are workarounds.\n",
@@ -1352,7 +1352,7 @@
         "id": "Tz4eAAGY19MM"
       },
       "source": [
-        "There is no straightforward way to upgrade a raw `Graph.pb` file to TensorFlow 2.0. Your best bet is to upgrade the code that generated the file.\n",
+        "There is no straightforward way to upgrade a raw `Graph.pb` file to TensorFlow 2.x. Your best bet is to upgrade the code that generated the file.\n",
         "\n",
         "But, if you have a \"frozen graph\" (a `tf.Graph` where the variables have been turned into constants), then it is possible to convert this to a [`concrete_function`](https://tensorflow.org/guide/concrete_function) using `v1.wrap_function`:\n"
       ]
@@ -1479,7 +1479,7 @@
       "source": [
         "### Training with Estimators\n",
         "\n",
-        "Estimators are supported in TensorFlow 2.0.\n",
+        "Estimators are supported in TensorFlow 2.x.\n",
         "\n",
         "When you use estimators, you can use `input_fn`, `tf.estimator.TrainSpec`, and `tf.estimator.EvalSpec` from TensorFlow 1.x.\n",
         "\n",
@@ -1542,7 +1542,7 @@
         "id": "IXCQdhGq9SbB"
       },
       "source": [
-        "There are some differences in how to construct your estimators in TensorFlow 2.0.\n",
+        "There are some differences in how to construct your estimators in TensorFlow 2.x.\n",
         "\n",
         "It's recommended that you define your model using Keras, then use the `tf.keras.estimator.model_to_estimator` utility to turn your model into an estimator. The code below shows how to use this utility when creating and training an estimator."
       ]
@@ -1623,7 +1623,7 @@
         "<a name=\"minimal_changes\"></a>\n",
         "\n",
         "#### Custom model_fn with minimal changes\n",
-        "To make your custom `model_fn` work in TF 2.0, if you prefer minimal changes to the existing code, `tf.compat.v1` symbols such as `optimizers` and `metrics` can be used.\n",
+        "To make your custom `model_fn` work in TensorFlow 2.x, if you prefer minimal changes to the existing code, `tf.compat.v1` symbols such as `optimizers` and `metrics` can be used.\n",
         "\n",
         "Using a Keras model in a custom `model_fn` is similar to using it in a custom training loop:\n",
         "\n",
@@ -1691,9 +1691,9 @@
         "id": "XVxHmU2ccfAG"
       },
       "source": [
-        "#### Custom `model_fn` with TF 2.0 symbols\n",
+        "#### Custom `model_fn` with TensorFlow 2.x symbols\n",
         "\n",
-        "If you want to get rid of all TF 1.x symbols and upgrade your custom `model_fn` to native TF 2.0, you need to update the optimizer and metrics to `tf.keras.optimizers` and `tf.keras.metrics`.\n",
+        "If you want to get rid of all TensorFlow 1.x symbols and upgrade your custom `model_fn` to native TensorFlow 2.x, you need to update the optimizer and metrics to `tf.keras.optimizers` and `tf.keras.metrics`.\n",
         "\n",
         "In the custom `model_fn`, besides the above [changes](#minimal_changes), more upgrades need to be made:\n",
         "\n",
@@ -1704,7 +1704,7 @@
         "  - If the loss is a callable (such as a function), use `Optimizer.minimize` to get the `train_op/minimize_op`.\n",
         "- Use `tf.keras.metrics` instead of `tf.compat.v1.metrics` for evaluation.\n",
         "\n",
-        "For the above example of `my_model_fn`, the migrated code with 2.0 symbols is shown as:"
+        "For the above example of `my_model_fn`, the migrated code with TensorFlow 2.x symbols is shown as:"
       ]
     },
     {
@@ -1770,15 +1770,15 @@
       "source": [
         "### Premade Estimators\n",
         "\n",
-        "[Premade Estimators](https://www.tensorflow.org/guide/premade_estimators) in the family of `tf.estimator.DNN*`, `tf.estimator.Linear*` and `tf.estimator.DNNLinearCombined*` are still supported in the TensorFlow 2.0 API. However, some arguments have changed:\n",
+        "[Premade Estimators](https://www.tensorflow.org/guide/premade_estimators) in the family of `tf.estimator.DNN*`, `tf.estimator.Linear*` and `tf.estimator.DNNLinearCombined*` are still supported in the TensorFlow 2.x API. However, some arguments have changed:\n",
         "\n",
-        "1. `input_layer_partitioner`: Removed in 2.0.\n",
+        "1. `input_layer_partitioner`: Removed in v2.\n",
         "2. `loss_reduction`: Updated to `tf.keras.losses.Reduction` instead of `tf.compat.v1.losses.Reduction`. Its default value is also changed to `tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE` from `tf.compat.v1.losses.Reduction.SUM`.\n",
         "3. `optimizer`, `dnn_optimizer` and `linear_optimizer`: this argument has been updated to `tf.keras.optimizers` instead of the `tf.compat.v1.train.Optimizer`. \n",
         "\n",
         "To migrate the above changes:\n",
         "\n",
-        "1. No migration is needed for `input_layer_partitioner` since [`Distribution Strategy`](https://www.tensorflow.org/guide/distributed_training) will handle it automatically in TF 2.0.\n",
+        "1. No migration is needed for `input_layer_partitioner` since [`Distribution Strategy`](https://www.tensorflow.org/guide/distributed_training) will handle it automatically in TensorFlow 2.x.\n",
         "2. For `loss_reduction`, check `tf.keras.losses.Reduction` for the supported options.\n",
         "3. For `optimizer` arguments: \n",
         "    - If you do not: 1) pass in the `optimizer`, `dnn_optimizer` or `linear_optimizer` argument, or 2) specify the `optimizer` argument as a `string` in your code, then you don't need to change anything because `tf.keras.optimizers` is used by default. \n",
@@ -1794,7 +1794,7 @@
         "#### Checkpoint Converter\n",
         "<a id=\"checkpoint_converter\"></a>\n",
         "\n",
-        "The migration to `keras.optimizers` will break checkpoints saved using TF 1.x, as `tf.keras.optimizers` generates a different set of variables to be saved in checkpoints. To make old checkpoint reusable after your migration to TF 2.0, try the [checkpoint converter tool](https://github.com/tensorflow/estimator/blob/master/tensorflow_estimator/python/estimator/tools/checkpoint_converter.py)."
+        "The migration to `keras.optimizers` will break checkpoints saved using TensorFlow 1.x, as `tf.keras.optimizers` generates a different set of variables to be saved in checkpoints. To make old checkpoint reusable after your migration to TensorFlow 2.x, try the [checkpoint converter tool](https://github.com/tensorflow/estimator/blob/master/tensorflow_estimator/python/estimator/tools/checkpoint_converter.py)."
       ]
     },
     {
@@ -1849,7 +1849,7 @@
         "id": "x36cWcmM8Eu1"
       },
       "source": [
-        "The following demonstrate the differences between TensorFlow 1.x and TensorFlow 2.0."
+        "The following demonstrate the differences between TensorFlow 1.x and TensorFlow 2.x."
       ]
     },
     {
@@ -1872,13 +1872,13 @@
         "id": "kDFck03neNy0"
       },
       "source": [
-        "If you had this in TF 1.x:\n",
+        "If you had this in TensorFlow 1.x:\n",
         "\n",
         "```python\n",
         "value = shape[i].value\n",
         "```\n",
         "\n",
-        "Then do this in TF 2.0:\n"
+        "Then do this in TensorFlow 2.x:\n"
       ]
     },
     {
@@ -1899,7 +1899,7 @@
         "id": "bPWPNKRiZmkd"
       },
       "source": [
-        "If you had this in TF 1.x:\n",
+        "If you had this in TensorFlow 1.x:\n",
         "\n",
         "```python\n",
         "for dim in shape:\n",
@@ -1907,7 +1907,7 @@
         "    print(value)\n",
         "```\n",
         "\n",
-        "Then do this in TF 2.0:"
+        "Then do this in TensorFlow 2.x:"
       ]
     },
     {
@@ -1928,14 +1928,14 @@
         "id": "YpRgngu3Zw-A"
       },
       "source": [
-        "If you had this in TF 1.x (Or used any other dimension method):\n",
+        "If you had this in TensorFlow 1.x (or used any other dimension method):\n",
         "\n",
         "```python\n",
         "dim = shape[i]\n",
         "dim.assert_is_compatible_with(other_dim)\n",
         "```\n",
         "\n",
-        "Then do this in TF 2.0:"
+        "Then do this in TensorFlow 2.x:"
       ]
     },
     {
@@ -2027,7 +2027,7 @@
         "4. Use `tf.keras` or `tf.estimator` training and evaluation loops where you can.\n",
         "5. Otherwise, use custom loops, but be sure to avoid sessions & collections.\n",
         "\n",
-        "It takes a little work to convert code to idiomatic TensorFlow 2.0, but every change results in:\n",
+        "It takes a little work to convert code to idiomatic TensorFlow 2.x, but every change results in:\n",
         "\n",
         "- Fewer lines of code.\n",
         "- Increased clarity and simplicity.\n",

--- a/site/en/guide/migrate.ipynb
+++ b/site/en/guide/migrate.ipynb
@@ -139,7 +139,7 @@
         "id": "_Ni9zLLvwcOR"
       },
       "source": [
-        "## Make the code for TensorFlow 2.x\n",
+        "## Create code for TensorFlow 2.x\n",
         "\n",
         "This guide will walk through several examples of converting TensorFlow 1.x code to TensorFlow 2.x. These changes will let your code take advantage of performance optimizations and simplified API calls.\n",
         "\n",

--- a/site/en/guide/migrate.ipynb
+++ b/site/en/guide/migrate.ipynb
@@ -67,12 +67,10 @@
         "id": "meUTrR4I6m1C"
       },
       "source": [
-        "This doc for users of low level TensorFlow APIs. If you are using \n",
-        "the high level APIs (`tf.keras`) there may be little or no action\n",
-        "you need to take to make your code fully TensorFlow 2.0 compatible: \n",
+        "This guide is for users of low-level TensorFlow APIs. If you are using the high-level APIs (`tf.keras`) there may be little or no action you need to take to make your code fully TensorFlow 2.0 compatible: \n",
         " \n",
-        "* Check your [optimizer's default learning rate](#keras_optimizer_lr). \n",
-        "* Note that the \"name\" that metrics are logged to [may have changed](#keras_metric_names)."
+        "- Check your [optimizer's default learning rate](#keras_optimizer_lr). \n",
+        "- Note that the \"name\" that metrics are logged to [may have changed](#keras_metric_names)."
       ]
     },
     {
@@ -81,9 +79,9 @@
         "id": "C0V10enS1_WU"
       },
       "source": [
-        "It is still possible to run 1.X code, unmodified ([except for contrib](https://github.com/tensorflow/community/blob/master/rfcs/20180907-contrib-sunset.md)), in TensorFlow 2.0:\n",
+        "It is still possible to run 1.x code, unmodified ([except for contrib](https://github.com/tensorflow/community/blob/master/rfcs/20180907-contrib-sunset.md)), in TensorFlow 2.0:\n",
         "\n",
-        "```\n",
+        "```python\n",
         "import tensorflow.compat.v1 as tf\n",
         "tf.disable_v2_behavior()\n",
         "```\n",
@@ -99,9 +97,9 @@
       "source": [
         "## Automatic conversion script\n",
         "\n",
-        "The first step, before attempting to implement the changes described in this doc,  is to try running the [upgrade script](./upgrade.md).\n",
+        "The first step, before attempting to implement the changes described in this doc, is to try running the [upgrade script](./upgrade.md).\n",
         "\n",
-        "This will do an initial pass at upgrading your code to TensorFlow 2.0. But it can't make your code idiomatic to  2.0. Your code may still make use of `tf.compat.v1` endpoints to access placeholders, sessions, collections, and other 1.x-style functionality."
+        "This will execute an initial pass at upgrading your code to TensorFlow 2.0 but it can't make your code idiomatic to 2.0. Your code may still make use of `tf.compat.v1` endpoints to access placeholders, sessions, collections, and other 1.x-style functionality."
       ]
     },
     {
@@ -112,7 +110,7 @@
       "source": [
         "## Top-level behavioral changes\n",
         "\n",
-        "If your code works in TensorFlow 2.0 using `tf.compat.v1.disable_v2_behavior()`, there are still global behavioral changes you may need to address. The major changes are:"
+        "If your code works in TensorFlow 2.0 using `tf.compat.v1.disable_v2_behavior`, there are still global behavioral changes you may need to address. The major changes are:"
       ]
     },
     {
@@ -121,16 +119,16 @@
         "id": "1y-W0Mz_zB6Y"
       },
       "source": [
-        "* *Eager execution, `v1.enable_eager_execution()`* : Any code that implicitly uses a `tf.Graph` will fail. Be sure to wrap this code in a `with tf.Graph().as_default()` context. \n",
+        "- *Eager execution, `v1.enable_eager_execution()`* : Any code that implicitly uses a `tf.Graph` will fail. Be sure to wrap this code in a `with tf.Graph().as_default()` context. \n",
         "    \n",
-        "* *Resource variables, `v1.enable_resource_variables()`*: Some code may depends on non-deterministic behaviors enabled by TF reference variables. \n",
+        "- *Resource variables, `v1.enable_resource_variables()`*: Some code may depends on non-deterministic behaviors enabled by TF reference variables. \n",
         "Resource variables are locked while being written to, and so provide more intuitive consistency guarantees.\n",
         "\n",
-        "  * This may change behavior in edge cases.\n",
-        "  * This may create extra copies and can have higher memory usage.\n",
-        "  * This can be disabled by passing `use_resource=False` to the `tf.Variable` constructor.\n",
+        "  - This may change behavior in edge cases.\n",
+        "  - This may create extra copies and can have higher memory usage.\n",
+        "  - This can be disabled by passing `use_resource=False` to the `tf.Variable` constructor.\n",
         "\n",
-        "* *Tensor shapes, `v1.enable_v2_tensorshape()`*: TF 2.0 simplifies the behavior of tensor shapes. Instead of `t.shape[0].value` you can say `t.shape[0]`. These changes should be small, and it makes sense to fix them right away. See [TensorShape](#tensorshape) for examples.\n",
+        "- *Tensor shapes, `v1.enable_v2_tensorshape()`*: TF 2.0 simplifies the behavior of tensor shapes. Instead of `t.shape[0].value` you can say `t.shape[0]`. These changes should be small, and it makes sense to fix them right away. Refer to the [TensorShape](#tensorshape) section for examples.\n",
         "\n",
         "* *Control flow, `v1.enable_control_flow_v2()`*: The TF 2.0 control flow implementation has been simplified, and so produces different graph representations. Please [file bugs](https://github.com/tensorflow/tensorflow/issues) for any issues."
       ]
@@ -142,7 +140,6 @@
       },
       "source": [
         "## Make the code 2.0-native\n",
-        "\n",
         "\n",
         "This guide will walk through several examples of converting TensorFlow 1.x code to TensorFlow 2.0. These changes will let your code take advantage of performance optimizations and simplified API calls.\n",
         "\n",
@@ -159,17 +156,17 @@
         "\n",
         "Every `v1.Session.run` call should be replaced by a Python function.\n",
         "\n",
-        "* The `feed_dict` and `v1.placeholder`s become function arguments.\n",
-        "* The `fetches` become the function's return value. \n",
-        "* During conversion eager execution allows easy debugging with standard Python tools like `pdb`.\n",
+        "- The `feed_dict` and `v1.placeholder`s become function arguments.\n",
+        "- The `fetches` become the function's return value. \n",
+        "- During conversion eager execution allows easy debugging with standard Python tools like `pdb`.\n",
         "\n",
-        "After that add a `tf.function` decorator to make it run efficiently in graph. See the [Autograph Guide](function.ipynb) for more on how this works.\n",
+        "After that, add a `tf.function` decorator to make it run efficiently in graph. Check out the [Autograph guide](function.ipynb) for more information about how this works.\n",
         "\n",
         "Note that:\n",
         "\n",
-        "* Unlike `v1.Session.run` a `tf.function` has a fixed return signature, and always returns all outputs. If this causes performance problems, create two separate functions.\n",
+        "- Unlike `v1.Session.run`, a `tf.function` has a fixed return signature and always returns all outputs. If this causes performance problems, create two separate functions.\n",
         "\n",
-        "* There is no need for a `tf.control_dependencies` or similar operations: A `tf.function` behaves as if it were run in the order written. `tf.Variable` assignments and `tf.assert`s, for example, are executed automatically.\n",
+        "- There is no need for a `tf.control_dependencies` or similar operations: A `tf.function` behaves as if it were run in the order written. `tf.Variable` assignments and `tf.assert`s, for example, are executed automatically.\n",
         "\n",
         "The [converting models section](#converting_models) contains a working example of this conversion process.\n"
       ]
@@ -196,9 +193,9 @@
         "\n",
         "These `Layer` and `Model` classes implement several other properties that remove the need for global collections. Their `.losses` property can be a replacement for using the `tf.GraphKeys.LOSSES` collection.\n",
         "\n",
-        "See the [keras guides](keras.ipynb) for details.\n",
+        "Refer to the [Keras guides](keras.ipynb) for more details.\n",
         "\n",
-        "Warning: Many `tf.compat.v1` symbols  use the global collections implicitly.\n"
+        "Warning: Many `tf.compat.v1` symbols use the global collections implicitly.\n"
       ]
     },
     {
@@ -209,7 +206,7 @@
       "source": [
         "### 3. Upgrade your training loops\n",
         "\n",
-        "Use the highest level API that works for your use case.  Prefer `tf.keras.Model.fit` over building your own training loops.\n",
+        "Use the highest-level API that works for your use case. Prefer `tf.keras.Model.fit` over building your own training loops.\n",
         "\n",
         "These high level functions manage a lot of the low-level details that might be easy to miss if you write your own training loop. For example, they automatically collect the regularization losses, and set the `training=True` argument when calling the model.\n"
       ]
@@ -226,13 +223,13 @@
         "\n",
         "They can be passed directly to the `tf.keras.Model.fit` method.\n",
         "\n",
-        "```\n",
+        "```python\n",
         "model.fit(dataset, epochs=5)\n",
         "```\n",
         "\n",
         "They can be iterated over directly standard Python:\n",
         "\n",
-        "```\n",
+        "```python\n",
         "for example_batch, label_batch in dataset:\n",
         "    break\n",
         "```\n"
@@ -272,17 +269,17 @@
         "\n",
         "Examples of low-level API use include:\n",
         "\n",
-        "* using variable scopes to control reuse\n",
-        "* creating variables with `v1.get_variable`.\n",
-        "* accessing collections explicitly\n",
-        "* accessing collections implicitly with methods like :\n",
+        "- Using variable scopes to control reuse.\n",
+        "- Creating variables with `v1.get_variable`.\n",
+        "- Accessing collections explicitly.\n",
+        "- Accessing collections implicitly with methods like:\n",
         "\n",
-        "  * `v1.global_variables`\n",
-        "  * `v1.losses.get_regularization_loss`\n",
+        "  - `v1.global_variables`\n",
+        "  - `v1.losses.get_regularization_loss`\n",
         "\n",
-        "* using `v1.placeholder` to set up graph inputs\n",
-        "* executing graphs with `Session.run`\n",
-        "* initializing variables manually\n"
+        "- Using `v1.placeholder` to set up graph inputs.\n",
+        "- Executing graphs with `Session.run`.\n",
+        "- Initializing variables manually."
       ]
     },
     {
@@ -364,12 +361,12 @@
       "source": [
         "In the converted code:\n",
         "\n",
-        "* The variables are local Python objects.\n",
-        "* The `forward` function still defines the calculation.\n",
-        "* The `Session.run` call is replaced with a call to `forward`\n",
-        "* The optional `tf.function` decorator can be added for performance.\n",
-        "* The regularizations are calculated manually, without referring to any global collection.\n",
-        "* **No sessions or placeholders.**"
+        "- The variables are local Python objects.\n",
+        "- The `forward` function still defines the calculation.\n",
+        "- The `Session.run` call is replaced with a call to `forward`.\n",
+        "- The optional `tf.function` decorator can be added for performance.\n",
+        "- The regularizations are calculated manually, without referring to any global collection.\n",
+        "- **No sessions or placeholders**."
       ]
     },
     {
@@ -487,20 +484,19 @@
         "id": "BsAseSMfB9XN"
       },
       "source": [
-        "* The simple stack of layers fits neatly into `tf.keras.Sequential`. (For more complex models see [custom layers and models](keras/custom_layers_and_models.ipynb), and [the functional API](keras/functional.ipynb).)\n",
-        "* The model tracks the variables, and regularization losses.\n",
-        "* The conversion was one-to-one because there is a direct mapping from `v1.layers` to `tf.keras.layers`.\n",
+        "- The simple stack of layers fits neatly into `tf.keras.Sequential`. (For more complex models, check out the [custom layers and models](keras/custom_layers_and_models.ipynb) and [the functional API](keras/functional.ipynb) guides.)\n",
+        "- The model tracks the variables, and regularization losses.\n",
+        "- The conversion was one-to-one because there is a direct mapping from `v1.layers` to `tf.keras.layers`.\n",
         "\n",
         "Most arguments stayed the same. But notice the differences:\n",
         "\n",
-        "* The `training` argument is passed to each layer by the model when it runs.\n",
-        "* The first argument to the original `model` function (the input `x`) is gone. This is because object layers separate building the model from calling the model.\n",
-        "\n",
+        "- The `training` argument is passed to each layer by the model when it runs.\n",
+        "- The first argument to the original `model` function (the input `x`) is gone. This is because object layers separate building the model from calling the model.\n",
         "\n",
         "Also note that:\n",
         "\n",
-        "* If you were using regularizers of initializers from  `tf.contrib`, these have more argument changes than others.\n",
-        "* The code no longer writes to collections, so functions like `v1.losses.get_regularization_loss` will no longer return these values, potentially breaking your training loops."
+        "- If you were using regularizers of initializers from `tf.contrib`, these have more argument changes than others.\n",
+        "- The code no longer writes to collections, so functions like `v1.losses.get_regularization_loss` will no longer return these values, potentially breaking your training loops."
       ]
     },
     {
@@ -559,7 +555,7 @@
       },
       "outputs": [],
       "source": [
-        "# Here are all the trainable variables.\n",
+        "# Here are all the trainable variables\n",
         "len(model.trainable_variables)"
       ]
     },
@@ -571,7 +567,7 @@
       },
       "outputs": [],
       "source": [
-        "# Here is the regularization loss.\n",
+        "# Here is the regularization loss\n",
         "model.losses"
       ]
     },
@@ -653,7 +649,7 @@
         "* Build the variables in `build`.\n",
         "* Execute the calculations in `call`, and return the result.\n",
         "\n",
-        "The `v1.variable_scope` is essentially a layer of its own. So rewrite it as a `tf.keras.layers.Layer`. See [the guide](keras/custom_layers_and_models.ipynb) for details."
+        "The `v1.variable_scope` is essentially a layer of its own. So rewrite it as a `tf.keras.layers.Layer`. Check out the [Making new Layers and Models via subclassing guide](keras/custom_layers_and_models.ipynb) for details."
       ]
     },
     {
@@ -731,21 +727,21 @@
       "source": [
         "Some things to note:\n",
         "\n",
-        "* Subclassed Keras models & layers need to run in both v1 graphs (no automatic control dependencies) and in eager mode\n",
-        "  * Wrap the `call()` in a `tf.function()` to get autograph and automatic control dependencies\n",
+        "- Subclassed Keras models and layers need to run in both v1 graphs (no automatic control dependencies) and in eager mode:\n",
+        "  - Wrap the `call` in a `tf.function` to get autograph and automatic control dependencies.\n",
         "\n",
-        "* Don't forget to accept a `training` argument to `call`.\n",
-        "    * Sometimes it is a `tf.Tensor`\n",
-        "    * Sometimes it is a Python boolean.\n",
+        "- Don't forget to accept a `training` argument to `call`:\n",
+        "    - Sometimes it is a `tf.Tensor`\n",
+        "    - Sometimes it is a Python boolean\n",
         "\n",
-        "* Create model variables in constructor or `Model.build` using `self.add_weight()`.\n",
-        "  * In `Model.build` you have access to the input shape, so can create weights with matching shape.\n",
-        "  * Using `tf.keras.layers.Layer.add_weight` allows Keras to track variables and regularization losses.\n",
+        "- Create model variables in constructor or `Model.build` using `self.add_weight:\n",
+        "  - In `Model.build` you have access to the input shape, so can create weights with matching shape\n",
+        "  - Using `tf.keras.layers.Layer.add_weight` allows Keras to track variables and regularization losses\n",
         "\n",
-        "* Don't keep `tf.Tensors` in your objects.\n",
-        "  * They might get created either in a `tf.function` or in the eager context, and these tensors behave differently.\n",
-        "  * Use `tf.Variable`s for state, they are always usable from both contexts\n",
-        "  * `tf.Tensors` are only for intermediate values."
+        "- Don't keep `tf.Tensors` in your objects:\n",
+        "  - They might get created either in a `tf.function` or in the eager context, and these tensors behave differently\n",
+        "  - Use `tf.Variable`s for state, they are always usable from both contexts\n",
+        "  - `tf.Tensors` are only for intermediate values"
       ]
     },
     {
@@ -754,16 +750,16 @@
         "id": "ulaB1ymO4pw5"
       },
       "source": [
-        "### A note on Slim & contrib.layers\n",
+        "### A note on Slim and contrib.layers\n",
         "\n",
-        "A large amount of older TensorFlow 1.x code uses the [Slim](https://ai.googleblog.com/2016/08/tf-slim-high-level-library-to-define.html) library, which was packaged with TensorFlow 1.x as `tf.contrib.layers`. As a `contrib` module, this is no longer available in TensorFlow 2.0, even in `tf.compat.v1`. Converting code using Slim to TF 2.0 is more involved than converting repositories that use `v1.layers`. In fact, it may make sense to convert your Slim code to `v1.layers` first, then convert to Keras.\n",
+        "A large amount of older TensorFlow 1.x code uses the [Slim](https://ai.googleblog.com/2016/08/tf-slim-high-level-library-to-define.html) library, which was packaged with TensorFlow 1.x as `tf.contrib.layers`. As a `contrib` module, this is no longer available in TensorFlow 2.0, even in `tf.compat.v1`. Converting code using Slim to TensorFlow 2.0 is more involved than converting repositories that use `v1.layers`. In fact, it may make sense to convert your Slim code to `v1.layers` first, then convert to Keras.\n",
         "\n",
-        "* Remove `arg_scopes`, all args need to be explicit\n",
-        "* If you use them, split `normalizer_fn` and `activation_fn` into their own layers\n",
-        "* Separable conv layers map to one or more different Keras layers (depthwise, pointwise, and separable Keras layers)\n",
-        "* Slim and `v1.layers` have different arg names & default values\n",
-        "* Some args have different scales\n",
-        "* If you use Slim pre-trained models, try out Keras's pre-traimed models from `tf.keras.applications` or [TF Hub](https://tfhub.dev/s?q=slim%20tf2)'s TF2 SavedModels exported from the original Slim code.\n",
+        "- Remove `arg_scopes`, all args need to be explicit.\n",
+        "- If you use them, split `normalizer_fn` and `activation_fn` into their own layers.\n",
+        "- Separable conv layers map to one or more different Keras layers (depthwise, pointwise, and separable Keras layers).\n",
+        "- Slim and `v1.layers` have different argument names and default values.\n",
+        "- Some args have different scales.\n",
+        "- If you use Slim pre-trained models, try out Keras's pre-traimed models from `tf.keras.applications` or [TF Hub](https://tfhub.dev/s?q=slim%20tf2)'s TensorFlow 2 SavedModels exported from the original Slim code.\n",
         "\n",
         "Some `tf.contrib` layers might not have been moved to core TensorFlow but have instead been moved to the [TF add-ons package](https://github.com/tensorflow/addons).\n"
       ]
@@ -796,7 +792,7 @@
         "id": "m6htasZ7iBB4"
       },
       "source": [
-        "### Using Datasets"
+        "### Using TensorFlow Datasets"
       ]
     },
     {
@@ -807,7 +803,7 @@
       "source": [
         "The [TensorFlow Datasets](https://tensorflow.org/datasets) package (`tfds`) contains utilities for loading predefined datasets as `tf.data.Dataset` objects.\n",
         "\n",
-        "For this example, load the MNISTdataset, using `tfds`:"
+        "For this example, you can load the MNIST dataset using `tfds`:"
       ]
     },
     {
@@ -830,9 +826,9 @@
       "source": [
         "Then prepare the data for training:\n",
         "\n",
-        "  * Re-scale each image.\n",
-        "  * Shuffle the order of the examples.\n",
-        "  * Collect batches of images and labels.\n"
+        "  - Re-scale each image.\n",
+        "  - Shuffle the order of the examples.\n",
+        "  - Collect batches of images and labels.\n"
       ]
     },
     {
@@ -843,7 +839,7 @@
       },
       "outputs": [],
       "source": [
-        "BUFFER_SIZE = 10 # Use a much larger value for real code.\n",
+        "BUFFER_SIZE = 10 # Use a much larger value for real code\n",
         "BATCH_SIZE = 64\n",
         "NUM_EPOCHS = 5\n",
         "\n",
@@ -900,18 +896,18 @@
       "source": [
         "### Use Keras training loops\n",
         "\n",
-        "If you don't need low level control of your training process, using Keras's built-in `fit`, `evaluate`, and `predict` methods is recommended. These methods provide a uniform interface to train the model regardless of the implementation (sequential,  functional, or sub-classed).\n",
+        "If you don't need low-level control of your training process, using Keras's built-in `fit`, `evaluate`, and `predict` methods is recommended. These methods provide a uniform interface to train the model regardless of the implementation (sequential,  functional, or sub-classed).\n",
         "\n",
         "The advantages of these methods include:\n",
         "\n",
-        "* They accept Numpy arrays, Python generators and, `tf.data.Datasets`\n",
-        "* They apply regularization, and activation losses automatically.\n",
-        "* They support `tf.distribute` [for multi-device training](distributed_training.ipynb).\n",
-        "* They support arbitrary callables as losses and metrics.\n",
-        "* They support callbacks like `tf.keras.callbacks.TensorBoard`, and custom callbacks.\n",
-        "* They are performant, automatically using TensorFlow graphs.\n",
+        "- They accept Numpy arrays, Python generators and, `tf.data.Datasets`.\n",
+        "- They apply regularization, and activation losses automatically.\n",
+        "- They support `tf.distribute` [for multi-device training](distributed_training.ipynb).\n",
+        "- They support arbitrary callables as losses and metrics.\n",
+        "- They support callbacks like `tf.keras.callbacks.TensorBoard`, and custom callbacks.\n",
+        "- They are performant, automatically using TensorFlow graphs.\n",
         "\n",
-        "Here is an example of training a model using a `Dataset`. (For details on how this works see [tutorials](../tutorials).)"
+        "Here is an example of training a model using a `Dataset`. (For details on how this works, check out the [tutorials](../tutorials) section.)"
       ]
     },
     {
@@ -961,7 +957,7 @@
         "\n",
         "You can also use `tf.keras.Model.test_on_batch` or `tf.keras.Model.evaluate` to check performance during training.\n",
         "\n",
-        "Note: `train_on_batch` and `test_on_batch`, by default return the loss and metrics for the single batch. If you pass `reset_metrics=False` they return accumulated metrics and you must remember to appropriately reset the metric accumulators. Also remember that some metrics like `AUC` require `reset_metrics=False` to be calculated correctly.\n",
+        "Note: `train_on_batch` and `test_on_batch` by default return the loss and metrics for the single batch. If you pass `reset_metrics=False`, they return accumulated metrics and you must remember to appropriately reset the metric accumulators. Also, remember that some metrics like `AUC` require `reset_metrics=False` to be calculated correctly.\n",
         "\n",
         "To continue training the above model:\n"
       ]
@@ -980,7 +976,7 @@
         "              metrics=['accuracy'])\n",
         "\n",
         "for epoch in range(NUM_EPOCHS):\n",
-        "  #Reset the metric accumulators\n",
+        "  # Reset the metric accumulators\n",
         "  model.reset_metrics()\n",
         "\n",
         "  for image_batch, label_batch in train_data:\n",
@@ -991,7 +987,7 @@
         "          \"{}: {:.3f}\".format(metrics_names[1], result[1]))\n",
         "  for image_batch, label_batch in test_data:\n",
         "    result = model.test_on_batch(image_batch, label_batch,\n",
-        "                                 # return accumulated metrics\n",
+        "                                 # Return accumulated metrics\n",
         "                                 reset_metrics=False)\n",
         "  metrics_names = model.metrics_names\n",
         "  print(\"\\neval: \",\n",
@@ -1017,15 +1013,15 @@
         "\n",
         "Remember:\n",
         "\n",
-        "* Always include a `training` argument on the `call` method of subclassed layers and models.\n",
-        "* Make sure to call the model with the `training` argument set correctly.\n",
-        "* Depending on usage, model variables may not exist until the model is run on a batch of data.\n",
-        "* You need to manually handle things like regularization losses for the model.\n",
+        "- Always include a `training` argument on the `call` method of subclassed layers and models.\n",
+        "- Make sure to call the model with the `training` argument set correctly.\n",
+        "- Depending on usage, model variables may not exist until the model is run on a batch of data.\n",
+        "- You need to manually handle things like regularization losses for the model.\n",
         "\n",
         "Note the simplifications relative to v1:\n",
         "\n",
-        "* There is no need to run variable initializers. Variables are initialized on creation.\n",
-        "* There is no need to add manual control dependencies. Even in `tf.function` operations act as in eager mode."
+        "- There is no need to run variable initializers. Variables are initialized on creation.\n",
+        "- There is no need to add manual control dependencies. Even in `tf.function` operations act as in eager mode."
       ]
     },
     {
@@ -1101,9 +1097,9 @@
       "source": [
         "A metric object has the following methods:\n",
         "\n",
-        "* `Metric.update_state()` — add new observations\n",
-        "* `Metric.result()` —get the current result of the metric, given the observed values\n",
-        "* `Metric.reset_states()` — clear all observations.\n",
+        "- `Metric.update_state()`: add new observations.\n",
+        "- `Metric.result()`: get the current result of the metric, given the observed values.\n",
+        "- `Metric.reset_states()`: clear all observations.\n",
         "\n",
         "The object itself is callable. Calling updates the state with new observations, as with `update_state`, and returns the new result of the metric.\n",
         "\n",
@@ -1227,7 +1223,7 @@
         "id": "A6El-NxAQ8aF"
       },
       "source": [
-        "The optimizers in `v1.train`, like `v1.train.AdamOptimizer` and `v1.train.GradientDescentOptimizer`, have equivalents in `tf.keras.optimizers`."
+        "The optimizers in `v1.train`, such as `v1.train.AdamOptimizer` and `v1.train.GradientDescentOptimizer`, have equivalents in `tf.keras.optimizers`."
       ]
     },
     {
@@ -1240,16 +1236,16 @@
         "\n",
         "Here are things to keep in mind when converting your optimizers:\n",
         "\n",
-        "* Upgrading your optimizers [may make old checkpoints incompatible](#checkpoints).\n",
-        "* All epsilons now default to `1e-7` instead of `1e-8` (which is negligible in most use cases).\n",
-        "* `v1.train.GradientDescentOptimizer` can be directly replaced by `tf.keras.optimizers.SGD`. \n",
-        "* `v1.train.MomentumOptimizer` can be directly replaced by the `SGD` optimizer using the momentum argument: `tf.keras.optimizers.SGD(..., momentum=...)`.\n",
-        "* `v1.train.AdamOptimizer` can be converted to use `tf.keras.optimizers.Adam`. The `beta1` and `beta2` arguments have been renamed to `beta_1` and `beta_2`.\n",
-        "* `v1.train.RMSPropOptimizer` can be converted to `tf.keras.optimizers.RMSprop`. The `decay` argument has been renamed to `rho`.\n",
-        "* `v1.train.AdadeltaOptimizer` can be converted directly to `tf.keras.optimizers.Adadelta`.\n",
-        "* `tf.train.AdagradOptimizer` can be converted directly to `tf.keras.optimizers.Adagrad`.\n",
-        "* `tf.train.FtrlOptimizer` can be converted directly to `tf.keras.optimizers.Ftrl`. The `accum_name` and `linear_name` arguments have been removed.\n",
-        "* The `tf.contrib.AdamaxOptimizer` and `tf.contrib.NadamOptimizer`, can be converted directly to `tf.keras.optimizers.Adamax` and `tf.keras.optimizers.Nadam`. The `beta1`, and `beta2` arguments have been renamed to `beta_1` and `beta_2`.\n"
+        "- Upgrading your optimizers [may make old checkpoints incompatible](#checkpoints).\n",
+        "- All epsilons now default to `1e-7` instead of `1e-8` (which is negligible in most use cases).\n",
+        "- `v1.train.GradientDescentOptimizer` can be directly replaced by `tf.keras.optimizers.SGD`. \n",
+        "- `v1.train.MomentumOptimizer` can be directly replaced by the `SGD` optimizer using the momentum argument: `tf.keras.optimizers.SGD(..., momentum=...)`.\n",
+        "- `v1.train.AdamOptimizer` can be converted to use `tf.keras.optimizers.Adam`. The `beta1` and `beta2` arguments have been renamed to `beta_1` and `beta_2`.\n",
+        "- `v1.train.RMSPropOptimizer` can be converted to `tf.keras.optimizers.RMSprop`. The `decay` argument has been renamed to `rho`.\n",
+        "- `v1.train.AdadeltaOptimizer` can be converted directly to `tf.keras.optimizers.Adadelta`.\n",
+        "- `tf.train.AdagradOptimizer` can be converted directly to `tf.keras.optimizers.Adagrad`.\n",
+        "- `tf.train.FtrlOptimizer` can be converted directly to `tf.keras.optimizers.Ftrl`. The `accum_name` and `linear_name` arguments have been removed.\n",
+        "- `tf.contrib.AdamaxOptimizer` and `tf.contrib.NadamOptimizer` can be converted directly to `tf.keras.optimizers.Adamax` and `tf.keras.optimizers.Nadam`, respectively. The `beta1`, and `beta2` arguments have been renamed to `beta_1` and `beta_2`.\n"
       ]
     },
     {
@@ -1267,10 +1263,10 @@
         "\n",
         "The following default learning rates have changed:\n",
         "\n",
-        "* `optimizers.Adagrad` from 0.01 to 0.001\n",
-        "* `optimizers.Adadelta` from 1.0 to 0.001\n",
-        "* `optimizers.Adamax` from 0.002 to 0.001\n",
-        "* `optimizers.Nadam` from 0.002 to 0.001"
+        "- `optimizers.Adagrad` from 0.01 to 0.001\n",
+        "- `optimizers.Adadelta` from 1.0 to 0.001\n",
+        "- `optimizers.Adamax` from 0.002 to 0.001\n",
+        "- `optimizers.Nadam` from 0.002 to 0.001"
       ]
     },
     {
@@ -1288,7 +1284,7 @@
         "id": "0tx7FyM_RHwJ"
       },
       "source": [
-        "TensorFlow 2 includes significant changes to the `tf.summary` API used to write summary data for visualization in TensorBoard.  For a general introduction to the new `tf.summary`, there are [several tutorials available](https://www.tensorflow.org/tensorboard/get_started) that use the TF 2 API. This includes a [TensorBoard TF 2 Migration Guide](https://www.tensorflow.org/tensorboard/migrate)"
+        "TensorFlow 2 includes significant changes to the `tf.summary` API used to write summary data for visualization in TensorBoard. For a general introduction to the new `tf.summary`, there are [several tutorials available](https://www.tensorflow.org/tensorboard/get_started) that use the TensorFlow 2 API. This includes a [TensorBoard TensorFlow 2 migration guide](https://www.tensorflow.org/tensorboard/migrate)."
       ]
     },
     {
@@ -1297,7 +1293,7 @@
         "id": "JmMLBKs66DeA"
       },
       "source": [
-        "## Saving & Loading\n"
+        "## Saving and loading\n"
       ]
     },
     {
@@ -1316,15 +1312,15 @@
         "\n",
         "The simplest approach it to line up the names of the new model with the names in the checkpoint:\n",
         "\n",
-        "* Variables still all have a `name` argument you can set.\n",
-        "* Keras models also take a `name` argument as which they set as the prefix for their variables.\n",
-        "* The `v1.name_scope` function can be used to set variable name prefixes. This is very different from `tf.variable_scope`. It only affects names, and  doesn't track variables & reuse.\n",
+        "- Variables still all have a `name` argument you can set.\n",
+        "- Keras models also take a `name` argument as which they set as the prefix for their variables.\n",
+        "- The `v1.name_scope` function can be used to set variable name prefixes. This is very different from `tf.variable_scope`. It only affects names, and doesn't track variables and reuse.\n",
         "\n",
-        "If that does not work for your use-case, try the `v1.train.init_from_checkpoint` function. It takes an `assignment_map` argument, which specifies the mapping from old names to new names.\n",
+        "If that does not work for your use case, try the `v1.train.init_from_checkpoint` function. It takes an `assignment_map` argument, which specifies the mapping from old names to new names.\n",
         "\n",
-        "Note: Unlike object based checkpoints, which can [defer loading](checkpoint.ipynb#loading_mechanics), name-based checkpoints require that all variables be built when the function is called. Some models defer building variables until you call `build` or run the model on a batch of data.\n",
+        "Note: Unlike object-based checkpoints, which can [defer loading](checkpoint.ipynb#loading_mechanics), name-based checkpoints require that all variables be built when the function is called. Some models defer building variables until you call `build` or run the model on a batch of data.\n",
         "\n",
-        "The [TensorFlow Estimator repository](https://github.com/tensorflow/estimator/blob/master/tensorflow_estimator/python/estimator/tools/checkpoint_converter.py) includes a [conversion tool](#checkpoint_converter) to upgrade the checkpoints for premade estimators from TensorFlow 1.X to 2.0. It may serve as an example of how to build a tool for a similar use-case."
+        "The [TensorFlow Estimator repository](https://github.com/tensorflow/estimator/blob/master/tensorflow_estimator/python/estimator/tools/checkpoint_converter.py) includes a [conversion tool](#checkpoint_converter) to upgrade the checkpoints for premade estimators from TensorFlow 1.x to 2.0. It may serve as an example of how to build a tool for a similar use case."
       ]
     },
     {
@@ -1337,8 +1333,8 @@
         "\n",
         "There are no significant compatibility concerns for saved models.\n",
         "\n",
-        "* TensorFlow 1.x saved_models work in TensorFlow 2.x.\n",
-        "* TensorFlow 2.x saved_models work in TensorFlow 1.x—if all the ops are supported."
+        "- TensorFlow 1.x saved_models work in TensorFlow 2.x.\n",
+        "- TensorFlow 2.x saved_models work in TensorFlow 1.x if all the ops are supported."
       ]
     },
     {
@@ -1358,7 +1354,7 @@
       "source": [
         "There is no straightforward way to upgrade a raw `Graph.pb` file to TensorFlow 2.0. Your best bet is to upgrade the code that generated the file.\n",
         "\n",
-        "But, if you have a \"Frozen graph\" (a `tf.Graph` where the variables have been turned into constants), then it is possible to convert this to a [`concrete_function`](https://tensorflow.org/guide/concrete_function) using `v1.wrap_function`:\n"
+        "But, if you have a \"frozen graph\" (a `tf.Graph` where the variables have been turned into constants), then it is possible to convert this to a [`concrete_function`](https://tensorflow.org/guide/concrete_function) using `v1.wrap_function`:\n"
       ]
     },
     {
@@ -1485,7 +1481,7 @@
         "\n",
         "Estimators are supported in TensorFlow 2.0.\n",
         "\n",
-        "When you use estimators, you can use `input_fn()`, `tf.estimator.TrainSpec`, and `tf.estimator.EvalSpec` from TensorFlow 1.x.\n",
+        "When you use estimators, you can use `input_fn`, `tf.estimator.TrainSpec`, and `tf.estimator.EvalSpec` from TensorFlow 1.x.\n",
         "\n",
         "Here is an example using `input_fn` with train and evaluate specs."
       ]
@@ -1524,7 +1520,7 @@
         "  train_data = mnist_train.map(scale).shuffle(BUFFER_SIZE).batch(BATCH_SIZE)\n",
         "  return train_data.repeat()\n",
         "\n",
-        "# Define train & eval specs\n",
+        "# Define train and eval specs\n",
         "train_spec = tf.estimator.TrainSpec(input_fn=input_fn,\n",
         "                                    max_steps=STEPS_PER_EPOCH * NUM_EPOCHS)\n",
         "eval_spec = tf.estimator.EvalSpec(input_fn=input_fn,\n",
@@ -1548,7 +1544,7 @@
       "source": [
         "There are some differences in how to construct your estimators in TensorFlow 2.0.\n",
         "\n",
-        "We recommend that you define your model using Keras, then use the `tf.keras.estimator.model_to_estimator` utility to turn your model into an estimator. The code below shows how to use this utility when creating and training an estimator."
+        "It's recommended that you define your model using Keras, then use the `tf.keras.estimator.model_to_estimator` utility to turn your model into an estimator. The code below shows how to use this utility when creating and training an estimator."
       ]
     },
     {
@@ -1600,7 +1596,7 @@
         "id": "RBoa-xXPs4rD"
       },
       "source": [
-        "Note: We do not support creating weighted metrics in Keras and converting them to weighted metrics in the Estimator API using `model_to_estimator` You will have to create these metrics directly on the estimator spec using the `add_metrics` function."
+        "Note: TensorFlow does not support creating weighted metrics in Keras and converting them to weighted metrics in the Estimator API using `model_to_estimator`. You will have to create these metrics directly on the estimator spec using the `add_metrics` function."
       ]
     },
     {
@@ -1615,7 +1611,7 @@
         "\n",
         "However, for compatibility reasons, a custom `model_fn` will still run in 1.x-style graph mode. This means there is no eager execution and no automatic control dependencies.\n",
         "\n",
-        "Note: Long term, you should plan to migrate away from `tf.estimator`, especially using a custom `model_fn`. The alternative APIs are `tf.keras` and `tf.distribute`. If you still need an `Estimator` for some part of your training you can use the `tf.keras.estimator.model_to_estimator` converter to create an `Estimator` from a `keras.Model`.\n"
+        "Note: Long term, you should plan to migrate away from `tf.estimator`, especially using a custom `model_fn`. The alternative APIs are `tf.keras` and `tf.distribute`. If you still need an `Estimator` for some part of your training, you can use the `tf.keras.estimator.model_to_estimator` converter to create an `Estimator` from a `keras.Model`.\n"
       ]
     },
     {
@@ -1629,15 +1625,15 @@
         "#### Custom model_fn with minimal changes\n",
         "To make your custom `model_fn` work in TF 2.0, if you prefer minimal changes to the existing code, `tf.compat.v1` symbols such as `optimizers` and `metrics` can be used.\n",
         "\n",
-        "Using a Keras models in a custom `model_fn` is similar to using it in a custom training loop:\n",
+        "Using a Keras model in a custom `model_fn` is similar to using it in a custom training loop:\n",
         "\n",
-        "* Set the `training` phase appropriately, based on the `mode` argument.\n",
-        "* Explicitly pass the model's `trainable_variables` to the optimizer.\n",
+        "- Set the `training` phase appropriately, based on the `mode` argument.\n",
+        "- Explicitly pass the model's `trainable_variables` to the optimizer.\n",
         "\n",
         "But there are important differences, relative to a [custom loop](#custom_loop):\n",
         "\n",
-        "* Instead of using `Model.losses`, extract the losses using `Model.get_losses_for`.\n",
-        "* Extract the model's updates using `Model.get_updates_for`.\n",
+        "- Instead of using `Model.losses`, extract the losses using `Model.get_losses_for`.\n",
+        "- Extract the model's updates using `Model.get_updates_for`.\n",
         "\n",
         "Note: \"Updates\" are changes that need to be applied to a model after each batch. For example, the moving averages of the mean and variance in a `layers.BatchNormalization` layer.\n",
         "\n",
@@ -1696,16 +1692,17 @@
       },
       "source": [
         "#### Custom `model_fn` with TF 2.0 symbols\n",
+        "\n",
         "If you want to get rid of all TF 1.x symbols and upgrade your custom `model_fn` to native TF 2.0, you need to update the optimizer and metrics to `tf.keras.optimizers` and `tf.keras.metrics`.\n",
         "\n",
         "In the custom `model_fn`, besides the above [changes](#minimal_changes), more upgrades need to be made:\n",
         "\n",
-        "* Use [`tf.keras.optimizers`](https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/keras/optimizers) instead of `v1.train.Optimizer`.\n",
-        "* Explicitly pass the model's `trainable_variables` to the `tf.keras.optimizers`.\n",
-        "* To compute the `train_op/minimize_op`,\n",
-        "  * Use `Optimizer.get_updates()` if the loss is scalar loss `Tensor`(not a callable). The first element in the returned list is the desired `train_op/minimize_op`. \n",
-        "  * If the loss is a callable (such as a function), use `Optimizer.minimize()` to get the `train_op/minimize_op`.\n",
-        "* Use [`tf.keras.metrics`](https://www.tensorflow.org/api_docs/python/tf/keras/metrics) instead of `tf.compat.v1.metrics` for evaluation.\n",
+        "- Use `tf.keras.optimizers` instead of `v1.train.Optimizer`.\n",
+        "- Explicitly pass the model's `trainable_variables` to the `tf.keras.optimizers`.\n",
+        "- To compute the `train_op/minimize_op`,\n",
+        "  - Use `Optimizer.get_updates` if the loss is scalar loss `Tensor` (not a callable). The first element in the returned list is the desired `train_op/minimize_op`. \n",
+        "  - If the loss is a callable (such as a function), use `Optimizer.minimize` to get the `train_op/minimize_op`.\n",
+        "- Use `tf.keras.metrics` instead of `tf.compat.v1.metrics` for evaluation.\n",
         "\n",
         "For the above example of `my_model_fn`, the migrated code with 2.0 symbols is shown as:"
       ]
@@ -1760,7 +1757,7 @@
         "    train_op=train_op,\n",
         "    eval_metric_ops={'Accuracy': accuracy_obj})\n",
         "\n",
-        "# Create the Estimator & Train.\n",
+        "# Create the Estimator and train.\n",
         "estimator = tf.estimator.Estimator(model_fn=my_model_fn)\n",
         "tf.estimator.train_and_evaluate(estimator, train_spec, eval_spec)"
       ]
@@ -1773,16 +1770,19 @@
       "source": [
         "### Premade Estimators\n",
         "\n",
-        "[Premade Estimators](https://www.tensorflow.org/guide/premade_estimators) in the family of `tf.estimator.DNN*`, `tf.estimator.Linear*` and `tf.estimator.DNNLinearCombined*` are still supported in the TensorFlow 2.0 API, however, some arguments have changed:\n",
+        "[Premade Estimators](https://www.tensorflow.org/guide/premade_estimators) in the family of `tf.estimator.DNN*`, `tf.estimator.Linear*` and `tf.estimator.DNNLinearCombined*` are still supported in the TensorFlow 2.0 API. However, some arguments have changed:\n",
         "\n",
         "1. `input_layer_partitioner`: Removed in 2.0.\n",
         "2. `loss_reduction`: Updated to `tf.keras.losses.Reduction` instead of `tf.compat.v1.losses.Reduction`. Its default value is also changed to `tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE` from `tf.compat.v1.losses.Reduction.SUM`.\n",
-        "3. `optimizer`, `dnn_optimizer` and `linear_optimizer`: this arg has been updated to `tf.keras.optimizers` instead of the `tf.compat.v1.train.Optimizer`. \n",
+        "3. `optimizer`, `dnn_optimizer` and `linear_optimizer`: this argument has been updated to `tf.keras.optimizers` instead of the `tf.compat.v1.train.Optimizer`. \n",
         "\n",
         "To migrate the above changes:\n",
+        "\n",
         "1. No migration is needed for `input_layer_partitioner` since [`Distribution Strategy`](https://www.tensorflow.org/guide/distributed_training) will handle it automatically in TF 2.0.\n",
-        "2. For `loss_reduction`, check [`tf.keras.losses.Reduction`](https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/keras/losses/Reduction) for the supported options.\n",
-        "3. For `optimizer` args, if you do not pass in an `optimizer`, `dnn_optimizer` or `linear_optimizer` arg, or if you specify the `optimizer` arg as a `string` in your code, you don't need to change anything. `tf.keras.optimizers` is used by default. Otherwise, you need to update it from `tf.compat.v1.train.Optimizer` to its corresponding [`tf.keras.optimizers`](https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/keras/optimizers)\n"
+        "2. For `loss_reduction`, check `tf.keras.losses.Reduction` for the supported options.\n",
+        "3. For `optimizer` arguments: \n",
+        "    - If you do not: 1) pass in the `optimizer`, `dnn_optimizer` or `linear_optimizer` argument, or 2) specify the `optimizer` argument as a `string` in your code, then you don't need to change anything because `tf.keras.optimizers` is used by default. \n",
+        "    - Otherwise, you need to update it from `tf.compat.v1.train.Optimizer` to its corresponding `tf.keras.optimizers`.\n"
       ]
     },
     {
@@ -1814,7 +1814,7 @@
         "id": "DMc6zDJaJwNw"
       },
       "source": [
-        "The tool has builtin help:"
+        "The tool has built-in help:"
       ]
     },
     {
@@ -1838,7 +1838,7 @@
         "\n",
         "## TensorShape\n",
         "\n",
-        "This class was simplified to hold `int`s, instead of `tf.compat.v1.Dimension` objects. So there is no need to call `.value()` to get an `int`.\n",
+        "This class was simplified to hold `int`s, instead of `tf.compat.v1.Dimension` objects. So there is no need to call `.value` to get an `int`.\n",
         "\n",
         "Individual `tf.compat.v1.Dimension` objects are still accessible from `tf.TensorShape.dims`."
       ]
@@ -2004,11 +2004,11 @@
         "id": "8u63n5S7Y9IX"
       },
       "source": [
-        "## Other Changes\n",
+        "## Other changes\n",
         "\n",
-        "* Remove `tf.colocate_with`: TensorFlow's device placement algorithms have improved significantly. This should no longer be necessary. If removing it causes a performance degredation [please file a bug](https://github.com/tensorflow/tensorflow/issues).\n",
+        "- Remove `tf.colocate_with`: TensorFlow's device placement algorithms have improved significantly. This should no longer be necessary. If removing it causes a performance degredation [please file a bug](https://github.com/tensorflow/tensorflow/issues).\n",
         "\n",
-        "* Replace `v1.ConfigProto` usage with the equivalent functions from `tf.config`.\n"
+        "- Replace `v1.ConfigProto` usage with the equivalent functions from `tf.config`.\n"
       ]
     },
     {
@@ -2027,12 +2027,11 @@
         "4. Use `tf.keras` or `tf.estimator` training and evaluation loops where you can.\n",
         "5. Otherwise, use custom loops, but be sure to avoid sessions & collections.\n",
         "\n",
-        "\n",
         "It takes a little work to convert code to idiomatic TensorFlow 2.0, but every change results in:\n",
         "\n",
-        "* Fewer lines of code.\n",
-        "* Increased clarity and simplicity.\n",
-        "* Easier debugging.\n"
+        "- Fewer lines of code.\n",
+        "- Increased clarity and simplicity.\n",
+        "- Easier debugging."
       ]
     }
   ],

--- a/site/en/guide/migrate.ipynb
+++ b/site/en/guide/migrate.ipynb
@@ -759,7 +759,7 @@
         "- Separable conv layers map to one or more different Keras layers (depthwise, pointwise, and separable Keras layers).\n",
         "- Slim and `v1.layers` have different argument names and default values.\n",
         "- Some args have different scales.\n",
-        "- If you use Slim pre-trained models, try out Keras's pre-traimed models from `tf.keras.applications` or [TF Hub](https://tfhub.dev/s?q=slim%20tf2)'s TensorFlow 2.x SavedModels exported from the original Slim code.\n",
+        "- If you use Slim pre-trained models, try out Keras's pre-traimed models from `tf.keras.applications` or [TF Hub](https://tfhub.dev/s?tf-version=tf2&q=slim)'s TensorFlow 2.x SavedModels exported from the original Slim code.\n",
         "\n",
         "Some `tf.contrib` layers might not have been moved to core TensorFlow but have instead been moved to the [TensorFlow Addons package](https://www.tensorflow.org/addons/overview).\n"
       ]

--- a/site/en/guide/migrate.ipynb
+++ b/site/en/guide/migrate.ipynb
@@ -37,7 +37,7 @@
         "id": "77z2OchJTk0l"
       },
       "source": [
-        "# Migrate your TensorFlow 1.x code to TensorFlow 2.x\n",
+        "# Migrate your TensorFlow 1 code to TensorFlow 2\n",
         "\n",
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
         "  <td>\n",

--- a/site/en/guide/migrate.ipynb
+++ b/site/en/guide/migrate.ipynb
@@ -97,7 +97,7 @@
       "source": [
         "## Automatic conversion script\n",
         "\n",
-        "The first step, before attempting to implement the changes described in this doc, is to try running the [upgrade script](./upgrade.md).\n",
+        "The first step, before attempting to implement the changes described in this guide, is to try running the [upgrade script](./upgrade.md).\n",
         "\n",
         "This will execute an initial pass at upgrading your code to TensorFlow 2.x but it can't make your code idiomatic to v2. Your code may still make use of `tf.compat.v1` endpoints to access placeholders, sessions, collections, and other 1.x-style functionality."
       ]
@@ -366,7 +366,7 @@
         "- The `Session.run` call is replaced with a call to `forward`.\n",
         "- The optional `tf.function` decorator can be added for performance.\n",
         "- The regularizations are calculated manually, without referring to any global collection.\n",
-        "- **No sessions or placeholders**."
+        "- **There's no usage of sessions or placeholders**."
       ]
     },
     {
@@ -495,7 +495,7 @@
         "\n",
         "Also note that:\n",
         "\n",
-        "- If you were using regularizers of initializers from `tf.contrib`, these have more argument changes than others.\n",
+        "- If you are using regularizers or initializers from `tf.contrib`, these have more argument changes than others.\n",
         "- The code no longer writes to collections, so functions like `v1.losses.get_regularization_loss` will no longer return these values, potentially breaking your training loops."
       ]
     },
@@ -1611,7 +1611,7 @@
         "\n",
         "However, for compatibility reasons, a custom `model_fn` will still run in 1.x-style graph mode. This means there is no eager execution and no automatic control dependencies.\n",
         "\n",
-        "Note: Long term, you should plan to migrate away from `tf.estimator`, especially using a custom `model_fn`. The alternative APIs are `tf.keras` and `tf.distribute`. If you still need an `Estimator` for some part of your training, you can use the `tf.keras.estimator.model_to_estimator` converter to create an `Estimator` from a `keras.Model`.\n"
+        "Note: In the long term, you should plan to migrate away from `tf.estimator`, especially using a custom `model_fn`. The alternative APIs are `tf.keras` and `tf.distribute`. If you still need an `Estimator` for some part of your training, you can use the `tf.keras.estimator.model_to_estimator` converter to create an `Estimator` from a `keras.Model`.\n"
       ]
     },
     {
@@ -2039,7 +2039,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "migrate.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/site/en/guide/migrate.ipynb
+++ b/site/en/guide/migrate.ipynb
@@ -139,7 +139,7 @@
         "id": "_Ni9zLLvwcOR"
       },
       "source": [
-        "## Make the code TensorFlow 2.x-native\n",
+        "## Make the code for TensorFlow 2.x\n",
         "\n",
         "This guide will walk through several examples of converting TensorFlow 1.x code to TensorFlow 2.x. These changes will let your code take advantage of performance optimizations and simplified API calls.\n",
         "\n",
@@ -1693,7 +1693,7 @@
       "source": [
         "#### Custom `model_fn` with TensorFlow 2.x symbols\n",
         "\n",
-        "If you want to get rid of all TensorFlow 1.x symbols and upgrade your custom `model_fn` to native TensorFlow 2.x, you need to update the optimizer and metrics to `tf.keras.optimizers` and `tf.keras.metrics`.\n",
+        "If you want to get rid of all TensorFlow 1.x symbols and upgrade your custom `model_fn` to TensorFlow 2.x, you need to update the optimizer and metrics to `tf.keras.optimizers` and `tf.keras.metrics`.\n",
         "\n",
         "In the custom `model_fn`, besides the above [changes](#minimal_changes), more upgrades need to be made:\n",
         "\n",

--- a/site/en/guide/migrate.ipynb
+++ b/site/en/guide/migrate.ipynb
@@ -2039,6 +2039,7 @@
     "colab": {
       "collapsed_sections": [],
       "name": "migrate.ipynb",
+      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/site/en/guide/migrate.ipynb
+++ b/site/en/guide/migrate.ipynb
@@ -110,7 +110,7 @@
       "source": [
         "## Top-level behavioral changes\n",
         "\n",
-        "If your code works in TensorFlow x using `tf.compat.v1.disable_v2_behavior`, there are still global behavioral changes you may need to address. The major changes are:"
+        "If your code works in TensorFlow 2.x using `tf.compat.v1.disable_v2_behavior`, there are still global behavioral changes you may need to address. The major changes are:"
       ]
     },
     {


### PR DESCRIPTION
Splitting PR https://github.com/tensorflow/docs/pull/1736 into smaller digestible bits.

- Also proposing to use "2.x" instead of "2.0" since we're currently on v2.4.

Cheers @lamberta @MarkDaoust 