### PR TITLE
Use updated style for GitHub Action env vars

### DIFF
--- a/.github/workflows/bot-pr-new.yaml
+++ b/.github/workflows/bot-pr-new.yaml
@@ -50,7 +50,7 @@ jobs:
 
           msg+="If commits are added to the pull request, synchronize your local branch: <code>git pull origin $HEAD_REF</code>\n"
         fi
-        echo "::set-env name=MESSAGE::$msg"
+        echo "MESSAGE=$msg" >> $GITHUB_ENV
     - name: Post comment
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
set-env is deprecated for GitHub Actions env vars. Update to [new style](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable).

Tested here: https://github.com/lamberta/tf-docs/pull/9
