### PR TITLE
Fix argument for listing GPU

### DIFF
--- a/site/en/guide/distributed_training.ipynb
+++ b/site/en/guide/distributed_training.ipynb
@@ -439,7 +439,7 @@
       },
       "outputs": [],
       "source": [
-        "if tf.config.list_physical_devices('gpu'):\n",
+        "if tf.config.list_physical_devices('GPU'):\n",
         "  strategy = tf.distribute.MirroredStrategy()\n",
         "else:  # use default strategy\n",
         "  strategy = tf.distribute.get_strategy() \n",

--- a/site/en/guide/distributed_training.ipynb
+++ b/site/en/guide/distributed_training.ipynb
@@ -816,15 +816,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "hvZOgb_yw7l9"
-      },
-      "source": [
-        ""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "cP6BUIBtudRk"
       },
       "source": [
@@ -881,7 +872,6 @@
         "Tce3stUlHN0L"
       ],
       "name": "distributed_training.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
`tf.config.list_physical_devices('gpu')` does not correctly list the GPUs, changing to `GPU` fixes it. Reference: https://www.tensorflow.org/api_docs/python/tf/config/list_physical_devices