### PR TITLE
Clarify get_dummies behavior

### DIFF
--- a/site/en/tutorials/keras/regression.ipynb
+++ b/site/en/tutorials/keras/regression.ipynb
@@ -252,7 +252,7 @@
         "id": "8XKitwaH4v8h"
       },
       "source": [
-        "The `\"Origin\"` column is really categorical, not numeric. So convert that to a one-hot:\n",
+        "The `\"Origin\"` column is really categorical, not numeric. So convert that to a one-hot with `pd.get_dummies`:\n",
         "\n",
         "Note: You can set up the `keras.Model` to do this kind of transformation for you. That's beyond the scope of this tutorial. See the [preprocessing layers](../structured_data/preprocessing_layers.ipynb) or [Loading CSV data](../load_data/csv.ipynb) tutorials for examples."
       ]
@@ -276,7 +276,7 @@
       },
       "outputs": [],
       "source": [
-        "dataset = pd.get_dummies(dataset, prefix='', prefix_sep='')\n",
+        "dataset = pd.get_dummies(dataset, columns=['Origin'], prefix='', prefix_sep='')\n",
         "dataset.tail()"
       ]
     },


### PR DESCRIPTION
I was mystified by this `get_dummies` call:

1. "Dummies" means nothing to me; I didn't know it was another term for one-hot. I hinted at this by mentioning the function in the text.
2. How on earth does `get_dummies` know that `Origin` is the categorical property? Why not `Cylinders` also? It turns out the current code kinda "works by accident" - it's because the dtype of the Origin column is "object". If it was "string", it wouldn't work. I fixed this by being explicit about which column it should convert to one-hot.