### PR TITLE
Fix custom estimators link

### DIFF
--- a/site/en/tutorials/estimator/premade.ipynb
+++ b/site/en/tutorials/estimator/premade.ipynb
@@ -221,7 +221,7 @@
         "`tf.estimator`\n",
         "(for example, `LinearRegressor`) to implement common ML algorithms. Beyond\n",
         "those, you may write your own\n",
-        "[custom Estimators](https://www.tensorflow.org/guide/custom_estimators).\n",
+        "[custom Estimators](https://www.tensorflow.org/guide/estimator#custom_estimators).\n",
         "We recommend using pre-made Estimators when just getting started.\n",
         "\n",
         "To write a TensorFlow program based on pre-made Estimators, you must perform the\n",


### PR DESCRIPTION
https://www.tensorflow.org/guide/custom_estimators is not an existing page.
https://www.tensorflow.org/guide/custom_estimators -> https://www.tensorflow.org/guide/estimator#custom_estimators