### PR TITLE
Remove unused "x = inputs" assignment

### DIFF
--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -394,10 +394,9 @@
       "source": [
         "def unet_model(output_channels):\n",
         "  inputs = tf.keras.layers.Input(shape=[128, 128, 3])\n",
-        "  x = inputs\n",
         "\n",
         "  # Downsampling through the model\n",
-        "  skips = down_stack(x)\n",
+        "  skips = down_stack(inputs)\n",
         "  x = skips[-1]\n",
         "  skips = reversed(skips[:-1])\n",
         "\n",


### PR DESCRIPTION
Removing this assignment results in an identical model and less confusing code