### PR TITLE
Correct call to Hyperband tuner

### DIFF
--- a/site/en/tutorials/keras/keras_tuner.ipynb
+++ b/site/en/tutorials/keras/keras_tuner.ipynb
@@ -237,7 +237,7 @@
       },
       "outputs": [],
       "source": [
-        "tuner = kt.Hyperband(model_builder,\n",
+        "tuner = kt.tuners.Hyperband(model_builder,\n",
         "                     objective = 'val_accuracy', \n",
         "                     max_epochs = 10,\n",
         "                     factor = 3,\n",


### PR DESCRIPTION
Previously omitted the 'tuners' subdirectory.  Unclear to me if this worked for a previous version, but this is how it's done in the docs and it works.