### PR TITLE
Add more hyperlinks for improved understandability

### DIFF
--- a/site/en/tutorials/keras/classification.ipynb
+++ b/site/en/tutorials/keras/classification.ipynb
@@ -154,7 +154,7 @@
         "\n",
         "This guide uses Fashion MNIST for variety, and because it's a slightly more challenging problem than regular MNIST. Both datasets are relatively small and are used to verify that an algorithm works as expected. They're good starting points to test and debug code.\n",
         "\n",
-        "Here, 60,000 images are used to train the network and 10,000 images to evaluate how accurately the network learned to classify images. You can access the Fashion MNIST directly from TensorFlow. Import and load the Fashion MNIST data directly from TensorFlow:"
+        "Here, 60,000 images are used to train the network and 10,000 images to evaluate how accurately the network learned to classify images. You can access the Fashion MNIST directly from TensorFlow. Import and [load the Fashion MNIST data](https://www.tensorflow.org/api_docs/python/tf/keras/datasets/fashion_mnist/load_data) directly from TensorFlow:"
       ]
     },
     {
@@ -442,7 +442,7 @@
       "source": [
         "### Set up the layers\n",
         "\n",
-        "The basic building block of a neural network is the *layer*. Layers extract representations from the data fed into them. Hopefully, these representations are meaningful for the problem at hand.\n",
+        "The basic building block of a neural network is the [*layer*](https://www.tensorflow.org/api_docs/python/tf/keras/layers). Layers extract representations from the data fed into them. Hopefully, these representations are meaningful for the problem at hand.\n",
         "\n",
         "Most of deep learning consists of chaining together simple layers. Most layers, such as `tf.keras.layers.Dense`, have parameters that are learned during training."
       ]
@@ -474,11 +474,11 @@
         "\n",
         "### Compile the model\n",
         "\n",
-        "Before the model is ready for training, it needs a few more settings. These are added during the model's *compile* step:\n",
+        "Before the model is ready for training, it needs a few more settings. These are added during the model's [*compile*](https://www.tensorflow.org/api_docs/python/tf/keras/Model#compile) step:\n",
         "\n",
-        "* *Loss function* —This measures how accurate the model is during training. You want to minimize this function to \"steer\" the model in the right direction.\n",
-        "* *Optimizer* —This is how the model is updated based on the data it sees and its loss function.\n",
-        "* *Metrics* —Used to monitor the training and testing steps. The following example uses *accuracy*, the fraction of the images that are correctly classified."
+        "* [*Loss function*](https://www.tensorflow.org/api_docs/python/tf/keras/losses) —This measures how accurate the model is during training. You want to minimize this function to \"steer\" the model in the right direction.\n",
+        "* [*Optimizer*](https://www.tensorflow.org/api_docs/python/tf/keras/optimizers) —This is how the model is updated based on the data it sees and its loss function.\n",
+        "* [*Metrics*](https://www.tensorflow.org/api_docs/python/tf/keras/metrics) —Used to monitor the training and testing steps. The following example uses *accuracy*, the fraction of the images that are correctly classified."
       ]
     },
     {
@@ -518,7 +518,7 @@
       "source": [
         "### Feed the model\n",
         "\n",
-        "To start training,  call the `model.fit` method—so called because it \"fits\" the model to the training data:"
+        "To start training,  call the [`model.fit`](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit) method—so called because it \"fits\" the model to the training data:"
       ]
     },
     {


### PR DESCRIPTION
Addresses all improvements listed at [#47552](https://github.com/tensorflow/tensorflow/issues/47552) except point (3).

For point (3), specifying `unit = 128` for a required parameter is unnecessarily verbose in my opinion (https://python-docs.readthedocs.io/en/latest/writing/style.html). Let me know if you feel this needs to be changed.

Fixes: tensorflow/tensorflow#47552