### PR TITLE
Added pre-commit hook for nbfmt

### DIFF
--- a/tools/tensorflow_docs/tools/.pre-commit-hooks.yaml
+++ b/tools/tensorflow_docs/tools/.pre-commit-hooks.yaml
@@ -1,3 +1,5 @@
+# Example using the https://pre-commit.com/ framework.
+# See: https://github.com/tensorflow/docs/blob/master/tools/tensorflow_docs/tools/README.md#pre-commit
 - id: nbformat
   name: nbformat
   description: "Run 'nbformat' on a Jupyter Notebook"

--- a/tools/tensorflow_docs/tools/.pre-commit-hooks.yaml
+++ b/tools/tensorflow_docs/tools/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: nbformat
+  name: nbformat
+  description: "Run 'nbformat' on a Jupyter Notebook"
+  entry: python -m tensorflow_docs.tools.nbfmt
+  language: python
+  language_version: python3
+  require_serial: true
+  types: [jupyter]
+  additional_dependencies: []

--- a/tools/tensorflow_docs/tools/README.md
+++ b/tools/tensorflow_docs/tools/README.md
@@ -51,6 +51,28 @@ up-to-date formatted state. See the tensorflow/docs
 [GitHub Actions workflow](https://github.com/tensorflow/docs/blob/master/.github/workflows/ci.yaml)
 for an example.
 
+### Pre-commit
+
+You can set up the nbfmt tool as a pre-commit check in other repos.
+To do this, use a standard Git hook or use the [https://pre-commit.com/](https://pre-commit.com/) framework to create the hook for you.
+
+If you want to use pre-commit to handle the hook installation for you, include the .pre-commit-config.yaml file in your repo with the following contents:
+
+```
+repos:
+- repo: https://github.com/tensorflow/docs
+  rev: pre-commit
+```
+
+Someone who clones that repo for development would then install the hook with:
+
+```
+# Install pre-commit framework
+pip3 install pre-commit
+
+# Install hooks
+pre-commit install
+```
 
 ## nblint
 

--- a/tools/tensorflow_docs/tools/README.md
+++ b/tools/tensorflow_docs/tools/README.md
@@ -53,10 +53,14 @@ for an example.
 
 ### Pre-commit
 
-You can set up the nbfmt tool as a pre-commit check in other repos.
-To do this, use a standard Git hook or use the [https://pre-commit.com/](https://pre-commit.com/) framework to create the hook for you.
+You can set up the `nbfmt` tool as a pre-commit check in other repos. To do
+this, use a standard Git hook or use the
+[https://pre-commit.com/](https://pre-commit.com/) framework to create the hook
+for you.
 
-If you want to use pre-commit to handle the hook installation for you, include the .pre-commit-config.yaml file in your repo with the following contents:
+If you want to use pre-commit to handle the hook installation for you, include
+the [.pre-commit-hooks.yaml](./.pre-commit-hooks.yaml) file in your repo with
+the following contents:
 
 ```
 repos:


### PR DESCRIPTION
Added a pre-commit hook that automatically calls nbfmt on every commit.

This uses the https://pre-commit.com/ framework.

To use it in another repo, the repo would need a .pre-commit-config.yaml file with the following contents:

```
repos:
- repo: https://github.com/tensorflow/docs
  rev: 6dc5e8258b871233e1dd373b49576f9755153bc2
```

Someone who clones that repo for development would then install the hook with:

```
# Install pre-commit framework
pip3 install pre-commit

# Install hooks
pre-commit install
```

