### PR TITLE
Fix incorrect link to save/restore model in multi-worker training tutorial

### DIFF
--- a/site/en/tutorials/distribute/multi_worker_with_keras.ipynb
+++ b/site/en/tutorials/distribute/multi_worker_with_keras.ipynb
@@ -1106,7 +1106,7 @@
       "source": [
         "If you inspect the directory of `backup_dir` you specified in `BackupAndRestore`, you may notice some temporarily generated checkpoint files. Those files are needed for recovering the previously lost instances, and they will be removed by the library at the end of `tf.keras.Model.fit()` upon successful exiting of your training.\n",
         "\n",
-        "Note: Currently BackupAndRestore only supports eager mode. In graph mode, consider using [Save/Restore Model](#scrollTo=EUNV5Utc1d0s) mentioned above, and by providing `initial_epoch` in `model.fit()`."
+        "Note: Currently BackupAndRestore only supports eager mode. In graph mode, consider using [Save/Restore Model](https://www.tensorflow.org/tutorials/distribute/multi_worker_with_keras#model_saving_and_loading) mentioned above, and by providing `initial_epoch` in `model.fit()`."
       ]
     },
     {


### PR DESCRIPTION
The existing link does not work.