### PR TITLE
Don't guess at default batch size

### DIFF
--- a/site/en/tutorials/keras/save_and_load.ipynb
+++ b/site/en/tutorials/keras/save_and_load.ipynb
@@ -402,6 +402,7 @@
         "model.fit(train_images, \n",
         "          train_labels,\n",
         "          epochs=50, \n",
+        "          batch_size=batch_size, \n",
         "          callbacks=[cp_callback],\n",
         "          validation_data=(test_images, test_labels),\n",
         "          verbose=0)"


### PR DESCRIPTION
I was confused about this isolated `batch_size` variable - turns out it's (ab)using the fact that 32 is the current default batch size if unspecified

But if we need to know the batch size, we should specify it