### PR TITLE
Define loss_object before usage in generator_loss function

### DIFF
--- a/site/en/tutorials/generative/pix2pix.ipynb
+++ b/site/en/tutorials/generative/pix2pix.ipynb
@@ -602,6 +602,17 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "Q1Xbz5OaLj5C"
+      },
+      "outputs": [],
+      "source": [
+        "loss_object = tf.keras.losses.BinaryCrossentropy(from_logits=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
         "id": "90BIcCKcDMxz"
       },
       "outputs": [],
@@ -716,17 +727,6 @@
         "  * real_loss is a sigmoid cross entropy loss of the **real images** and an **array of ones(since these are the real images)**\n",
         "  * generated_loss is a sigmoid cross entropy loss of the **generated images** and an **array of zeros(since these are the fake images)**\n",
         "  * Then the total_loss is the sum of real_loss and the generated_loss\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Q1Xbz5OaLj5C"
-      },
-      "outputs": [],
-      "source": [
-        "loss_object = tf.keras.losses.BinaryCrossentropy(from_logits=True)"
       ]
     },
     {


### PR DESCRIPTION
I was confused by this reference to an as-yet-undefined variable. It's not an error as long as the function is not called, but it's bad style