### PR TITLE
Update gpu.ipynb

### DIFF
--- a/site/en/guide/gpu.ipynb
+++ b/site/en/guide/gpu.ipynb
@@ -122,9 +122,9 @@
         "*   `\"/GPU:0\"`: Short-hand notation for the first GPU of your machine that is visible to TensorFlow.\n",
         "*   `\"/job:localhost/replica:0/task:0/device:GPU:1\"`: Fully qualified name of the second GPU of your machine that is visible to TensorFlow.\n",
         "\n",
-        "If a TensorFlow operation has both CPU and GPU implementations, by default the GPU devices will be given priority when the operation is assigned to a device. For example, `tf.matmul` has both CPU and GPU kernels. On a system with devices `CPU:0` and `GPU:0`, the `GPU:0` device will be selected to run `tf.matmul` unless you explicitly request running it on another device.\n",
+        "If a TensorFlow operation has both CPU and GPU implementations, by default, the GPU device is prioritized when the operation is assigned. For example, `tf.matmul` has both CPU and GPU kernels and on a system with devices `CPU:0` and `GPU:0`, the `GPU:0` device is selected to run `tf.matmul` unless you explicitly request to run it on another device.\n",
         "\n",
-        "If a TensorFlow operation has no corresponding GPU implementation then the operation will fall back on CPU. For example, `tf.cast` only has CPU kernel. On a system with devices `CPU:0` and `GPU:0`, the `CPU:0` device will be selected to run `tf.cast` even though explicitly request running it on `GPU:0` device."
+        "If a TensorFlow operation has no corresponding GPU implementation, then the operation falls back to the CPU device. For example, since `tf.cast` only has a CPU kernel, on a system with devices `CPU:0` and `GPU:0`, the `CPU:0` device is selected to run `tf.cast`, even if requested to run on the `GPU:0` device."
       ]
     },
     {

--- a/site/en/guide/gpu.ipynb
+++ b/site/en/guide/gpu.ipynb
@@ -244,7 +244,7 @@
         "## Limiting GPU memory growth\n",
         "\n",
         "By default, TensorFlow maps nearly all of the GPU memory of all GPUs (subject to\n",
-        "[`CUDA_VISIBLE_DEVICES`](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars)) visible to the process. This is done to more efficiently use the relatively precious GPU memory resources on the devices by reducing memory fragmentation. To limit TensorFlow to a specific set of GPUs we use the `tf.config.experimental.set_visible_devices` method."
+        "[`CUDA_VISIBLE_DEVICES`](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars)) visible to the process. This is done to more efficiently use the relatively precious GPU memory resources on the devices by reducing memory fragmentation. To limit TensorFlow to a specific set of GPUs, use the `tf.config.experimental.set_visible_devices` method."
       ]
     },
     {
@@ -283,7 +283,7 @@
       "source": [
         "In some cases it is desirable for the process to only allocate a subset of the available memory, or to only grow the memory usage as is needed by the process. TensorFlow provides two methods to control this.\n",
         "\n",
-        "The first option is to turn on memory growth by calling `tf.config.experimental.set_memory_growth`, which attempts to allocate only as much GPU memory as needed for the runtime allocations: it starts out allocating very little memory, and as the program gets run and more GPU memory is needed, we extend the GPU memory region allocated to the TensorFlow process. Note we do not release memory, since it can lead to memory fragmentation. To turn on memory growth for a specific GPU, use the following code prior to allocating any tensors or executing any ops."
+        "The first option is to turn on memory growth by calling `tf.config.experimental.set_memory_growth`, which attempts to allocate only as much GPU memory as needed for the runtime allocations: it starts out allocating very little memory, and as the program gets run and more GPU memory is needed, the GPU memory region is extended for the TensorFlow process. Memory is not released since it can lead to memory fragmentation. To turn on memory growth for a specific GPU, use the following code prior to allocating any tensors or executing any ops."
       ]
     },
     {
@@ -455,7 +455,7 @@
       "source": [
         "## Using multiple GPUs\n",
         "\n",
-        "Developing for multiple GPUs will allow a model to scale with the additional resources. If developing on a system with a single GPU, we can simulate multiple GPUs with virtual devices. This enables easy testing of multi-GPU setups without requiring additional resources."
+        "Developing for multiple GPUs will allow a model to scale with the additional resources. If developing on a system with a single GPU, you can simulate multiple GPUs with virtual devices. This enables easy testing of multi-GPU setups without requiring additional resources."
       ]
     },
     {
@@ -495,7 +495,7 @@
         "id": "xmNzO0FxNkol"
       },
       "source": [
-        "Once we have multiple logical GPUs available to the runtime, we can utilize the multiple GPUs with `tf.distribute.Strategy` or with manual placement."
+        "Once there are multiple logical GPUs available to the runtime, you can utilize the multiple GPUs with `tf.distribute.Strategy` or with manual placement."
       ]
     },
     {

--- a/site/en/guide/gpu.ipynb
+++ b/site/en/guide/gpu.ipynb
@@ -122,7 +122,9 @@
         "*   `\"/GPU:0\"`: Short-hand notation for the first GPU of your machine that is visible to TensorFlow.\n",
         "*   `\"/job:localhost/replica:0/task:0/device:GPU:1\"`: Fully qualified name of the second GPU of your machine that is visible to TensorFlow.\n",
         "\n",
-        "If a TensorFlow operation has both CPU and GPU implementations, by default the GPU devices will be given priority when the operation is assigned to a device. For example, `tf.matmul` has both CPU and GPU kernels. On a system with devices `CPU:0` and `GPU:0`, the `GPU:0` device will be selected to run `tf.matmul` unless you explicitly request running it on another device."
+        "If a TensorFlow operation has both CPU and GPU implementations, by default the GPU devices will be given priority when the operation is assigned to a device. For example, `tf.matmul` has both CPU and GPU kernels. On a system with devices `CPU:0` and `GPU:0`, the `GPU:0` device will be selected to run `tf.matmul` unless you explicitly request running it on another device.\n",
+        "\n",
+        "If a TensorFlow operation has no corresponding GPU implementation then the operation will fall back on CPU. For example, `tf.cast` only has CPU kernel. On a system with devices `CPU:0` and `GPU:0`, the `CPU:0` device will be selected to run `tf.cast` even though explicitly request running it on `GPU:0` device."
       ]
     },
     {


### PR DESCRIPTION
For tensorflow ops that have no GPU implementation, the operation falls back on CPU.
See [gist](https://colab.research.google.com/gist/ymodak/f4efe214de48608dd6b5b1319d3d06e4/untitled14.ipynb) that exhibits the behavior.