### PR TITLE
fix: Error `dnn_horsepower_model` fit history doesn't have `val_loss` field

### DIFF
--- a/site/en/tutorials/keras/regression.ipynb
+++ b/site/en/tutorials/keras/regression.ipynb
@@ -1052,7 +1052,7 @@
         "history = dnn_horsepower_model.fit(\n",
         "    train_features['Horsepower'], train_labels,\n",
         "    validation_split=0.2,\n",
-        "    verbose=0, epochs=100)"
+        "    verbose=0, epochs=100, validation_split=0.2)"
       ]
     },
     {


### PR DESCRIPTION
The `dnn_horsepower_model` doesn't have `history.history['val_loss']` because the model fit not assign the validation split rate above.

```
plt.plot(history.history['val_loss'], label='val_loss')
KeyError: 'val_loss'
```