### PR TITLE
Fix NVIDIA GPU driver requirement for CUDA 11.2

### DIFF
--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -59,7 +59,7 @@ enable compute capabilities by [building TensorFlow from source](./source.md).
 The following NVIDIA® software must be installed on your system:
 
 *   [NVIDIA® GPU drivers](https://www.nvidia.com/drivers){:.external} —CUDA®
-    11.2 requires 460.x or higher.
+    11.2 requires 450.80.02 or higher.
 *   [CUDA® Toolkit](https://developer.nvidia.com/cuda-toolkit-archive){:.external}
     —TensorFlow supports CUDA® 11.2 (TensorFlow >= 2.5.0)
 *   [CUPTI](http://docs.nvidia.com/cuda/cupti/){:.external} ships with the CUDA®


### PR DESCRIPTION
Currently the software requirements specified for the TensorFlow 2.5.0 GPU installation list that CUDA 11.2 requires a driver version of `460.x` but actually it only requires a driver version of `450.80.02`. See Table 1 from NVIDIA's CUDA compatibility chart: https://docs.nvidia.com/deploy/cuda-compatibility/index.html