### PR TITLE
Fix link bug from 'basic_training_loops.ipynb' to 'distributed_training.ipynb'

### DIFF
--- a/site/en/guide/basic_training_loops.ipynb
+++ b/site/en/guide/basic_training_loops.ipynb
@@ -523,7 +523,7 @@
         "\n",
         "This is, however, an extremely simple problem. For a more practical introduction, see [Custom training walkthrough](../tutorials/customization/custom_training_walkthrough.ipynb).\n",
         "\n",
-        "For more on using built-in Keras training loops, see [this guide](keras/train_and_evaluate.ipynb).  For more on training loops and Keras, see [this guide](keras/writing_a_training_loop_from_scratch.ipynb).  For writing custom distributed training loops, see [this guide](./guide/distributed_training.ipynb#using_tfdistributestrategy_with_basic_training_loops_loops)."
+        "For more on using built-in Keras training loops, see [this guide](keras/train_and_evaluate.ipynb).  For more on training loops and Keras, see [this guide](keras/writing_a_training_loop_from_scratch.ipynb).  For writing custom distributed training loops, see [this guide](distributed_training.ipynb#using_tfdistributestrategy_with_basic_training_loops_loops)."
       ]
     }
   ],


### PR DESCRIPTION
There's a broken link on `basic_training_loops.ipynb` to `distributed_training.ipynb`

https://www.tensorflow.org/guide/basic_training_loops#next_steps