### PR TITLE
Updating checkpoint.ipynb by correcting a typo

### DIFF
--- a/site/en/guide/checkpoint.ipynb
+++ b/site/en/guide/checkpoint.ipynb
@@ -520,7 +520,7 @@
       "source": [
         "### Manually inspecting checkpoints\n",
         "\n",
-        "`tf.train.load_checkpoint` returns a `CheckpointReader` that gives lower level access to the checkpoint contents. It contains mappings from each vartiable's key, to the shape and dtype for each variable in the checkpoint. A variable's key is its object path, like in the graphs displayed above.\n",
+        "`tf.train.load_checkpoint` returns a `CheckpointReader` that gives lower level access to the checkpoint contents. It contains mappings from each variable's key, to the shape and dtype for each variable in the checkpoint. A variable's key is its object path, like in the graphs displayed above.\n",
         "\n",
         "Note: There is no higher level structure to the checkpoint. It only know's the paths and values for the variables, and has no concept of `models`, `layers` or how they are connected."
       ]


### PR DESCRIPTION
Correction of a typo; from "vartiable's key" to "variable's key".