### PR TITLE
Fix repeated title in tutorials/structured_data/imbalanced_data

### DIFF
--- a/site/en/tutorials/structured_data/imbalanced_data.ipynb
+++ b/site/en/tutorials/structured_data/imbalanced_data.ipynb
@@ -145,7 +145,7 @@
       "source": [
         "### Download the Kaggle Credit Card Fraud data set\n",
         "\n",
-        "Pandas is a Python library with many helpful utilities for loading and working with structured data and can be used to download CSVs into a dataframe.\n",
+        "Pandas is a Python library with many helpful utilities for loading and working with structured data. It can be used to download CSVs into a Pandas [DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html#pandas.DataFrame).\n",
         "\n",
         "Note: This dataset has been collected and analysed during a research collaboration of Worldline and the [Machine Learning Group](http://mlg.ulb.ac.be) of ULB (Université Libre de Bruxelles) on big data mining and fraud detection. More details on current and past projects on related topics are available [here](https://www.researchgate.net/project/Fraud-detection-5) and the page of the [DefeatFraud](https://mlg.ulb.ac.be/wordpress/portfolio_page/defeatfraud-assessment-and-validation-of-deep-feature-engineering-and-learning-solutions-for-fraud-detection/) project"
       ]
@@ -254,7 +254,7 @@
       },
       "outputs": [],
       "source": [
-        "# Use a utility from sklearn to split and shuffle our dataset.\n",
+        "# Use a utility from sklearn to split and shuffle your dataset.\n",
         "train_df, test_df = train_test_split(cleaned_df, test_size=0.2)\n",
         "train_df, val_df = train_test_split(train_df, test_size=0.2)\n",
         "\n",
@@ -641,7 +641,7 @@
       "source": [
         "### Checkpoint the initial weights\n",
         "\n",
-        "To make the various training runs more comparable, keep this initial model's weights in a checkpoint file, and load them into each model before training."
+        "To make the various training runs more comparable, keep this initial model's weights in a checkpoint file, and load them into each model before training:"
       ]
     },
     {
@@ -783,7 +783,8 @@
       },
       "source": [
         "### Check training history\n",
-        "In this section, you will produce plots of your model's accuracy and loss on the training and validation set. These are useful to check for overfitting, which you can learn more about in this [tutorial](https://www.tensorflow.org/tutorials/keras/overfit_and_underfit).\n",
+        "\n",
+        "In this section, you will produce plots of your model's accuracy and loss on the training and validation set. These are useful to check for overfitting, which you can learn more about in the [Overfit and underfit](https://www.tensorflow.org/tutorials/keras/overfit_and_underfit) tutorial.\n",
         "\n",
         "Additionally, you can produce these plots for any of the metrics you created above. False negatives are included as an example."
       ]
@@ -844,7 +845,7 @@
       "source": [
         "### Evaluate metrics\n",
         "\n",
-        "You can use a [confusion matrix](https://developers.google.com/machine-learning/glossary/#confusion_matrix) to summarize the actual vs. predicted labels where the X axis is the predicted label and the Y axis is the actual label."
+        "You can use a [confusion matrix](https://developers.google.com/machine-learning/glossary/#confusion_matrix) to summarize the actual vs. predicted labels, where the X axis is the predicted label and the Y axis is the actual label:"
       ]
     },
     {
@@ -888,7 +889,7 @@
         "id": "nOTjD5Z5Wp1U"
       },
       "source": [
-        "Evaluate your model on the test dataset and display the results for the metrics you created above."
+        "Evaluate your model on the test dataset and display the results for the metrics you created above:"
       ]
     },
     {
@@ -969,6 +970,7 @@
       },
       "source": [
         "### Plot the AUPRC\r\n",
+        "\n",
         "Now plot the [AUPRC](https://developers.google.com/machine-learning/glossary?hl=en#PR_AUC). Area under the interpolated precision-recall curve, obtained by plotting (recall, precision) points for different values of the classification threshold. Depending on how it's calculated, PR AUC may be equivalent to the average precision of the model.\r\n"
       ]
     },
@@ -1062,7 +1064,7 @@
         "\n",
         "Now try re-training and evaluating the model with class weights to see how that affects the predictions.\n",
         "\n",
-        "Note: Using `class_weights` changes the range of the loss. This may affect the stability of the training depending on the optimizer. Optimizers whose step size is dependent on the magnitude of the gradient, like `optimizers.SGD`, may fail. The optimizer used here, `optimizers.Adam`, is unaffected by the scaling change. Also note that because of the weighting, the total losses are not comparable between the two models."
+        "Note: Using `class_weights` changes the range of the loss. This may affect the stability of the training depending on the optimizer. Optimizers whose step size is dependent on the magnitude of the gradient, like `tf.keras.optimizers.SGD`, may fail. The optimizer used here, `tf.keras.optimizers.Adam`, is unaffected by the scaling change. Also note that because of the weighting, the total losses are not comparable between the two models."
       ]
     },
     {
@@ -1498,7 +1500,7 @@
       "source": [
         "Because training is easier on the balanced data, the above training procedure may overfit quickly. \n",
         "\n",
-        "So break up the epochs to give the `callbacks.EarlyStopping` finer control over when to stop training."
+        "So break up the epochs to give the `tf.keras.callbacks.EarlyStopping` finer control over when to stop training."
       ]
     },
     {

--- a/site/en/tutorials/structured_data/imbalanced_data.ipynb
+++ b/site/en/tutorials/structured_data/imbalanced_data.ipynb
@@ -968,7 +968,7 @@
         "id": "Y5twGRLfNwmO"
       },
       "source": [
-        "### Plot the ROC\r\n",
+        "### Plot the AUPRC\r\n",
         "Now plot the [AUPRC](https://developers.google.com/machine-learning/glossary?hl=en#PR_AUC). Area under the interpolated precision-recall curve, obtained by plotting (recall, precision) points for different values of the classification threshold. Depending on how it's calculated, PR AUC may be equivalent to the average precision of the model.\r\n"
       ]
     },


### PR DESCRIPTION


In [tutorials/structured_data/imbalanced_data](https://github.com/tensorflow/docs/blob/master/site/en/tutorials/structured_data/imbalanced_data.ipynb) the section "[Plot the ROC](https://www.tensorflow.org/tutorials/structured_data/imbalanced_data#plot_the_roc)" is repeated, the second one should be "[Plot the AUPRC](https://www.tensorflow.org/tutorials/structured_data/imbalanced_data#plot_the_roc_2)".

