### PR TITLE
Fixing erroneous comment in Intermediate Results section

### DIFF
--- a/site/en/guide/autodiff.ipynb
+++ b/site/en/guide/autodiff.ipynb
@@ -481,7 +481,7 @@
         "\n",
         "# Use the tape to compute the gradient of z with respect to the\n",
         "# intermediate value y.\n",
-        "# dz_dx = 2 * y, where y = x ** 2\n",
+        "# dz_dx = dz_dy * dy_dx where dz_dy = 2 * y and y = x ** 2\n",
         "print(tape.gradient(z, y).numpy())"
       ]
     },

--- a/site/en/guide/autodiff.ipynb
+++ b/site/en/guide/autodiff.ipynb
@@ -1022,7 +1022,6 @@
         "Tce3stUlHN0L"
       ],
       "name": "autodiff.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/site/en/guide/autodiff.ipynb
+++ b/site/en/guide/autodiff.ipynb
@@ -481,7 +481,7 @@
         "\n",
         "# Use the tape to compute the gradient of z with respect to the\n",
         "# intermediate value y.\n",
-        "# dz_dx = dz_dy * dy_dx where dz_dy = 2 * y and y = x ** 2\n",
+        "# dz_dy = 2 * y and y = x ** 2 = 9\n",
         "print(tape.gradient(z, y).numpy())"
       ]
     },


### PR DESCRIPTION
Comment in intermediate results incorrectly states "dz_dx = 2 * y". It should state "dz_dy = 2*y" and proceeding with the chain rule: "dz_dx = dz_dy * dy_dx where dz_dy = 2 * y and y = x ** 2"