### PR TITLE
Make plot() customizable to show more data

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -849,7 +849,7 @@
         "  plot_col_index = self.column_indices[plot_col]\n",
         "  max_n = min(max_subplots, len(inputs))\n",
         "  for n in range(max_n):\n",
-        "    plt.subplot(3, 1, n+1)\n",
+        "    plt.subplot(max_n, 1, n+1)\n",
         "    plt.ylabel(f'{plot_col} [normed]')\n",
         "    plt.plot(self.input_indices, inputs[n, :, plot_col_index],\n",
         "             label='Inputs', marker='.', zorder=-10)\n",


### PR DESCRIPTION
If you increase max_subplots today, there's an out of range error because 3 is hardcoded in the plt.subplot call.