### PR TITLE
Rename variable 'layers' - it does not contain layers

### DIFF
--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -351,10 +351,10 @@
         "    'block_13_expand_relu',  # 8x8\n",
         "    'block_16_project',      # 4x4\n",
         "]\n",
-        "layers = [base_model.get_layer(name).output for name in layer_names]\n",
+        "base_model_outputs = [base_model.get_layer(name).output for name in layer_names]\n",
         "\n",
         "# Create the feature extraction model\n",
-        "down_stack = tf.keras.Model(inputs=base_model.input, outputs=layers)\n",
+        "down_stack = tf.keras.Model(inputs=base_model.input, outputs=base_model_outputs)\n",
         "\n",
         "down_stack.trainable = False"
       ]


### PR DESCRIPTION
I followed this tutorial but my program wasn't working. The cause was that I had created a list of layers, but it was supposed to be a list of layer outputs. These are quite different things.