### PR TITLE
Fix typos

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -2583,13 +2583,13 @@
       "source": [
         "### Advanced: Autoregressive model\n",
         "\n",
-        "The above models all predict the entire output sequence as a in a single step.\n",
+        "The above models all predict the entire output sequence in a single step.\n",
         "\n",
         "In some cases it may be helpful for the model to decompose this prediction into individual time steps. Then each model's output can be fed back into itself at each step and predictions can be made conditioned on the previous one, like in the classic [Generating Sequences With Recurrent Neural Networks](https://arxiv.org/abs/1308.0850).\n",
         "\n",
         "One clear advantage to this style of model is that it can be set up to produce output with a varying length.\n",
         "\n",
-        "You could take any of single single-step multi-output models trained in the first half of this tutorial and run  in an autoregressive feedback loop, but here you'll focus on building a model that's been explicitly trained to do that.\n",
+        "You could take any of the single-step multi-output models trained in the first half of this tutorial and run  in an autoregressive feedback loop, but here you'll focus on building a model that's been explicitly trained to do that.\n",
         "\n",
         "![Feedback a model's output to its input](images/multistep_autoregressive.png)\n"
       ]


### PR DESCRIPTION
1. 'output sequence as a in a single step.' -> 'output sequence in a single step.'

2. 'You could take any of single single-step multi-output models' -> 'You could take any of the single-step multi-output models'