### PR TITLE
use Pandas timestamp instead of datetime timestamp

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -398,7 +398,7 @@
       },
       "outputs": [],
       "source": [
-        "timestamp_s = date_time.map(datetime.datetime.timestamp)"
+        "timestamp_s = date_time.map(pd.Timestamp.timestamp)"
       ]
     },
     {


### PR DESCRIPTION
While the pandas dataframe seems to be in UTC (my inspector shows 'Z'  for zulu timezone, =UTC), Using datetime.datetime.timestamp seems to interpret the time as the local time. This results in different outputs depending on your local timezone (clearly visible in the ' Time of Day signal plot' ).

Using the pandas equivalent function works uniformly independent from local environment.