### PR TITLE
Fix wrong link in data input pipelines page

### DIFF
--- a/site/en/guide/data.ipynb
+++ b/site/en/guide/data.ipynb
@@ -2124,7 +2124,7 @@
         "id": "t0JMgvXEz9y1"
       },
       "source": [
-        "For an end to end time series example see: [Time series forecasting](../../tutorials/text/time_series.ipynb)."
+        "For an end to end time series example see: [Time series forecasting](../../tutorials/structured_data/time_series.ipynb)."
       ]
     },
     {


### PR DESCRIPTION
The link to Time series forecasting from the data input pipelines page
was wrong.

 Fixes tensorflow/tensorflow#48123