### PR TITLE
Minor revision of the TF Better performance with `tf.function` guide

### DIFF
--- a/site/en/guide/function.ipynb
+++ b/site/en/guide/function.ipynb
@@ -272,8 +272,7 @@
         "id": "K7scSzLx662f"
       },
       "source": [
-        "When we pass arguments of different types into a `Function`, both stages are run:\n",
-        "\n"
+        "When we pass arguments of different types into a `Function`, both stages are run:\n"
       ]
     },
     {
@@ -370,8 +369,6 @@
         "id": "h62XoXho6EWN"
       },
       "source": [
-        "\n",
-        "\n",
         "- The key generated for a `tf.Tensor` is its shape and dtype.\n",
         "- The key generated for a `tf.Variable` is a unique variable id.\n",
         "- The key generated for a Python primitive (like `int`, `float`, `str`) is its value. \n",
@@ -385,7 +382,6 @@
         "id": "GNNN4lgRzpIs"
       },
       "source": [
-        "\n",
         "Note: Cache keys are based on the `Function` input parameters so changes to global and [free variables](https://docs.python.org/3/reference/executionmodel.html#binding-of-names) alone will not create a new trace. See [this section](#depending_on_python_global_and_free_variables) for recommended practices when dealing with Python global and free variables."
       ]
     },
@@ -1200,8 +1196,7 @@
         "id": "Tu0SnPwaL7pI"
       },
       "source": [
-        "You can close over outer names, as long as you don't update their values.\n",
-        "\n"
+        "You can close over outer names, as long as you don't update their values.\n"
       ]
     },
     {
@@ -1296,7 +1291,6 @@
       },
       "outputs": [],
       "source": [
-        "\n",
         "print(\"Adding bias!\")\n",
         "new_model.bias += 5.0\n",
         "# Create new Function and ConcreteFunction since you modified new_model.\n",
@@ -1519,7 +1513,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "function.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/site/en/guide/function.ipynb
+++ b/site/en/guide/function.ipynb
@@ -61,12 +61,11 @@
         "id": "J122XQYG7W6w"
       },
       "source": [
-        "In TensorFlow 2, eager execution is turned on by default. The user interface is intuitive and flexible (running one-off operations is much easier\n",
-        "and faster), but this can come at the expense of performance and deployability.\n",
+        "In TensorFlow 2, [eager execution](eager.ipynb) is turned on by default. The user interface is intuitive and flexible (running one-off operations is much easier and faster), but this can come at the expense of performance and deployability.\n",
         "\n",
         "You can use `tf.function` to make graphs out of your programs. It is a transformation tool that creates Python-independent dataflow graphs out of your Python code. This will help you create performant and portable models, and it is required to use `SavedModel`.\n",
         "\n",
-        "This guide will help you conceptualize how `tf.function` works under the hood so you can use it effectively.\n",
+        "This guide will help you conceptualize how `tf.function` works under the hood, so you can use it effectively.\n",
         "\n",
         "The main takeaways and recommendations are:\n",
         "\n",
@@ -228,7 +227,7 @@
         "  return conv_layer(image)\n",
         "\n",
         "image = tf.zeros([1, 200, 200, 100])\n",
-        "# warm up\n",
+        "# Warm up\n",
         "conv_layer(image); conv_fn(image)\n",
         "print(\"Eager conv:\", timeit.timeit(lambda: conv_layer(image), number=10))\n",
         "print(\"Function conv:\", timeit.timeit(lambda: conv_fn(image), number=10))\n",
@@ -426,11 +425,11 @@
         "  return tf.where(x % 2 == 0, x // 2, 3 * x + 1)\n",
         "\n",
         "print(next_collatz(tf.constant([1, 2])))\n",
-        "# We specified a 1-D tensor in the input signature, so this should fail.\n",
+        "# You specified a 1-D tensor in the input signature, so this should fail.\n",
         "with assert_raises(ValueError):\n",
         "  next_collatz(tf.constant([[1, 2], [3, 4]]))\n",
         "\n",
-        "# We specified an int32 dtype in the input signature, so this should fail.\n",
+        "# You specified an int32 dtype in the input signature, so this should fail.\n",
         "with assert_raises(ValueError):\n",
         "  next_collatz(tf.constant([1.0, 2.0]))\n"
       ]
@@ -443,7 +442,7 @@
       "source": [
         "- Specify a \\[None\\] dimension in `tf.TensorSpec` to allow for flexibility in trace reuse.\n",
         "\n",
-        "  Since TensorFlow matches tensors based on their shape, using a `None` dimension as a wildcard will allow `Function`s to reuse traces for variably-sized input. Variably-sized input can occur if you have sequences of different length, or images of different sizes for each batch (See [Transformer](../tutorials/text/transformer.ipynb) and [Deep Dream](../tutorials/generative/deepdream.ipynb) tutorials for example)."
+        "  Since TensorFlow matches tensors based on their shape, using a `None` dimension as a wildcard will allow `Function`s to reuse traces for variably-sized input. Variably-sized input can occur if you have sequences of different length, or images of different sizes for each batch (See the [Transformer](../tutorials/text/transformer.ipynb) and [Deep Dream](../tutorials/generative/deepdream.ipynb) tutorials for example)."
       ]
     },
     {
@@ -472,7 +471,7 @@
       "source": [
         "- Cast Python arguments to Tensors to reduce retracing.\n",
         "\n",
-        "  Often, Python arguments are used to control hyperparameters and graph constructions - for example, `num_layers=10` or `training=True` or `nonlinearity='relu'`. So if the Python argument changes, it makes sense that you'd have to retrace the graph.\n",
+        "  Often, Python arguments are used to control hyperparameters and graph constructions - for example, `num_layers=10` or `training=True` or `nonlinearity='relu'`. So, if the Python argument changes, it makes sense that you'd have to retrace the graph.\n",
         "\n",
         "  However, it's possible that a Python argument is not being used to control graph construction. In these cases, a change in the Python value can trigger needless retracing. Take, for example, this training loop, which AutoGraph will dynamically unroll. Despite the multiple traces, the generated graph is actually identical, so retracing is unnecessary."
       ]
@@ -708,7 +707,7 @@
         "- Plain old Python `print` calls only execute during tracing, helping you track down when your function gets (re)traced.\n",
         "- `tf.print` calls will execute every time, and can help you track down intermediate values during execution.\n",
         "- `tf.debugging.enable_check_numerics` is an easy way to track down where NaNs and Inf are created.\n",
-        "- `pdb` can help you understand what's going on during tracing. (Caveat: PDB will drop you into AutoGraph-transformed source code.)"
+        "- `pdb` (the [Python debugger](https://docs.python.org/3/library/pdb.html)) can help you understand what's going on during tracing. (Caveat: `pdb` will drop you into AutoGraph-transformed source code.)"
       ]
     },
     {
@@ -717,7 +716,7 @@
         "id": "5f05Vr_YBUCz"
       },
       "source": [
-        "## AutoGraph Transformations\n",
+        "## AutoGraph transformations\n",
         "\n",
         "AutoGraph is a library that is on by default in `tf.function`, and transforms a subset of Python eager code into graph-compatible TensorFlow ops. This includes control flow like `if`, `for`, `while`.\n",
         "\n",
@@ -732,7 +731,7 @@
       },
       "outputs": [],
       "source": [
-        "# Simple loop\n",
+        "# A simple loop\n",
         "\n",
         "@tf.function\n",
         "def f(x):\n",
@@ -776,7 +775,7 @@
         "\n",
         "A Python conditional executes during tracing, so exactly one branch of the conditional will be added to the graph. Without AutoGraph, this traced graph would be unable to take the alternate branch if there is data-dependent control flow.\n",
         "\n",
-        "`tf.cond` traces and adds both branches of the conditional to the graph, dynamically selecting a branch at execution time. Tracing can have unintended side effects; see [AutoGraph tracing effects](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/autograph/g3doc/reference/control_flow.md#effects-of-the-tracing-process) for more."
+        "`tf.cond` traces and adds both branches of the conditional to the graph, dynamically selecting a branch at execution time. Tracing can have unintended side effects; check out [AutoGraph tracing effects](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/autograph/g3doc/reference/control_flow.md#effects-of-the-tracing-process) for more information."
       ]
     },
     {
@@ -847,7 +846,7 @@
       "source": [
         "#### Looping over Python data\n",
         "\n",
-        "A common pitfall is to loop over Python/Numpy data within a `tf.function`. This loop will execute during the tracing process, adding a copy of your model to the `tf.Graph` for each iteration of the loop.\n",
+        "A common pitfall is to loop over Python/NumPy data within a `tf.function`. This loop will execute during the tracing process, adding a copy of your model to the `tf.Graph` for each iteration of the loop.\n",
         "\n",
         "If you want to wrap the entire training loop in `tf.function`, the safest way to do this is to wrap your data as a `tf.data.Dataset` so that AutoGraph will dynamically unroll the training loop."
       ]
@@ -889,9 +888,9 @@
         "id": "JeD2U-yrbfVb"
       },
       "source": [
-        "When wrapping Python/Numpy data in a Dataset, be mindful of `tf.data.Dataset.from_generator` versus ` tf.data.Dataset.from_tensors`. The former will keep the data in Python and fetch it via `tf.py_function` which can have performance implications, whereas the latter will bundle a copy of the data as one large `tf.constant()` node in the graph, which can have memory implications.\n",
+        "When wrapping Python/NumPy data in a Dataset, be mindful of `tf.data.Dataset.from_generator` versus ` tf.data.Dataset.from_tensors`. The former will keep the data in Python and fetch it via `tf.py_function` which can have performance implications, whereas the latter will bundle a copy of the data as one large `tf.constant()` node in the graph, which can have memory implications.\n",
         "\n",
-        "Reading data from files via TFRecordDataset/CsvDataset/etc. is the most effective way to consume data, as then TensorFlow itself can manage the asynchronous loading and prefetching of data, without having to involve Python. To learn more, see the [tf.data guide](../../guide/data)."
+        "Reading data from files via `TFRecordDataset`, `CsvDataset`, etc. is the most effective way to consume data, as then TensorFlow itself can manage the asynchronous loading and prefetching of data, without having to involve Python. To learn more, see the [`tf.data`: Build TensorFlow input pipelines](../../guide/data) guide."
       ]
     },
     {
@@ -1076,7 +1075,7 @@
         "id": "wcS3TAgCjTWR"
       },
       "source": [
-        "Just like how TensorFlow has a specialized `tf.TensorArray` for list constructs, it has a specialized `tf.data.Iterator` for iteration constructs. See the section on [AutoGraph Transformations](#autograph_transformations) for an overview. Also, the [`tf.data`](https://www.tensorflow.org/guide/data) API can help implement generator patterns:\n"
+        "Just like how TensorFlow has a specialized `tf.TensorArray` for list constructs, it has a specialized `tf.data.Iterator` for iteration constructs. See the section on [AutoGraph transformations](#autograph_transformations) for an overview. Also, the [`tf.data`](https://www.tensorflow.org/guide/data) API can help implement generator patterns:\n"
       ]
     },
     {


### PR DESCRIPTION
Nearly the same as old PR https://github.com/tensorflow/docs/pull/1779 (linting). Fresh fork. PTAL @lamberta 

Notable changes:

- Add a link to the Eager mode notebook:

```
In TensorFlow 2, [eager execution](eager.ipynb) is turned on by default.
```

- Add a short `pdb` description + link to the Python debugger:

```
`pdb` (the [Python debugger](https://docs.python.org/3/library/pdb.html)) can help you understand what's going on during tracing. (Caveat: `pdb` will drop you into AutoGraph-transformed source code.)
```

- "NumPy"