### PR TITLE
Update keras_tuner.ipynb

### DIFF
--- a/site/en/tutorials/keras/keras_tuner.ipynb
+++ b/site/en/tutorials/keras/keras_tuner.ipynb
@@ -359,7 +359,7 @@
         "hypermodel = tuner.hypermodel.build(best_hps)\n",
         "\n",
         "# Retrain the model\n",
-        "hypermodel.fit(img_test, label_test, epochs=best_epoch)"
+        "hypermodel.fit(img_train, label_train, epochs=best_epoch)"
       ]
     },
     {

--- a/site/en/tutorials/keras/keras_tuner.ipynb
+++ b/site/en/tutorials/keras/keras_tuner.ipynb
@@ -415,7 +415,6 @@
         "Tce3stUlHN0L"
       ],
       "name": "keras_tuner.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/site/en/tutorials/keras/keras_tuner.ipynb
+++ b/site/en/tutorials/keras/keras_tuner.ipynb
@@ -410,6 +410,7 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
     "colab": {
       "collapsed_sections": [
         "Tce3stUlHN0L"


### PR DESCRIPTION
Corrected a typo in the tutorial on using `training` data (`img_train`, `label_train`)  instead of `test` data (`img_test`, `label_test`) with `hypermodel`.

Fixes https://github.com/tensorflow/tensorflow/issues/47725