### PR TITLE
Lint TensorFlow: Mixed Precision guide

### DIFF
--- a/site/en/guide/mixed_precision.ipynb
+++ b/site/en/guide/mixed_precision.ipynb
@@ -834,8 +834,7 @@
     "kernelspec": {
       "display_name": "Python 3",
       "name": "python3"
-    },
-    "language_info": {}
+    }
   },
   "nbformat": 4,
   "nbformat_minor": 0

--- a/site/en/guide/mixed_precision.ipynb
+++ b/site/en/guide/mixed_precision.ipynb
@@ -120,7 +120,7 @@
         "\n",
         "While mixed precision will run on most hardware, it will only speed up models on recent NVIDIA GPUs and Cloud TPUs. NVIDIA GPUs support using a mix of float16 and float32, while TPUs support a mix of bfloat16 and float32.\n",
         "\n",
-        "Among NVIDIA GPUs, those with compute capability 7.0 or higher will see the greatest performance benefit from mixed precision because they have special hardware units, called Tensor Cores, to accelerate float16 matrix multiplications and convolutions. Older GPUs offer no mathematical performance benefit for using mixed precision, however memory and bandwidth savings can enable some speedups. You can look up the compute capability for your GPU at NVIDIA's [CUDA GPU web page](https://developer.nvidia.com/cuda-gpus). Examples of GPUs that will benefit most from mixed precision include RTX GPUs, the Titan V, and the V100."
+        "Among NVIDIA GPUs, those with compute capability 7.0 or higher will see the greatest performance benefit from mixed precision because they have special hardware units, called Tensor Cores, to accelerate float16 matrix multiplications and convolutions. Older GPUs offer no math performance benefit for using mixed precision, however memory and bandwidth savings can enable some speedups. You can look up the compute capability for your GPU at NVIDIA's [CUDA GPU web page](https://developer.nvidia.com/cuda-gpus). Examples of GPUs that will benefit most from mixed precision include RTX GPUs, the V100, and the A100."
       ]
     },
     {

--- a/site/en/guide/mixed_precision.ipynb
+++ b/site/en/guide/mixed_precision.ipynb
@@ -83,7 +83,7 @@
         "\n",
         "NVIDIA GPUs can run operations in float16 faster than in float32, and TPUs can run operations in bfloat16 faster than float32. Therefore, these lower-precision dtypes should be used whenever possible on those devices. However, variables and a few computations should still be in float32 for numeric reasons so that the model trains to the same quality. The Keras mixed precision API allows you to use a mix of either float16 or bfloat16 with float32, to get the performance benefits from float16/bfloat16 and the numeric stability benefits from float32.\n",
         "\n",
-        "Note: In this guide, the term \"numeric stability\" refers to how a model's quality is affected by the use of a lower-precision dtype instead of a higher precision dtype. We say an operation is \"numerically unstable\" in float16 or bfloat16 if running it in one of those dtypes causes the model to have worse evaluation accuracy or other metrics compared to running the operation in float32."
+        "Note: In this guide, the term \"numeric stability\" refers to how a model's quality is affected by the use of a lower-precision dtype instead of a higher precision dtype. An operation is \"numerically unstable\" in float16 or bfloat16 if running it in one of those dtypes causes the model to have worse evaluation accuracy or other metrics compared to running the operation in float32."
       ]
     },
     {
@@ -120,7 +120,7 @@
         "\n",
         "While mixed precision will run on most hardware, it will only speed up models on recent NVIDIA GPUs and Cloud TPUs. NVIDIA GPUs support using a mix of float16 and float32, while TPUs support a mix of bfloat16 and float32.\n",
         "\n",
-        "Among NVIDIA GPUs, those with compute capability 7.0 or higher will see the greatest performance benefit from mixed precision because they have special hardware units, called Tensor Cores, to accelerate float16 matrix multiplications and convolutions. Older GPUs offer no math performance benefit for using mixed precision, however memory and bandwidth savings can enable some speedups. You can look up the compute capability for your GPU at NVIDIA's [CUDA GPU web page](https://developer.nvidia.com/cuda-gpus). Examples of GPUs that will benefit most from mixed precision include RTX GPUs, the V100, and the A100."
+        "Among NVIDIA GPUs, those with compute capability 7.0 or higher will see the greatest performance benefit from mixed precision because they have special hardware units, called Tensor Cores, to accelerate float16 matrix multiplications and convolutions. Older GPUs offer no mathematical performance benefit for using mixed precision, however memory and bandwidth savings can enable some speedups. You can look up the compute capability for your GPU at NVIDIA's [CUDA GPU web page](https://developer.nvidia.com/cuda-gpus). Examples of GPUs that will benefit most from mixed precision include RTX GPUs, the Titan V, and the V100."
       ]
     },
     {
@@ -172,7 +172,7 @@
         "id": "54ecYY2Hn16E"
       },
       "source": [
-        "To use mixed precision in Keras, you need to create a `tf.keras.mixed_precision.Policy`, typically referred to as a *dtype policy*. Dtype policies specify the dtypes layers will run in. In this guide, you will construct a policy from the string `'mixed_float16'` and set it as the global policy. This will cause subsequently created layers to use mixed precision with a mix of float16 and float32."
+        "To use mixed precision in Keras, you need to create a `tf.keras.mixed_precision.experimental.Policy`, typically referred to as a *dtype policy*. Dtype policies specify the dtypes layers will run in. In this guide, you will construct a policy from the string `'mixed_float16'` and set it as the global policy. This will cause subsequently created layers to use mixed precision with a mix of float16 and float32."
       ]
     },
     {
@@ -329,9 +329,9 @@
         "id": "D0gSWxc9NN7q"
       },
       "source": [
-        "A softmax activation at the end of the model should be float32. Because the dtype policy is `mixed_float16`, the softmax activation would normally have a float16 compute dtype and output a float16 tensors.\n",
+        "A softmax activation at the end of the model should be float32. Because the dtype policy is `mixed_float16`, the softmax activation would normally have a float16 compute dtype and output float16 tensors.\n",
         "\n",
-        "This can be fixed by separating the Dense and softmax layers, and by passing `dtype='float32'` to the softmax layer"
+        "This can be fixed by separating the Dense and softmax layers, and by passing `dtype='float32'` to the softmax layer:"
       ]
     },
     {
@@ -354,7 +354,7 @@
         "id": "tUdkY_DHsP8i"
       },
       "source": [
-        "Passing `dtype='float32'` to the softmax layer constructor overrides the layer's dtype policy to be the `float32` policy, which does computations and keeps variables in float32. Equivalently, we could have instead passed `dtype=mixed_precision.Policy('float32')`; layers always convert the dtype argument to a policy. Because the `Activation` layer has no variables, the policy's variable dtype is ignored, but the policy's compute dtype of float32 causes softmax and the model output to be float32. \n",
+        "Passing `dtype='float32'` to the softmax layer constructor overrides the layer's dtype policy to be the `float32` policy, which does computations and keeps variables in float32. Equivalently, you could have instead passed `dtype=mixed_precision.Policy('float32')`; layers always convert the dtype argument to a policy. Because the `Activation` layer has no variables, the policy's variable dtype is ignored, but the policy's compute dtype of float32 causes softmax and the model output to be float32. \n",
         "\n",
         "\n",
         "Adding a float16 softmax in the middle of a model is fine, but a softmax at the end of the model should be in float32. The reason is that if the intermediate tensor flowing from the softmax to the loss is float16 or bfloat16, numeric issues may occur.\n",
@@ -384,7 +384,7 @@
         "id": "tpY4ZP7us5hA"
       },
       "source": [
-        "Next, finish and compile the model, and generate input data."
+        "Next, finish and compile the model, and generate input data:"
       ]
     },
     {
@@ -411,7 +411,7 @@
         "id": "0Sm8FJHegVRN"
       },
       "source": [
-        "This example cast the input data from int8 to float32. We don't cast to float16 since the division by 255 is on the CPU, which runs float16 operations slower than float32 operations. In this case, the performance difference in negligible, but in general you should run input processing math in float32 if it runs on the CPU. The first layer of the model will cast the inputs to float16, as each layer casts floating-point inputs to its compute dtype.\n",
+        "This example cast the input data from int8 to float32. You don't cast to float16 since the division by 255 is on the CPU, which runs float16 operations slower than float32 operations. In this case, the performance difference in negligible, but in general you should run input processing math in float32 if it runs on the CPU. The first layer of the model will cast the inputs to float16, as each layer casts floating-point inputs to its compute dtype.\n",
         "\n",
         "The initial weights of the model are retrieved. This will allow training from scratch again by loading the weights."
       ]
@@ -435,7 +435,7 @@
       "source": [
         "## Training the model with Model.fit\n",
         "\n",
-        "Next, train the model."
+        "Next, train the model:"
       ]
     },
     {
@@ -537,7 +537,7 @@
       "source": [
         "### Loss scaling overview\n",
         "\n",
-        "The basic concept of loss scaling is simple: simply multiply the loss by some large number, say $1024$. We call this number the *loss scale*. This will cause the gradients to scale by $1024$ as well, greatly reducing the chance of underflow. Once the final gradients are computed, divide them by $1024$ to bring them back to their correct values.\n",
+        "The basic concept of loss scaling is simple: simply multiply the loss by some large number, say $1024$, and you get the *loss scale* value. This will cause the gradients to scale by $1024$ as well, greatly reducing the chance of underflow. Once the final gradients are computed, divide them by $1024$ to bring them back to their correct values.\n",
         "\n",
         "The pseudocode for this process is:\n",
         "\n",
@@ -545,14 +545,96 @@
         "loss_scale = 1024\n",
         "loss = model(inputs)\n",
         "loss *= loss_scale\n",
-        "# We assume `grads` are float32. We do not want to divide float16 gradients\n",
+        "# Assume `grads` are float32. You do not want to divide float16 gradients.\n",
         "grads = compute_gradient(loss, model.trainable_variables)\n",
         "grads /= loss_scale\n",
         "```\n",
         "\n",
         "Choosing a loss scale can be tricky. If the loss scale is too low, gradients may still underflow to zero. If too high, the opposite the problem occurs: the gradients may overflow to infinity.\n",
         "\n",
-        "To solve this, TensorFlow dynamically determines the loss scale so you do not have to choose one manually. If you use `tf.keras.Model.fit`, loss scaling is done for you so you do not have to do any extra work. If you use a custom training loop, you must explicitly use the special optimizer wrapper `tf.keras.mixed_precision.LossScaleOptimizer` in order to use loss scaling. This is described in the next section.\n"
+        "To solve this, TensorFlow dynamically determines the loss scale so you do not have to choose one manually. If you use `tf.keras.Model.fit`, loss scaling is done for you so you do not have to do any extra work. This is explained further in the next section.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qlbxbjxShf0m"
+      },
+      "source": [
+        "### Choosing the loss scale\n",
+        "\n",
+        "Each dtype policy optionally has an associated `tf.mixed_precision.experimental.LossScale` object, which represents a fixed or dynamic loss scale. By default, the loss scale for the `mixed_float16` policy is a `tf.mixed_precision.experimental.DynamicLossScale`, which dynamically determines the loss scale value. Other policies do not have a loss scale by default, as it is only necessary when float16 is used. You can query the loss scale of the policy:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "0iSbassjdldy"
+      },
+      "outputs": [],
+      "source": [
+        "loss_scale = policy.loss_scale\n",
+        "print('Loss scale: %s' % loss_scale)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "l8c0ULUxdu2b"
+      },
+      "source": [
+        "The loss scale prints a lot of internal state, but you can ignore it. The most important part is the `current_loss_scale` part, which shows the loss scale's current value."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Mr0cAMCHfhlj"
+      },
+      "source": [
+        "You can instead use a static loss scale by passing a number when constructing a dtype policy:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "4Sa4bGFif9GW"
+      },
+      "outputs": [],
+      "source": [
+        "new_policy = mixed_precision.Policy('mixed_float16', loss_scale=1024)\n",
+        "print(new_policy.loss_scale)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "alD_0frtgFKK"
+      },
+      "source": [
+        "The dtype policy constructor always converts the loss scale to a `LossScale` object. In this case, it's converted to a `tf.mixed_precision.experimental.FixedLossScale`, the only other `LossScale` subclass other than `DynamicLossScale`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Gi1DLrLF7bnr"
+      },
+      "source": [
+        "Note: *Using anything other than a dynamic loss scale is not recommended*. Choosing a fixed loss scale can be difficult, as making it too low will cause the model to not train as well, and making it too high will cause Infs or NaNs to appear in the gradients. A dynamic loss scale is typically near the optimal loss scale, so you do not have to do any work. Currently, dynamic loss scales are a bit slower than fixed loss scales, but the performance will be improved in the future."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LJ_1W-Axh2bp"
+      },
+      "source": [
+        "Models, like layers, each have a dtype policy. If present, a model uses its policy's loss scale to apply loss scaling in the `tf.keras.Model.fit` method. This means if `Model.fit` is used, you do not have to worry about loss scaling at all: The `mixed_float16` policy will have a dynamic loss scale by default, and `Model.fit` will apply it.\n",
+        "\n",
+        "With custom training loops, the model will ignore the policy's loss scale, and you will have to apply it manually. This is explained in the next section."
       ]
     },
     {
@@ -570,7 +652,7 @@
         "id": "CRANRZZ69nA7"
       },
       "source": [
-        "So far, you trained a Keras model with mixed precision using `tf.keras.Model.fit`. Next, you will use mixed precision with a custom training loop. If you do not already know what a custom training loop is, please read [the Custom training guide](../tutorials/customization/custom_training_walkthrough.ipynb) first."
+        "So far, you have trained a Keras model with mixed precision using `tf.keras.Model.fit`. Next, you will use mixed precision with a custom training loop. If you do not already know what a custom training loop is, please read the [Custom training guide](../tutorials/customization/custom_training_walkthrough.ipynb) first."
       ]
     },
     {
@@ -580,6 +662,7 @@
       },
       "source": [
         "Running a custom training loop with mixed precision requires two changes over running it in float32:\n",
+        "\n",
         "1. Build the model with mixed precision (you already did this)\n",
         "2. Explicitly use loss scaling if `mixed_float16` is used.\n"
       ]
@@ -590,7 +673,7 @@
         "id": "M2zpp7_65mTZ"
       },
       "source": [
-        "For step (2), you will use the `tf.keras.mixed_precision.LossScaleOptimizer` class, which wraps an optimizer and applies loss scaling. By default, it dynamically determines the loss scale so you do not have to choose one. Construct a `LossScaleOptimizer` as follows."
+        "For step (2), you will use the `tf.keras.mixed_precision.experimental.LossScaleOptimizer` class, which wraps an optimizer and applies loss scaling. It takes two arguments: the optimizer and the loss scale. Construct one as follows to use a dynamic loss scale:"
       ]
     },
     {
@@ -620,7 +703,7 @@
         "id": "JZYEr5hA3MXZ"
       },
       "source": [
-        "Next, define the loss object and the `tf.data.Dataset`s."
+        "Next, define the loss object and the `tf.data.Dataset`s:"
       ]
     },
     {
@@ -643,9 +726,10 @@
         "id": "4W0zxrxC3nww"
       },
       "source": [
-        "Next, define the training step function. Two new methods from the loss scale optimizer are used in order to scale the loss and unscale the gradients:\n",
-        "* `get_scaled_loss(loss)`: Multiplies the loss by the loss scale\n",
-        "* `get_unscaled_gradients(gradients)`: Takes in a list of scaled gradients as inputs, and divides each one by the loss scale to unscale them\n",
+        "Next, define the training step function. You will use two new methods from the loss scale optimizer to scale the loss and unscale the gradients:\n",
+        "\n",
+        "- `get_scaled_loss(loss)`: Multiplies the loss by the loss scale\n",
+        "- `get_unscaled_gradients(gradients)`: Takes in a list of scaled gradients as inputs, and divides each one by the loss scale to unscale them\n",
         "\n",
         "These functions must be used in order to prevent underflow in the gradients. `LossScaleOptimizer.apply_gradients` will then apply gradients if none of them have Infs or NaNs. It will also update the loss scale, halving it if the gradients had Infs or NaNs and potentially increasing it otherwise."
       ]
@@ -685,7 +769,7 @@
         "id": "IHIvKKhg4Y-G"
       },
       "source": [
-        "Now define the test step.\n"
+        "Now, define the test step:\n"
       ]
     },
     {
@@ -707,7 +791,7 @@
         "id": "hBs98MZyhBOB"
       },
       "source": [
-        "Load the initial weights of the model, so you can retrain from scratch."
+        "Load the initial weights of the model, so you can retrain from scratch:"
       ]
     },
     {
@@ -727,7 +811,7 @@
         "id": "s9Pi1ADM47Ud"
       },
       "source": [
-        "Finally, run the custom training loop."
+        "Finally, run the custom training loop:"
       ]
     },
     {
@@ -762,24 +846,25 @@
         "Here are some performance tips when using mixed precision on GPUs.\n",
         "\n",
         "### Increasing your batch size\n",
+        "\n",
         "If it doesn't affect model quality, try running with double the batch size when using mixed precision. As float16 tensors use half the memory, this often allows you to double your batch size without running out of memory. Increasing batch size typically increases training throughput, i.e. the training elements per second your model can run on.\n",
         "\n",
         "### Ensuring GPU Tensor Cores are used\n",
         "\n",
         "As mentioned previously, modern NVIDIA GPUs use a special hardware unit called Tensor Cores that can multiply float16 matrices very quickly. However, Tensor Cores requires certain dimensions of tensors to be a multiple of 8. In the examples below, an argument is bold if and only if it needs to be a multiple of 8 for Tensor Cores to be used.\n",
         "\n",
-        "* tf.keras.layers.Dense(**units=64**)\n",
-        "* tf.keras.layers.Conv2d(**filters=48**, kernel_size=7, stride=3)\n",
-        "  * And similarly for other convolutional layers, such as tf.keras.layers.Conv3d\n",
-        "* tf.keras.layers.LSTM(**units=64**)\n",
-        "  * And similar for other RNNs, such as tf.keras.layers.GRU\n",
-        "* tf.keras.Model.fit(epochs=2, **batch_size=128**)\n",
+        "- tf.keras.layers.Dense(**units=64**)\n",
+        "- tf.keras.layers.Conv2d(**filters=48**, kernel_size=7, stride=3)\n",
+        "  - And similarly for other convolutional layers, such as tf.keras.layers.Conv3d\n",
+        "- tf.keras.layers.LSTM(**units=64**)\n",
+        "  - And similar for other RNNs, such as tf.keras.layers.GRU\n",
+        "- tf.keras.Model.fit(epochs=2, **batch_size=128**)\n",
         "\n",
-        "You should try to use Tensor Cores when possible. If you want to learn more [NVIDIA deep learning performance guide](https://docs.nvidia.com/deeplearning/sdk/dl-performance-guide/index.html) describes the exact requirements for using Tensor Cores as well as other Tensor Core-related performance information.\n",
+        "You should try to use Tensor Cores when possible. If you want to learn more, [NVIDIA deep learning performance guide](https://docs.nvidia.com/deeplearning/sdk/dl-performance-guide/index.html) describes the exact requirements for using Tensor Cores as well as other Tensor Core-related performance information.\n",
         "\n",
         "### XLA\n",
         "\n",
-        "XLA is a compiler that can further increase mixed precision performance, as well as float32 performance to a lesser extent. See the [XLA guide](https://www.tensorflow.org/xla) for details."
+        "XLA is a compiler that can further increase mixed precision performance, as well as float32 performance to a lesser extent. Refer to the [XLA guide](https://www.tensorflow.org/xla) for details."
       ]
     },
     {
@@ -789,9 +874,10 @@
       },
       "source": [
         "## Cloud TPU performance tips\n",
-        "As on GPUs, you should try doubling your batch size, as bfloat16 tensors use half the memory. Doubling batch size may increase training throughput.\n",
         "\n",
-        "TPUs do not require any other mixed precision-specific tuning to get optimal performance. TPUs already require the use of XLA. They benefit from having certain dimensions being multiples of $128$, but this applies equally to float32 as it does for mixed precision. See the [Cloud TPU Performance Guide](https://cloud.google.com/tpu/docs/performance-guide) for general TPU performance tips, which apply to mixed precision as well as float32."
+        "As with GPUs, you should try doubling your batch size when using Cloud TPUs because bfloat16 tensors use half the memory. Doubling batch size may increase training throughput.\n",
+        "\n",
+        "TPUs do not require any other mixed precision-specific tuning to get optimal performance. They already require the use of XLA. TPUs benefit from having certain dimensions being multiples of $128$, but this applies equally to the float32 type as it does for mixed precision. Check the [Cloud TPU performance guide](https://cloud.google.com/tpu/docs/performance-guide) for general TPU performance tips, which apply to mixed precision as well as float32 tensors."
       ]
     },
     {
@@ -801,18 +887,21 @@
       },
       "source": [
         "## Summary\n",
-        "* You should use mixed precision if you use TPUs or NVIDIA GPUs with at least compute capability 7.0, as it will improve performance by up to 3x.\n",
-        "* You can use mixed precision with the following lines:\n",
-        "  ```\n",
+        "\n",
+        "- You should use mixed precision if you use TPUs or NVIDIA GPUs with at least compute capability 7.0, as it will improve performance by up to 3x.\n",
+        "- You can use mixed precision with the following lines:\n",
+        "\n",
+        "  ```python\n",
         "  # On TPUs, use 'mixed_bfloat16' instead\n",
         "  mixed_precision.set_global_policy('mixed_float16')\n",
         "  ```\n",
-        "* If your model ends in softmax, make sure it is float32. And regardless of what your model ends in, make sure the output is float32.\n",
-        "* If you use a custom training loop with `mixed_float16`, in addition to the above lines, you need to wrap your optimizer with a `tf.keras.mixed_precision.LossScaleOptimizer`. Then call `optimizer.get_scaled_loss` to scale the loss, and `optimizer.get_unscaled_gradients` to unscale the gradients.\n",
-        "* Double the training batch size if it does not reduce evaluation accuracy\n",
-        "* On GPUs, ensure most tensor dimensions are a multiple of $8$ to maximize performance\n",
         "\n",
-        "For more examples of mixed precision using the `tf.keras.mixed_precision` API, see the [official models repository](https://github.com/tensorflow/models/tree/master/official). Most official models, such as [ResNet](https://github.com/tensorflow/models/tree/master/official/vision/image_classification) and [Transformer](https://github.com/tensorflow/models/blob/master/official/nlp/transformer) will run using mixed precision by passing `--dtype=fp16`. \n"
+        "- If your model ends with a softmax activation function, make sure the output is of type float32. And, regardless of what your model ends in, make sure the output data type is also float32.\n",
+        "- If you use a custom training loop with `mixed_float16`, in addition to the above lines, you need to wrap your optimizer with a `tf.keras.mixed_precision.experimental.LossScaleOptimizer`. Then call `optimizer.get_scaled_loss` to scale the loss, and `optimizer.get_unscaled_gradients` to unscale the gradients.\n",
+        "- You should double the training batch size if it does not reduce evaluation accuracy.\n",
+        "- On GPUs, make sure that most tensor dimensions are a multiple of $8$ to maximize performance.\n",
+        "\n",
+        "For more examples of mixed precision using the `tf.keras.mixed_precision` API, check the [official models repository](https://github.com/tensorflow/models/tree/master/official). Most official models, such as [ResNet](https://github.com/tensorflow/models/tree/master/official/vision/image_classification) and [Transformer](https://github.com/tensorflow/models/blob/master/official/nlp/transformer), will run using mixed precision by passing `--dtype=fp16`.\n"
       ]
     }
   ],

--- a/site/en/guide/mixed_precision.ipynb
+++ b/site/en/guide/mixed_precision.ipynb
@@ -172,7 +172,7 @@
         "id": "54ecYY2Hn16E"
       },
       "source": [
-        "To use mixed precision in Keras, you need to create a `tf.keras.mixed_precision.experimental.Policy`, typically referred to as a *dtype policy*. Dtype policies specify the dtypes layers will run in. In this guide, you will construct a policy from the string `'mixed_float16'` and set it as the global policy. This will cause subsequently created layers to use mixed precision with a mix of float16 and float32."
+        "To use mixed precision in Keras, you need to create a `tf.keras.mixed_precision.Policy`, typically referred to as a *dtype policy*. Dtype policies specify the dtypes layers will run in. In this guide, you will construct a policy from the string `'mixed_float16'` and set it as the global policy. This will cause subsequently created layers to use mixed precision with a mix of float16 and float32."
       ]
     },
     {

--- a/site/en/guide/mixed_precision.ipynb
+++ b/site/en/guide/mixed_precision.ipynb
@@ -552,89 +552,7 @@
         "\n",
         "Choosing a loss scale can be tricky. If the loss scale is too low, gradients may still underflow to zero. If too high, the opposite the problem occurs: the gradients may overflow to infinity.\n",
         "\n",
-        "To solve this, TensorFlow dynamically determines the loss scale so you do not have to choose one manually. If you use `tf.keras.Model.fit`, loss scaling is done for you so you do not have to do any extra work. This is explained further in the next section.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qlbxbjxShf0m"
-      },
-      "source": [
-        "### Choosing the loss scale\n",
-        "\n",
-        "Each dtype policy optionally has an associated `tf.mixed_precision.experimental.LossScale` object, which represents a fixed or dynamic loss scale. By default, the loss scale for the `mixed_float16` policy is a `tf.mixed_precision.experimental.DynamicLossScale`, which dynamically determines the loss scale value. Other policies do not have a loss scale by default, as it is only necessary when float16 is used. You can query the loss scale of the policy:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "0iSbassjdldy"
-      },
-      "outputs": [],
-      "source": [
-        "loss_scale = policy.loss_scale\n",
-        "print('Loss scale: %s' % loss_scale)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "l8c0ULUxdu2b"
-      },
-      "source": [
-        "The loss scale prints a lot of internal state, but you can ignore it. The most important part is the `current_loss_scale` part, which shows the loss scale's current value."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Mr0cAMCHfhlj"
-      },
-      "source": [
-        "You can instead use a static loss scale by passing a number when constructing a dtype policy:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "4Sa4bGFif9GW"
-      },
-      "outputs": [],
-      "source": [
-        "new_policy = mixed_precision.Policy('mixed_float16', loss_scale=1024)\n",
-        "print(new_policy.loss_scale)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "alD_0frtgFKK"
-      },
-      "source": [
-        "The dtype policy constructor always converts the loss scale to a `LossScale` object. In this case, it's converted to a `tf.mixed_precision.experimental.FixedLossScale`, the only other `LossScale` subclass other than `DynamicLossScale`."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Gi1DLrLF7bnr"
-      },
-      "source": [
-        "Note: *Using anything other than a dynamic loss scale is not recommended*. Choosing a fixed loss scale can be difficult, as making it too low will cause the model to not train as well, and making it too high will cause Infs or NaNs to appear in the gradients. A dynamic loss scale is typically near the optimal loss scale, so you do not have to do any work. Currently, dynamic loss scales are a bit slower than fixed loss scales, but the performance will be improved in the future."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "LJ_1W-Axh2bp"
-      },
-      "source": [
-        "Models, like layers, each have a dtype policy. If present, a model uses its policy's loss scale to apply loss scaling in the `tf.keras.Model.fit` method. This means if `Model.fit` is used, you do not have to worry about loss scaling at all: The `mixed_float16` policy will have a dynamic loss scale by default, and `Model.fit` will apply it.\n",
-        "\n",
-        "With custom training loops, the model will ignore the policy's loss scale, and you will have to apply it manually. This is explained in the next section."
+        "To solve this, TensorFlow dynamically determines the loss scale so you do not have to choose one manually. If you use `tf.keras.Model.fit`, loss scaling is done for you so you do not have to do any extra work. If you use a custom training loop, you must explicitly use the special optimizer wrapper `tf.keras.mixed_precision.LossScaleOptimizer` in order to use loss scaling. This is described in the next section.\n"
       ]
     },
     {
@@ -673,7 +591,7 @@
         "id": "M2zpp7_65mTZ"
       },
       "source": [
-        "For step (2), you will use the `tf.keras.mixed_precision.experimental.LossScaleOptimizer` class, which wraps an optimizer and applies loss scaling. It takes two arguments: the optimizer and the loss scale. Construct one as follows to use a dynamic loss scale:"
+        "For step (2), you will use the `tf.keras.mixed_precision.LossScaleOptimizer` class, which wraps an optimizer and applies loss scaling. By default, it dynamically determines the loss scale so you do not have to choose one. Construct a `LossScaleOptimizer` as follows."
       ]
     },
     {
@@ -896,10 +814,10 @@
         "  mixed_precision.set_global_policy('mixed_float16')\n",
         "  ```\n",
         "\n",
-        "- If your model ends with a softmax activation function, make sure the output is of type float32. And, regardless of what your model ends in, make sure the output data type is also float32.\n",
-        "- If you use a custom training loop with `mixed_float16`, in addition to the above lines, you need to wrap your optimizer with a `tf.keras.mixed_precision.experimental.LossScaleOptimizer`. Then call `optimizer.get_scaled_loss` to scale the loss, and `optimizer.get_unscaled_gradients` to unscale the gradients.\n",
-        "- You should double the training batch size if it does not reduce evaluation accuracy.\n",
-        "- On GPUs, make sure that most tensor dimensions are a multiple of $8$ to maximize performance.\n",
+        "* If your model ends in softmax, make sure it is float32. And regardless of what your model ends in, make sure the output is float32.\n",
+        "* If you use a custom training loop with `mixed_float16`, in addition to the above lines, you need to wrap your optimizer with a `tf.keras.mixed_precision.LossScaleOptimizer`. Then call `optimizer.get_scaled_loss` to scale the loss, and `optimizer.get_unscaled_gradients` to unscale the gradients.\n",
+        "* Double the training batch size if it does not reduce evaluation accuracy.\n",
+        "* On GPUs, ensure most tensor dimensions are a multiple of $8$ to maximize performance.\n",
         "\n",
         "For more examples of mixed precision using the `tf.keras.mixed_precision` API, check the [official models repository](https://github.com/tensorflow/models/tree/master/official). Most official models, such as [ResNet](https://github.com/tensorflow/models/tree/master/official/vision/image_classification) and [Transformer](https://github.com/tensorflow/models/blob/master/official/nlp/transformer), will run using mixed precision by passing `--dtype=fp16`.\n"
       ]

--- a/site/en/guide/mixed_precision.ipynb
+++ b/site/en/guide/mixed_precision.ipynb
@@ -828,7 +828,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "mixed_precision.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/site/en/guide/mixed_precision.ipynb
+++ b/site/en/guide/mixed_precision.ipynb
@@ -816,8 +816,8 @@
         "\n",
         "* If your model ends in softmax, make sure it is float32. And regardless of what your model ends in, make sure the output is float32.\n",
         "* If you use a custom training loop with `mixed_float16`, in addition to the above lines, you need to wrap your optimizer with a `tf.keras.mixed_precision.LossScaleOptimizer`. Then call `optimizer.get_scaled_loss` to scale the loss, and `optimizer.get_unscaled_gradients` to unscale the gradients.\n",
-        "* Double the training batch size if it does not reduce evaluation accuracy.\n",
-        "* On GPUs, ensure most tensor dimensions are a multiple of $8$ to maximize performance.\n",
+        "* Double the training batch size if it does not reduce evaluation accuracy\n",
+        "* On GPUs, ensure most tensor dimensions are a multiple of $8$ to maximize performance\n",
         "\n",
         "For more examples of mixed precision using the `tf.keras.mixed_precision` API, check the [official models repository](https://github.com/tensorflow/models/tree/master/official). Most official models, such as [ResNet](https://github.com/tensorflow/models/tree/master/official/vision/image_classification) and [Transformer](https://github.com/tensorflow/models/blob/master/official/nlp/transformer), will run using mixed precision by passing `--dtype=fp16`.\n"
       ]
@@ -834,7 +834,8 @@
     "kernelspec": {
       "display_name": "Python 3",
       "name": "python3"
-    }
+    },
+    "language_info": {}
   },
   "nbformat": 4,
   "nbformat_minor": 0


### PR DESCRIPTION
Splitting PR #1736 into smaller digestible bits. Cheers @lamberta @MarkDaoust 

There's a section on a technique for mixed precision training called "loss scaling" (I also read about it here https://arxiv.org/abs/1910.12385). It looks like we can say "a loss scale value" or "a loss scale hyperparameter". Here's my new suggestion:

```diff
The basic concept of loss scaling is simple:
- simply multiply the loss by some large number, say $1024$, 
+ multiply the loss by some large number, say $1024$, 
- We call this number the *loss scale*...
- You can call this number the *loss scale*.
+ and you get the *loss scale* value.
...
```

(I've removed "simply" to avoid repetition/duplication.)

Thank you 🙏