### PR TITLE
Nit: fix small typos in the Solve GLUE tasks using BERT on TPU tutorial

### DIFF
--- a/site/en/tutorials/text/solve_glue_tasks_using_bert_on_tpu.ipynb
+++ b/site/en/tutorials/text/solve_glue_tasks_using_bert_on_tpu.ipynb
@@ -176,9 +176,9 @@
         "id": "sv7A19G32Kfw"
       },
       "source": [
-        "Next, configure TFHub to read checkpoints directly from TFHub's Cloud Storage buckets. This is only recomended when running TFHub models on TPU.\n",
+        "Next, configure TFHub to read checkpoints directly from TFHub's Cloud Storage buckets. This is only recommended when running TFHub models on TPU.\n",
         "\n",
-        "Without this setting TFHub would download the compressed file and extract the checkpoint locally. Attempting to load from these local files will fail with following Error:\n",
+        "Without this setting TFHub would download the compressed file and extract the checkpoint locally. Attempting to load from these local files will fail with following error:\n",
         "\n",
         "```\n",
         "InvalidArgumentError: Unimplemented: File system scheme '[local]' not implemented\n",
@@ -231,7 +231,7 @@
         "  strategy = tf.distribute.MirroredStrategy()\n",
         "  print('Using GPU')\n",
         "else:\n",
-        "  raise ValueError('Running on CPU is not recomended.')"
+        "  raise ValueError('Running on CPU is not recommended.')"
       ]
     },
     {
@@ -527,7 +527,7 @@
         "\n",
         "Each BERT model has a specific preprocessing model, make sure to use the proper one described on the BERT's model documentation.\n",
         "\n",
-        "Note: BERT adds a \"position embedding\" to the token embedding of each input, and these come from a fixed-size lookup table. That imposes a max seq length of 512 (which is also a practical limit, due to the quadratic growth of attention computation). For this colab 128 is good enough."
+        "Note: BERT adds a \"position embedding\" to the token embedding of each input, and these come from a fixed-size lookup table. That imposes a max seq length of 512 (which is also a practical limit, due to the quadratic growth of attention computation). For this Colab 128 is good enough."
       ]
     },
     {
@@ -1073,7 +1073,7 @@
         "    else:\n",
         "      print(f'Sentence1 entails sentence2')\n",
         "\n",
-        "  print(f'Bert raw results:{bert_result[0]}')\n",
+        "  print(f'BERT raw results:{bert_result[0]}')\n",
         "  print()"
       ]
     },


### PR DESCRIPTION
A few small changes: "recommended", "Colab", "error", "BERT"