### PR TITLE
Fix load_data/text.ipynb

### DIFF
--- a/site/en/tutorials/load_data/text.ipynb
+++ b/site/en/tutorials/load_data/text.ipynb
@@ -779,7 +779,7 @@
       "source": [
         "export_model = tf.keras.Sequential(\n",
         "    [binary_vectorize_layer, binary_model,\n",
-        "     layers.Activation('sigmoid')])\n",
+        "     layers.Activation('softmax')])\n",
         "\n",
         "export_model.compile(\n",
         "    loss=losses.SparseCategoricalCrossentropy(from_logits=False),\n",
@@ -1398,7 +1398,7 @@
       "source": [
         "export_model = tf.keras.Sequential(\n",
         "    [preprocess_layer, model,\n",
-        "     layers.Activation('sigmoid')])\n",
+        "     layers.Activation('softmax')])\n",
         "\n",
         "export_model.compile(\n",
         "    loss=losses.SparseCategoricalCrossentropy(from_logits=False),\n",
@@ -1691,7 +1691,7 @@
         "     layers.Activation('sigmoid')])\n",
         "\n",
         "export_model.compile(\n",
-        "    loss=losses.SparseCategoricalCrossentropy(from_logits=False),\n",
+        "    loss=losses.BinaryCrossentropy(from_logits=False),\n",
         "    optimizer='adam',\n",
         "    metrics=['accuracy'])"
       ]


### PR DESCRIPTION
1. Use Softmax activation for export_model that have num_labels > 1:
- For models that have num_labels > 1, I think it would be more accurate when using Softmax activation instead of Sigmoid at the last layer, although it still gets the correct result with Sigmoid

2. Use BinaryCrossentropy loss function for export_model in the [last section](https://www.tensorflow.org/tutorials/load_data/text?hl=en#export_the_model_3):
- The model in this section is for the Binary classification task. So for consistency, I think the loss function of the export_model should be BinaryCrossentropy