### PR TITLE
pylintrc location and Python 3.5

### DIFF
--- a/site/en/community/contribute/code_style.md
+++ b/site/en/community/contribute/code_style.md
@@ -11,19 +11,16 @@ and use [pylint](https://www.pylint.org/) to check your Python changes.
 
 ### pylint
 
-To install `pylint` and retrieve TensorFlow's custom style definition:
+To install `pylint`:
 
 ```bash
-
 $ pip install pylint
-$ wget -O /tmp/pylintrc https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/tools/ci_build/pylintrc
-
 ```
 
-To check a file with `pylint`:
+To check a file with `pylint` from the TensorFlow source code root directory:
 
 ```bash
-$ pylint --rcfile=/tmp/pylintrc myfile.py
+$ pylint --rcfile=tensorflow/tools/ci_build/pylintrc tensorflow/python/keras/losses.py
 ```
 
 ### Supported Python versions

--- a/site/en/community/contribute/code_style.md
+++ b/site/en/community/contribute/code_style.md
@@ -25,8 +25,8 @@ $ pylint --rcfile=tensorflow/tools/ci_build/pylintrc tensorflow/python/keras/los
 
 ### Supported Python versions
 
-TensorFlow supports Python 3.6-3.8. See the
-[installation guide](https://www.tensorflow.org/install) for details.
+For supported Python versions, see the TensorFlow
+[installation guide](https://www.tensorflow.org/install).
 
 See the TensorFlow
 [continuous build status](https://github.com/tensorflow/tensorflow/blob/master/README.md#continuous-build-status)

--- a/site/en/community/contribute/code_style.md
+++ b/site/en/community/contribute/code_style.md
@@ -25,7 +25,7 @@ $ pylint --rcfile=tensorflow/tools/ci_build/pylintrc tensorflow/python/keras/los
 
 ### Supported Python versions
 
-TensorFlow supports Python >= 3.6. See the
+TensorFlow supports Python 3.6-3.8. See the
 [installation guide](https://www.tensorflow.org/install) for details.
 
 See the TensorFlow

--- a/site/en/community/contribute/code_style.md
+++ b/site/en/community/contribute/code_style.md
@@ -25,7 +25,7 @@ $ pylint --rcfile=tensorflow/tools/ci_build/pylintrc tensorflow/python/keras/los
 
 ### Supported Python versions
 
-TensorFlow supports Python >= 3.5. See the
+TensorFlow supports Python >= 3.6. See the
 [installation guide](https://www.tensorflow.org/install) for details.
 
 See the TensorFlow

--- a/site/en/install/source_windows.md
+++ b/site/en/install/source_windows.md
@@ -13,7 +13,7 @@ environment.
 ### Install Python and the TensorFlow package dependencies
 
 Install a
-[Python 3.5.x or Python 3.6.x 64-bit release for Windows](https://www.python.org/downloads/windows/){:.external}.
+[Python 3.6.x 64-bit release for Windows](https://www.python.org/downloads/windows/){:.external}.
 Select *pip* as an optional feature and add it to your `%PATH%` environmental
 variable.
 


### PR DESCRIPTION
 - Simplify the description on how to access the `pylintrc` file -- no need to use `wget`, it is available in the TF checkout.
 - I found two more places where Python 3.5 is mentioned. Python 3.5 is not supported any more since TF 2.4.