### PR TITLE
Minor revision of the TF Distributed training guide

### DIFF
--- a/site/en/guide/distributed_training.ipynb
+++ b/site/en/guide/distributed_training.ipynb
@@ -83,11 +83,11 @@
         "\n",
         "In TensorFlow 2.x, you can execute your programs eagerly, or in a graph using [`tf.function`](function.ipynb). `tf.distribute.Strategy` intends to support both these modes of execution, but works best with `tf.function`. Eager mode is only recommended for debugging purpose and not supported for `TPUStrategy`. Although training is the focus of this guide, this API can also be used for distributing evaluation and prediction on different platforms.\n",
         "\n",
-        "You can use `tf.distribute.Strategy` with very few changes to your code, because we have changed the underlying components of TensorFlow to become strategy-aware. This includes variables, layers, models, optimizers, metrics, summaries, and checkpoints.\n",
+        "You can use `tf.distribute.Strategy` with very few changes to your code, because the underlying components of TensorFlow have been changed to become strategy-aware. This includes variables, layers, models, optimizers, metrics, summaries, and checkpoints.\n",
         "\n",
-        "In this guide, we explain various types of strategies and how you can use them in different situations. To learn how to debug performance issues, see the [Optimize TensorFlow GPU Performance](gpu_performance_analysis.md) guide.\n",
+        "In this guide, you will learn about various types of strategies and how you can use them in different situations. To learn how to debug performance issues, see the [Optimize TensorFlow GPU performance](gpu_performance_analysis.md) guide.\n",
         "\n",
-        "Note: For a deeper understanding of the concepts, please watch [this deep-dive presentation](https://youtu.be/jKV53r9-H14). This is especially recommended if you plan to write your own training loop.\n"
+        "Note: For a deeper understanding of the concepts, watch the deep-dive presentation—[Inside TensorFlow: `tf.distribute.Strategy`](https://youtu.be/jKV53r9-H14). This is especially recommended if you plan to write your own training loop.\n"
       ]
     },
     {
@@ -109,12 +109,13 @@
       },
       "source": [
         "## Types of strategies\n",
+        "\n",
         "`tf.distribute.Strategy` intends to cover a number of use cases along different axes. Some of these combinations are currently supported and others will be added in the future. Some of these axes are:\n",
         "\n",
         "* *Synchronous vs asynchronous training:* These are two common ways of distributing training with data parallelism. In sync training, all workers train over different slices of input data in sync, and aggregating gradients at each step. In async training, all workers are independently training over the input data and updating variables asynchronously. Typically sync training is supported via all-reduce and async through parameter server architecture.\n",
         "* *Hardware platform:* You may want to scale your training onto multiple GPUs on one machine, or multiple machines in a network (with 0 or more GPUs each), or on Cloud TPUs.\n",
         "\n",
-        "In order to support these use cases, there are six strategies available. The next section explains which of these are supported in which scenarios in TF. Here is a quick overview:\n",
+        "In order to support these use cases, there are 6 strategies available. The next section explains which of these are supported in which scenarios in TensorFlow. Here is a quick overview:\n",
         "\n",
         "| Training API          \t| MirroredStrategy  \t| TPUStrategy         \t| MultiWorkerMirroredStrategy     \t| CentralStorageStrategy          \t| ParameterServerStrategy  \t|\n",
         "|:-----------------------\t|:-------------------\t|:---------------------\t|:---------------------------------\t|:---------------------------------\t|:--------------------------\t|\n",
@@ -124,7 +125,7 @@
         "\n",
         "Note: [Experimental support](https://www.tensorflow.org/guide/versions#what_is_not_covered) means the APIs are not covered by any compatibilities guarantees.\n",
         "\n",
-        "Note: Estimator support is limited. Basic training and evaluation are experimental, and advanced features—such as scaffold—are not implemented. We recommend using Keras or custom training loops if a use case is not covered."
+        "Note: Estimator support is limited. Basic training and evaluation are experimental, and advanced features—such as scaffold—are not implemented. You should be using Keras or custom training loops if a use case is not covered."
       ]
     },
     {
@@ -134,13 +135,12 @@
       },
       "source": [
         "### MirroredStrategy\n",
+        "\n",
         "`tf.distribute.MirroredStrategy` supports synchronous distributed training on multiple GPUs on one machine. It creates one replica per GPU device. Each variable in the model is mirrored across all the replicas. Together, these variables form a single conceptual variable called `MirroredVariable`. These variables are kept in sync with each other by applying identical updates.\n",
         "\n",
-        "Efficient all-reduce algorithms are used to communicate the variable updates across the devices.\n",
-        "All-reduce aggregates tensors across all the devices by adding them up, and makes them available on each device.\n",
-        "It’s a fused algorithm that is very efficient and can reduce the overhead of synchronization significantly. There are many all-reduce algorithms and implementations available, depending on the type of communication available between devices. By default, it uses NVIDIA NCCL as the all-reduce implementation. You can choose from a few other options, or write your own.\n",
+        "Efficient all-reduce algorithms are used to communicate the variable updates across the devices. All-reduce aggregates tensors across all the devices by adding them up, and makes them available on each device. It’s a fused algorithm that is very efficient and can reduce the overhead of synchronization significantly. There are many all-reduce algorithms and implementations available, depending on the type of communication available between devices. By default, it uses the the NVIDIA Collective Communication Library ([NCCL](https://developer.nvidia.com/nccl)) as the all-reduce implementation. You can choose from a few other options or write your own.\n",
         "\n",
-        "Here is the simplest way of creating `MirroredStrategy`:\n"
+        "Here is the simplest way of creating `MirroredStrategy`:"
       ]
     },
     {
@@ -160,7 +160,7 @@
         "id": "wldY4aFCAH4r"
       },
       "source": [
-        "This will create a `MirroredStrategy` instance which will use all the GPUs that are visible to TensorFlow, and use NCCL as the cross device communication.\n",
+        "This will create a `MirroredStrategy` instance, which will use all the GPUs that are visible to TensorFlow, and NCCL—as the cross-device communication.\n",
         "\n",
         "If you wish to use only some of the GPUs on your machine, you can do so like this:"
       ]
@@ -182,7 +182,7 @@
         "id": "8-KDnrJLAhav"
       },
       "source": [
-        "If you wish to override the cross device communication, you can do so using the `cross_device_ops` argument by supplying an instance of `tf.distribute.CrossDeviceOps`. Currently,  `tf.distribute.HierarchicalCopyAllReduce` and `tf.distribute.ReductionToOneDevice` are two options other than `tf.distribute.NcclAllReduce` which is the default."
+        "If you wish to override the cross device communication, you can do so using the `cross_device_ops` argument by supplying an instance of `tf.distribute.CrossDeviceOps`. Currently, `tf.distribute.HierarchicalCopyAllReduce` and `tf.distribute.ReductionToOneDevice` are two options other than `tf.distribute.NcclAllReduce`, which is the default."
       ]
     },
     {
@@ -204,22 +204,22 @@
       },
       "source": [
         "### TPUStrategy\n",
-        "`tf.distribute.TPUStrategy` lets you run your TensorFlow training on Tensor Processing Units (TPUs). TPUs are Google's specialized ASICs designed to dramatically accelerate machine learning workloads. They are available on Google Colab, the [TensorFlow Research Cloud](https://www.tensorflow.org/tfrc) and [Cloud TPU](https://cloud.google.com/tpu).\n",
         "\n",
-        "In terms of distributed training architecture, `TPUStrategy` is the same `MirroredStrategy` - it implements synchronous distributed training. TPUs provide their own implementation of efficient all-reduce and other collective operations across multiple TPU cores, which are used in `TPUStrategy`.\n",
+        "`tf.distribute.TPUStrategy` lets you run your TensorFlow training on Tensor Processing Units (TPUs). TPUs are Google's specialized ASICs designed to dramatically accelerate machine learning workloads. They are available on [Google Colab](https://colab.research.google.com/), the [TensorFlow Research Cloud](https://www.tensorflow.org/tfrc), and [Cloud TPU](https://cloud.google.com/tpu).\n",
+        "\n",
+        "In terms of distributed training architecture, `TPUStrategy` is the same `MirroredStrategy`—it implements synchronous distributed training. TPUs provide their own implementation of efficient all-reduce and other collective operations across multiple TPU cores, which are used in `TPUStrategy`.\n",
         "\n",
         "Here is how you would instantiate `TPUStrategy`:\n",
         "\n",
-        "Note: To run this code in Colab, you should select TPU as the Colab runtime. See [TensorFlow TPU Guide](https://www.tensorflow.org/guide/tpu).\n",
+        "Note: To run this code in Colab, you should select TPU as the Colab runtime. (See [TensorFlow TPU Guide](https://www.tensorflow.org/guide/tpu)).\n",
         "\n",
-        "```\n",
+        "```python\n",
         "cluster_resolver = tf.distribute.cluster_resolver.TPUClusterResolver(\n",
         "    tpu=tpu_address)\n",
         "tf.config.experimental_connect_to_cluster(cluster_resolver)\n",
         "tf.tpu.experimental.initialize_tpu_system(cluster_resolver)\n",
         "tpu_strategy = tf.distribute.TPUStrategy(cluster_resolver)\n",
         "```\n",
-        "\n",
         "\n",
         "The `TPUClusterResolver` instance helps locate the TPUs. In Colab, you don't need to specify any arguments to it.\n",
         "\n",
@@ -258,7 +258,7 @@
         "id": "bt94JBvhEr4s"
       },
       "source": [
-        "`MultiWorkerMirroredStrategy` has two implementations for cross-device communications.  `CommunicationImplementation.RING` is RPC-based and supports both CPU and GPU.  `CommunicationImplementation.NCCL` uses [Nvidia's NCCL](https://developer.nvidia.com/nccl) and provides the state of art performance on GPU, but it doesn't support CPU.  `CollectiveCommunication.AUTO` defers the choice to Tensorflow.   You can specify them in the following way:\n"
+        "`MultiWorkerMirroredStrategy` has two implementations for cross-device communications. `CommunicationImplementation.RING` is [RPC](https://en.wikipedia.org/wiki/Remote_procedure_call)-based and supports both CPUs and GPUs. `CommunicationImplementation.NCCL` uses NCCL and provides state-of-art performance on GPUs but it doesn't support CPUs. `CollectiveCommunication.AUTO` defers the choice to Tensorflow. You can specify them in the following way:\n"
       ]
     },
     {
@@ -281,7 +281,7 @@
         "id": "0JiImlw3F77E"
       },
       "source": [
-        "One of the key differences to get multi worker training going, as compared to multi-GPU training, is the multi-worker setup. The `TF_CONFIG` environment variable is the standard way in TensorFlow to specify the cluster configuration to each worker that is part of the cluster. Learn more about [setting up TF_CONFIG](#TF_CONFIG)."
+        "One of the key differences to get multi worker training going, as compared to multi-GPU training, is the multi-worker setup. The `TF_CONFIG` environment variable is the standard way in TensorFlow to specify the cluster configuration to each worker that is part of the cluster. Learn more about [setting up `TF_CONFIG`](#TF_CONFIG)."
       ]
     },
     {
@@ -291,15 +291,16 @@
       },
       "source": [
         "### ParameterServerStrategy\n",
-        "Parameter server training is a common data-parallel method to scale up model training on multiple machines. A parameter server training cluster consists of workers and parameter servers. Variables are created on parameter servers and they are read and updated by workers in each step. Please see the [parameter server training tutorial](../tutorials/distribute/parameter_server_training.ipynb) for details.\n",
         "\n",
-        "TensorFlow 2 parameter server training uses a central-coordinator based architecture via the `tf.distribute.experimental.coordinator.ClusterCoordinator` class. \n",
+        "Parameter server training is a common data-parallel method to scale up model training on multiple machines. A parameter server training cluster consists of workers and parameter servers. Variables are created on parameter servers and they are read and updated by workers in each step. Check out the [Parameter server training](../tutorials/distribute/parameter_server_training.ipynb) tutorial for details.\n",
         "\n",
-        "In this implementation the `worker` and `parameter server` tasks run `tf.distribute.Server`s that listen for tasks from the coordinator. The coordinator creates resources, dispatches training tasks, writes checkpoints, and deals with task failures.\n",
+        "In TensorFlow 2, parameter server training uses a central coordinator-based architecture via the `tf.distribute.experimental.coordinator.ClusterCoordinator` class. \n",
+        "\n",
+        "In this implementation, the `worker` and `parameter server` tasks run `tf.distribute.Server`s that listen for tasks from the coordinator. The coordinator creates resources, dispatches training tasks, writes checkpoints, and deals with task failures.\n",
         "\n",
         "In the programming running on the coordinator, you will use a `ParameterServerStrategy` object to define a training step and use a `ClusterCoordinator` to dispatch training steps to remote workers. Here is the simplest way to create them:\n",
         "\n",
-        "```Python\n",
+        "```python\n",
         "strategy = tf.distribute.experimental.ParameterServerStrategy(\n",
         "    tf.distribute.cluster_resolver.TFConfigClusterResolver(),\n",
         "    variable_partitioner=variable_partitioner)\n",
@@ -307,9 +308,9 @@
         "    strategy)\n",
         "```\n",
         "\n",
-        "Note you will need to configure TF_CONFIG environment variable if you use `TFConfigClusterResolver`. It is similar to  [TF_CONFIG](#TF_CONFIG) in `MultiWorkerMirroredStrategy` but has additional caveats.\n",
+        "Note: You will need to configure the `TF_CONFIG` environment variable if you use `TFConfigClusterResolver`. It is similar to [`TF_CONFIG`](#TF_CONFIG) in `MultiWorkerMirroredStrategy` but has additional caveats.\n",
         "\n",
-        "In TF 1, `ParameterServerStrategy` is available only with estimator via `tf.compat.v1.distribute.experimental.ParameterServerStrategy` symbol."
+        "In TensorFlow 1, `ParameterServerStrategy` is available only with an Estimator via `tf.compat.v1.distribute.experimental.ParameterServerStrategy` symbol."
       ]
     },
     {
@@ -381,9 +382,9 @@
       "source": [
         "#### Default Strategy\n",
         "\n",
-        "Default strategy is a distribution strategy which is present when no explicit distribution strategy is in scope. It implements the `tf.distribute.Strategy` interface but is a pass-through and provides no actual distribution. For instance, `strategy.run(fn)` will simply call `fn`. Code written using this strategy should behave exactly as code written without any strategy. You can think of it as a \"no-op\" strategy.\n",
+        "The Default Strategy is a distribution strategy which is present when no explicit distribution strategy is in scope. It implements the `tf.distribute.Strategy` interface but is a pass-through and provides no actual distribution. For instance, `strategy.run(fn)` will simply call `fn`. Code written using this strategy should behave exactly as code written without any strategy. You can think of it as a \"no-op\" strategy.\n",
         "\n",
-        "Default strategy is a singleton - and one cannot create more instances of it. It can be obtained using `tf.distribute.get_strategy()` outside any explicit strategy's scope (the same API that can be used to get the current strategy inside an explicit strategy's scope). "
+        "The Default Strategy is a singleton—and one cannot create more instances of it. It can be obtained using `tf.distribute.get_strategy` outside any explicit strategy's scope (the same API that can be used to get the current strategy inside an explicit strategy's scope). "
       ]
     },
     {
@@ -405,7 +406,7 @@
       "source": [
         "This strategy serves two main purposes:\n",
         "\n",
-        "* It allows writing distribution aware library code unconditionally. For example, in `tf.optimizer`s can use `tf.distribute.get_strategy()` and use that strategy for reducing gradients - it will always return a strategy object on which we can call the reduce API.\n"
+        "* It allows writing distribution aware library code unconditionally. For example, in `tf.optimizer`s can use `tf.distribute.get_strategy` and use that strategy for reducing gradients—it will always return a strategy object on which you can call the reduce API.\n"
       ]
     },
     {
@@ -428,7 +429,7 @@
         "id": "JURbH-pUT51B"
       },
       "source": [
-        "* Similar to library code, it can be used to write end users' programs to work with and without distribution strategy, without requiring conditional logic. A sample code snippet illustrating this:"
+        "* Similar to library code, it can be used to write end users' programs to work with and without distribution strategy, without requiring conditional logic. Here's a sample code snippet illustrating this:"
       ]
     },
     {
@@ -441,11 +442,11 @@
       "source": [
         "if tf.config.list_physical_devices('GPU'):\n",
         "  strategy = tf.distribute.MirroredStrategy()\n",
-        "else:  # use default strategy\n",
+        "else:  # Use the Default Strategy\n",
         "  strategy = tf.distribute.get_strategy() \n",
         "\n",
         "with strategy.scope():\n",
-        "  # do something interesting\n",
+        "  # Do something interesting\n",
         "  print(tf.Variable(1.))"
       ]
     },
@@ -456,17 +457,18 @@
       },
       "source": [
         "#### OneDeviceStrategy\n",
+        "\n",
         "`tf.distribute.OneDeviceStrategy` is a strategy to place all variables and computation on a single specified device. \n",
         "\n",
-        "```\n",
+        "```python\n",
         "strategy = tf.distribute.OneDeviceStrategy(device=\"/gpu:0\")\n",
         "```\n",
         "\n",
-        "This strategy is distinct from the default strategy in a number of ways. In default strategy, the variable placement logic remains unchanged when compared to running TensorFlow without any distribution strategy. But when using `OneDeviceStrategy`, all variables created in its scope are explicitly placed on the specified device. Moreover, any functions called via `OneDeviceStrategy.run` will also be placed on the specified device. \n",
+        "This strategy is distinct from the Default Strategy in a number of ways. In the Default Strategy, the variable placement logic remains unchanged when compared to running TensorFlow without any distribution strategy. But when using `OneDeviceStrategy`, all variables created in its scope are explicitly placed on the specified device. Moreover, any functions called via `OneDeviceStrategy.run` will also be placed on the specified device. \n",
         "\n",
-        "Input distributed through this strategy will be prefetched to the specified device. In default strategy, there is no input distribution.\n",
+        "Input distributed through this strategy will be prefetched to the specified device. In the Default Strategy, there is no input distribution.\n",
         "\n",
-        "Similar to the default strategy, this strategy could also be used to test your code before switching to other strategies which actually distribute to multiple devices/machines. This will exercise the distribution strategy machinery somewhat more than default strategy, but not to the full extent as using `MirroredStrategy` or `TPUStrategy` etc. If you want code that behaves as if no strategy, then use default strategy."
+        "Similar to the Default Strategy, this strategy could also be used to test your code before switching to other strategies which actually distribute to multiple devices/machines. This will exercise the distribution strategy machinery somewhat more than default strategy, but not to the full extent as using `MirroredStrategy` or `TPUStrategy` etc. If you want code that behaves as if no strategy, then use default strategy."
       ]
     },
     {
@@ -486,15 +488,14 @@
       "source": [
         "## Using `tf.distribute.Strategy` with `tf.keras.Model.fit`\n",
         "\n",
-        "`tf.distribute.Strategy` is integrated into `tf.keras` which is TensorFlow's implementation of the\n",
-        "[Keras API specification](https://keras.io). `tf.keras`  is a high-level API to build and train models. By integrating into `tf.keras` backend, we've made it seamless for you to distribute your training written in the Keras training framework using `model.fit`.\n",
+        "`tf.distribute.Strategy` is integrated into `tf.keras`, which is TensorFlow's implementation of the [Keras API specification](https://keras.io). `tf.keras` is a high-level API to build and train models. By integrating into `tf.keras` backend, we've made it seamless for you to distribute your training written in the Keras training framework using `Model.fit`.\n",
         "\n",
         "Here's what you need to change in your code:\n",
         "\n",
         "1. Create an instance of the appropriate `tf.distribute.Strategy`.\n",
         "2. Move the creation of Keras model, optimizer and metrics inside `strategy.scope`.\n",
         "\n",
-        "We support all types of Keras models - sequential, functional and subclassed.\n",
+        "TensorFlow distribution strategies support all types of Keras models—Sequential, Functional, and subclassed.\n",
         "\n",
         "Here is a snippet of code to do this for a very simple Keras model with one dense layer:"
       ]
@@ -521,7 +522,7 @@
         "id": "773EOxCRVlTg"
       },
       "source": [
-        "This example usees `MirroredStrategy` so you can run this on a machine with multiple GPUs. `strategy.scope()` indicates to Keras which strategy to use to distribute the training. Creating models/optimizers/metrics inside this scope allows us to create distributed variables instead of regular variables. Once this is set up, you can fit your model like you would normally. `MirroredStrategy` takes care of replicating the model's training on the available GPUs, aggregating gradients, and more."
+        "This example uses `MirroredStrategy`, so you can run this on a machine with multiple GPUs. `strategy.scope()` indicates to Keras which strategy to use to distribute the training. Creating models/optimizers/metrics inside this scope allows you to create distributed variables instead of regular variables. Once this is set up, you can fit your model like you would normally. `MirroredStrategy` takes care of replicating the model's training on the available GPUs, aggregating gradients, and more."
       ]
     },
     {
@@ -543,7 +544,7 @@
         "id": "nofTLwyXWHK8"
       },
       "source": [
-        "Here a `tf.data.Dataset` provides the training and eval input. You can also use numpy arrays:"
+        "Here a `tf.data.Dataset` provides the training and eval input. You can also use NumPy arrays:"
       ]
     },
     {
@@ -555,6 +556,7 @@
       "outputs": [],
       "source": [
         "import numpy as np\n",
+        "\n",
         "inputs, targets = np.ones((100, 1)), np.ones((100, 1))\n",
         "model.fit(inputs, targets, epochs=2, batch_size=10)"
       ]
@@ -565,7 +567,7 @@
         "id": "IKqaj7QwX0Zb"
       },
       "source": [
-        "In both cases (dataset or numpy), each batch of the given input is divided equally among the multiple replicas. For instance, if using `MirroredStrategy` with 2 GPUs, each batch of size 10 will get divided among the 2 GPUs, with each receiving 5 input examples in each step. Each epoch will then train faster as you add more GPUs. Typically, you would want to increase your batch size as you add more accelerators so as to make effective use of the extra computing power. You will also need to re-tune your learning rate, depending on the model. You can use `strategy.num_replicas_in_sync` to get the number of replicas."
+        "In both cases—with `Dataset` or Numpy—each batch of the given input is divided equally among the multiple replicas. For instance, if you are using the `MirroredStrategy` with 2 GPUs, each batch of size 10 will get divided among the 2 GPUs, with each receiving 5 input examples in each step. Each epoch will then train faster as you add more GPUs. Typically, you would want to increase your batch size as you add more accelerators, so as to make effective use of the extra computing power. You will also need to re-tune your learning rate, depending on the model. You can use `strategy.num_replicas_in_sync` to get the number of replicas."
       ]
     },
     {
@@ -595,14 +597,13 @@
       "source": [
         "### What's supported now?\n",
         "\n",
-        "\n",
         "| Training API \t| MirroredStrategy  \t| TPUStrategy         \t| MultiWorkerMirroredStrategy     \t| ParameterServerStrategy          \t| CentralStorageStrategy \t|\n",
         "|----------------\t|---------------------\t|-----------------------\t|-----------------------------------\t|-----------------------------------\t|---------------------------\t|\n",
         "| Keras APIs   \t| Supported \t| Supported \t| Experimental support \t| Experimental support \t| Experimental support   \t|\n",
         "\n",
-        "### Examples and Tutorials\n",
+        "### Examples and tutorials\n",
         "\n",
-        "Here is a list of tutorials and examples that illustrate the above integration end to end with Keras:\n",
+        "Here is a list of tutorials and examples that illustrate the above integration end-to-end with Keras:\n",
         "\n",
         "1. [Tutorial](https://www.tensorflow.org/tutorials/distribute/keras) to train MNIST with `MirroredStrategy`.\n",
         "2. [Tutorial](https://www.tensorflow.org/tutorials/distribute/multi_worker_with_keras) to train MNIST using `MultiWorkerMirroredStrategy`.\n",
@@ -624,7 +625,7 @@
         "\n",
         "The `tf.distribute.Strategy` classes provide a core set of methods through to support custom training loops. Using these may require minor restructuring of the code initially, but once that is done, you should be able to switch between GPUs, TPUs, and multiple machines simply by changing the strategy instance.\n",
         "\n",
-        "Here we will show a brief snippet illustrating this use case for a simple training example using the same Keras model as before.\n"
+        "Here, you will see a brief snippet illustrating this use case for a simple training example using the same Keras model as before.\n"
       ]
     },
     {
@@ -677,7 +678,7 @@
         "id": "grzmTlSvn2j8"
       },
       "source": [
-        "Then, define one step of the training. Use `tf.GradientTape` to compute gradients and optimizer to apply those gradients to update our model's variables. To distribute this training step, put it in a function `train_step` and pass it to `tf.distrbute.Strategy.run` along with the dataset inputs you got from the `dist_dataset` created before:"
+        "Then, define one step of the training. Use `tf.GradientTape` to compute gradients and optimizer to apply those gradients to update your model's variables. To distribute this training step, put it in a function `train_step` and pass it to `tf.distrbute.Strategy.run` along with the dataset inputs you got from the `dist_dataset` created before:"
       ]
     },
     {
@@ -722,9 +723,9 @@
       "source": [
         "A few other things to note in the code above:\n",
         "\n",
-        "1. It used `tf.nn.compute_average_loss` to compute the loss. `tf.nn.compute_average_loss` sums the per example loss and divide the sum by the global_batch_size. This is important because later after the gradients are calculated on each replica, they are aggregated across the replicas by **summing** them.\n",
-        "2. It used the `tf.distribute.Strategy.reduce` API to aggregate the results returned by `tf.distribute.Strategy.run`. `tf.distribute.Strategy.run` returns results from each local replica in the strategy, and there are multiple ways to consume this result. You can `reduce` them to get an aggregated value. You can also do `tf.distribute.Strategy.experimental_local_results` to get the list of values contained in the result, one per local replica.\n",
-        "3. When `apply_gradients` is called within a distribution strategy scope, its behavior is modified. Specifically, before applying gradients on each parallel instance during synchronous training, it performs a sum-over-all-replicas of the gradients.\n"
+        "1. You used `tf.nn.compute_average_loss` to compute the loss. `tf.nn.compute_average_loss` sums the per example loss and divide the sum by the global_batch_size. This is important because later after the gradients are calculated on each replica, they are aggregated across the replicas by **summing** them.\n",
+        "2. You also used the `tf.distribute.Strategy.reduce` API to aggregate the results returned by `tf.distribute.Strategy.run`. `tf.distribute.Strategy.run` returns results from each local replica in the strategy, and there are multiple ways to consume this result. You can `reduce` them to get an aggregated value. You can also do `tf.distribute.Strategy.experimental_local_results` to get the list of values contained in the result, one per local replica.\n",
+        "3. When you call `apply_gradients` within a distribution strategy scope, its behavior is modified. Specifically, before applying gradients on each parallel instance during synchronous training, it performs a sum-over-all-replicas of the gradients.\n"
       ]
     },
     {
@@ -733,7 +734,7 @@
         "id": "o9k_6-6vpQ-P"
       },
       "source": [
-        "Finally, once you have defined the training step, we can iterate over `dist_dataset` and run the training in a loop:"
+        "Finally, once you have defined the training step, you can iterate over `dist_dataset` and run the training in a loop:"
       ]
     },
     {
@@ -754,10 +755,9 @@
         "id": "jK8eQXF_q1Zs"
       },
       "source": [
-        "In the example above, you iterated over the `dist_dataset` to provide input to your training. We also provide the  `tf.distribute.Strategy.make_experimental_numpy_dataset` to support numpy inputs. You can use this API to create a dataset before calling `tf.distribute.Strategy.experimental_distribute_dataset`.\n",
+        "In the example above, you iterated over the `dist_dataset` to provide input to your training. You are also provided with the `tf.distribute.Strategy.make_experimental_numpy_dataset` to support NumPy inputs. You can use this API to create a dataset before calling `tf.distribute.Strategy.experimental_distribute_dataset`.\n",
         "\n",
-        "Another way of iterating over your data is to explicitly use iterators. You may want to do this when you want to run for a given number of steps as opposed to iterating over the entire dataset.\n",
-        "The above iteration would now be modified to first create an iterator and then explicitly call `next` on it to get the input data.\n"
+        "Another way of iterating over your data is to explicitly use iterators. You may want to do this when you want to run for a given number of steps as opposed to iterating over the entire dataset. The above iteration would now be modified to first create an iterator and then explicitly call `next` on it to get the input data."
       ]
     },
     {
@@ -794,7 +794,8 @@
         "|:-----------------------\t|:-------------------\t|:-------------------\t|:-----------------------------\t|:------------------------\t|:-------------------------\t|\n",
         "| Custom Training Loop  \t|  Supported \t| Supported \t| Experimental support   \t| Experimental support \t| Experimental support        \t|\n",
         "\n",
-        "### Examples and Tutorials\n",
+        "### Examples and tutorials\n",
+        "\n",
         "Here are some examples for using distribution strategy with custom training loops:\n",
         "\n",
         "1. [Tutorial](https://www.tensorflow.org/tutorials/distribute/custom_training) to train MNIST using `MirroredStrategy`.\n",
@@ -820,18 +821,18 @@
       },
       "source": [
         "<a name=\"TF_CONFIG\"></a>\n",
-        "### Setting up TF\\_CONFIG environment variable\n",
+        "### Setting up the TF\\_CONFIG environment variable\n",
         "\n",
-        "For multi-worker training, as mentioned before, you need to set `TF_CONFIG` environment variable for each\n",
-        "binary running in your cluster. The `TF_CONFIG` environment variable is a JSON string which specifies what\n",
-        "tasks constitute a cluster, their addresses and each task's role in the cluster.  The\n",
-        "[tensorflow/ecosystem](https://github.com/tensorflow/ecosystem) repo provides a Kubernetes template in which sets\n",
-        "`TF_CONFIG` for your training tasks.\n",
+        "For multi-worker training, as mentioned before, you need to set up the `TF_CONFIG` environment variable for each binary running in your cluster. The `TF_CONFIG` environment variable is a JSON string which specifies what tasks constitute a cluster, their addresses and each task's role in the cluster. The [`tensorflow/ecosystem`](https://github.com/tensorflow/ecosystem) repo provides a Kubernetes template, which sets up `TF_CONFIG` for your training tasks.\n",
         "\n",
-        "There are two components of TF_CONFIG: cluster and task. cluster provides information about the training cluster, which is a dict consisting of different types of jobs such as worker. In multi-worker training, there is usually one worker that takes on a little more responsibility like saving checkpoint and writing summary file for TensorBoard in addition to what a regular worker does. Such worker is referred to as the 'chief' worker, and it is customary that the worker with index 0 is appointed as the chief worker (in fact this is how tf.distribute.Strategy is implemented). task on the other hand provides information of the current task. The first component cluster is the same for all workers, and the second component task is different on each worker and specifies the type and index of that worker.\n",
+        "There are two components of `TF_CONFIG`: a cluster and a task.\n",
+        "\n",
+        "- A cluster provides information about the training cluster, which is a dict consisting of different types of jobs such as worker. In multi-worker training, there is usually one worker that takes on a little more responsibility like saving checkpoint and writing summary file for TensorBoard in addition to what a regular worker does. Such worker is referred to as the \"chief\" worker, and it is customary that the worker with index 0 is appointed as the chief worker (in fact this is how `tf.distribute.Strategy` is implemented).\n",
+        "- A task on the other hand provides information of the current task. The first component cluster is the same for all workers, and the second component task is different on each worker and specifies the type and index of that worker.\n",
         "\n",
         "One example of `TF_CONFIG` is:\n",
-        "```\n",
+        "\n",
+        "```python\n",
         "os.environ[\"TF_CONFIG\"] = json.dumps({\n",
         "    \"cluster\": {\n",
         "        \"worker\": [\"host1:port\", \"host2:port\", \"host3:port\"],\n",
@@ -848,10 +849,7 @@
         "id": "fezd3aF8wj9r"
       },
       "source": [
-        "This `TF_CONFIG` specifies that there are three workers and two ps tasks in the\n",
-        "cluster along with their hosts and ports. The \"task\" part specifies that the\n",
-        "role of the current task in the cluster, worker 1 (the second worker). Valid roles in a cluster is\n",
-        "\"chief\", \"worker\", \"ps\" and \"evaluator\". There should be no \"ps\" job except when using `tf.distribute.experimental.ParameterServerStrategy`."
+        "This `TF_CONFIG` specifies that there are three workers and two `\"ps\"` tasks in the `\"cluster\"` along with their hosts and ports. The `\"task\"` part specifies that the role of the current task in the `\"cluster\"`—worker 1 (the second worker). Valid roles in a cluster are `\"chief\"`, `\"worker\"`, `\"ps\"`, and `\"evaluator\"`. There should be no `\"ps\"` job except when using `tf.distribute.experimental.ParameterServerStrategy`."
       ]
     },
     {

--- a/site/en/guide/distributed_training.ipynb
+++ b/site/en/guide/distributed_training.ipynb
@@ -488,7 +488,7 @@
       "source": [
         "## Using `tf.distribute.Strategy` with `tf.keras.Model.fit`\n",
         "\n",
-        "`tf.distribute.Strategy` is integrated into `tf.keras`, which is TensorFlow's implementation of the [Keras API specification](https://keras.io). `tf.keras` is a high-level API to build and train models. By integrating into `tf.keras` backend, we've made it seamless for you to distribute your training written in the Keras training framework using `Model.fit`.\n",
+        "`tf.distribute.Strategy` is integrated into `tf.keras`, which is TensorFlow's implementation of the [Keras API specification](https://keras.io). `tf.keras` is a high-level API to build and train models. By integrating into `tf.keras` backend, it's seamless for you to distribute your training written in the Keras training framework using `Model.fit`.\n",
         "\n",
         "Here's what you need to change in your code:\n",
         "\n",


### PR DESCRIPTION
This PR replaces an older PR - the APIs in TensorFlow distribution strategies - `tf.distribute` - have changed and the content has evolved. PTAL @lamberta 👍 

Notable changes for improved UX:

- Add a video description: _"Inside TensorFlow: `tf.distribute.Strategy`"_

```
For a deeper understanding of the concepts, watch the deep-dive presentation—[Inside TensorFlow: `tf.distribute.Strategy`](https://youtu.be/jKV53r9-H14). This is especially recommended if you plan to write your own training loop.
```

- Spell out **NCCL**: _"NVIDIA Collective Communication Library ([NCCL](https://developer.nvidia.com/nccl))"_.

- Add a Wiki link to **Remote Procedure Call (RPC)** (Wiki: _"In distributed computing, a remote procedure call (RPC) is when a computer program causes a procedure (subroutine) to execute in a different address space (commonly on another computer on a shared network)..."_).

```
`...CommunicationImplementation.RING` is [RPC](https://en.wikipedia.org/wiki/Remote_procedure_call)...
```

- Since the word "strategy" is used everywhere, use "Default Strategy" (capitalize both words) when discussing the particular strategy from the "Default Strategy"  section:

```
The Default Strategy is a distribution strategy which is present when no explicit distribution strategy is in scope. It implements the `tf.distribute.Strategy`...
```

- Use backticks in the _Setting up the TF_CONFIG environment variable_ section to explain various variables better.