### PR TITLE
set minimum Python version to 3.6 (since TF 2.4)

### DIFF
--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -20,7 +20,7 @@ landing_page:
         <table class="columns">
           <tr><td>
             <ul>
-              <li>Python 3.5–3.8</li>
+              <li>Python 3.6–3.8</li>
               <li>Ubuntu 16.04 or later</li>
               <li>Windows 7 or later (with <a href="https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads">C++ redistributable</a>)</li>
             </ul>

--- a/site/en/install/pip.html
+++ b/site/en/install/pip.html
@@ -26,7 +26,7 @@
 
 <h3>System requirements</h3>
 <ul>
-  <li>Python 3.5–3.8
+  <li>Python 3.6–3.8
     <ul>
       <li>Python 3.8 support requires TensorFlow 2.2 or later.</li>
     </ul>
@@ -61,7 +61,7 @@
   Check if your Python environment is already configured:
 </p>
 
-<aside class="note">Requires Python 3.5–3.8, pip and venv &gt;= 19.0</aside>
+<aside class="note">Requires Python 3.6–3.8, pip and venv &gt;= 19.0</aside>
 
 <pre class="prettyprint lang-bsh">
 <code class="devsite-terminal">python3 --version</code>


### PR DESCRIPTION
This was not yet reflected on https://www.tensorflow.org/install and https://www.tensorflow.org/install/pip
This PR removes the mentions of Python 3.5 on these pages.