### PR TITLE
Stop doubling up on ".tar.gz" extension

### DIFF
--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -169,7 +169,7 @@
       "source": [
         "url = \"https://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz\"\n",
         "\n",
-        "dataset = tf.keras.utils.get_file(\"aclImdb_v1.tar.gz\", url,\n",
+        "dataset = tf.keras.utils.get_file(\"aclImdb_v1\", url,\n",
         "                                    untar=True, cache_dir='.',\n",
         "                                    cache_subdir='')\n",
         "\n",


### PR DESCRIPTION
Providing filename with extension results in a file on disk called "aclImdb_v1.tar.gz.tar.gz"

`get_file` appears to want a filename without an extension (though the documentation for it is unclear)