### PR TITLE
IMG_SIZE to (IMG_SIZE,IMG_SIZE)

### DIFF
--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -189,7 +189,7 @@
         "train_dataset = image_dataset_from_directory(train_dir,\n",
         "                                             shuffle=True,\n",
         "                                             batch_size=BATCH_SIZE,\n",
-        "                                             image_size=IMG_SIZE)"
+        "                                             image_size=(IMG_SIZE,IMG_SIZE))"
       ]
     },
     {


### PR DESCRIPTION
image_size = IMG_SIZE caused error because of expectation of tuple of dim 2 (IMG_SIZE,IMG_SIZE)