### PR TITLE
Note lack of support for macOS 11 (Big Sur)

### DIFF
--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -26,7 +26,7 @@ landing_page:
             </ul>
           </td><td>
             <ul>
-              <li>macOS &gt;10.12.6 (Sierra) but &lt;11 (Big Sur) (no GPU support)</li>
+              <li>macOS &gt;=10.12.6 (Sierra) but &lt;11 (Big Sur) (no GPU support)</li>
               <li>Raspbian 9.0 or later</li>
             </ul>
           </td></tr>

--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -26,7 +26,10 @@ landing_page:
             </ul>
           </td><td>
             <ul>
-              <li>macOS &gt;=10.12.6 (Sierra) but &lt;11 (Big Sur) (no GPU support)</li>
+              <li>
+                macOS &gt;=10.12.6 (Sierra) but &lt;11 (Big Sur) (no GPU support).
+                For Big Sur and GPU support, use <a href="https://github.com/apple/tensorflow_macos">tensorflow_macos</a>.
+              </li>
               <li>Raspbian 9.0 or later</li>
             </ul>
           </td></tr>

--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -26,7 +26,7 @@ landing_page:
             </ul>
           </td><td>
             <ul>
-              <li>macOS >10.12.6 (Sierra) but <11 (Big Sur) (no GPU support)</li>
+              <li>macOS &gt;10.12.6 (Sierra) but &lt;11 (Big Sur) (no GPU support)</li>
               <li>Raspbian 9.0 or later</li>
             </ul>
           </td></tr>

--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -26,7 +26,7 @@ landing_page:
             </ul>
           </td><td>
             <ul>
-              <li>macOS 10.12.6 (Sierra) or later (no GPU support)</li>
+              <li>macOS >10.12.6 (Sierra) but <11 (Big Sur) (no GPU support)</li>
               <li>Raspbian 9.0 or later</li>
             </ul>
           </td></tr>


### PR DESCRIPTION
See https://github.com/tensorflow/tensorflow/issues/45120 and https://github.com/tensorflow/tensorflow/issues/47205 - installation, at least with the standard method, does not work on Big Sur.

Better to note this lack of support explicitly rather than make each macOS 11 user debug the installation.