### PR TITLE
Update gpu.md

### DIFF
--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -109,10 +109,6 @@ wget http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1
 <code class="devsite-terminal">sudo apt install ./nvidia-machine-learning-repo-ubuntu1804_1.0.0-1_amd64.deb</code>
 <code class="devsite-terminal">sudo apt-get update</code>
 
-# Install NVIDIA driver
-<code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-driver-450</code>
-# Reboot. Check that GPUs are visible using the command: nvidia-smi
-
 <code class="devsite-terminal">wget https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/libnvinfer7_7.1.3-1+cuda11.0_amd64.deb</code>
 <code class="devsite-terminal">sudo apt install ./libnvinfer7_7.1.3-1+cuda11.0_amd64.deb</code>
 <code class="devsite-terminal">sudo apt-get update</code>
@@ -149,12 +145,6 @@ wget http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1
 <code class="devsite-terminal">wget https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64/libnvinfer7_7.1.3-1+cuda11.0_amd64.deb</code>
 <code class="devsite-terminal">sudo apt install ./libnvinfer7_7.1.3-1+cuda11.0_amd64.deb</code>
 <code class="devsite-terminal">sudo apt-get update</code>
-
-# Install NVIDIA driver
-# Issue with driver install requires creating /usr/lib/nvidia
-<code class="devsite-terminal">sudo mkdir /usr/lib/nvidia</code>
-<code class="devsite-terminal">sudo apt-get install --no-install-recommends nvidia-driver-450</code>
-# Reboot. Check that GPUs are visible using the command: nvidia-smi
 
 # Install development and runtime libraries (~4GB)
 <code class="devsite-terminal">sudo apt-get install --no-install-recommends \

--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -119,6 +119,7 @@ wget http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1
     libcudnn8=8.0.4.30-1+cuda11.0  \
     libcudnn8-dev=8.0.4.30-1+cuda11.0
 </code>
+# Reboot. Check that GPUs are visible using the command: nvidia-smi
 
 # Install TensorRT. Requires that libcudnn8 is installed above.
 <code class="devsite-terminal">sudo apt-get install -y --no-install-recommends libnvinfer7=7.1.3-1+cuda11.0 \
@@ -152,6 +153,8 @@ wget http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1
     libcudnn8=8.0.4.30-1+cuda11.0  \
     libcudnn8-dev=8.0.4.30-1+cuda11.0
 </code>
+
+# Reboot. Check that GPUs are visible using the command: nvidia-smi
 
 # Install TensorRT. Requires that libcudnn7 is installed above.
 <code class="devsite-terminal">sudo apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Removed redundant commands to install NVIDIA drivers

The `sudo apt-get install --no-install-recommends nvidia-driver-450` command seems redundant as latest drivers are installed and overwritten in the next step. Please check the below screenshot for reference. 

- Above command installs NVIDIA driver version 450
![1](https://user-images.githubusercontent.com/57165142/109850441-8721ef80-7c78-11eb-8d21-8375d003cd0d.png)

- After installing development and runtime libraries the driver version is updated to 460 
![2](https://user-images.githubusercontent.com/57165142/109850607-b20c4380-7c78-11eb-9c4b-a897aa83e773.png)


Relevant to issue [#47405](https://github.com/tensorflow/tensorflow/issues/47405). Change was previously merged in PR [#1749](https://github.com/tensorflow/docs/pull/1749/).