### PR TITLE
Don't import tensorflow_datasets - it's not used (or even installed)

### DIFF
--- a/site/en/tutorials/keras/text_classification_with_hub.ipynb
+++ b/site/en/tutorials/keras/text_classification_with_hub.ipynb
@@ -136,7 +136,6 @@
         "\n",
         "import tensorflow as tf\n",
         "import tensorflow_hub as hub\n",
-        "import tensorflow_datasets as tfds\n",
         "\n",
         "print(\"Version: \", tf.__version__)\n",
         "print(\"Eager mode: \", tf.executing_eagerly())\n",


### PR DESCRIPTION
Following this tutorial locally causes: ModuleNotFoundError: No module named 'tensorflow_datasets'

If we want to keep it then we need: pip install tensorflow-datasets

But I think we don't want to keep it because the module is not even referenced in the rest of the tutorial