### PR TITLE
Fixing the Python version 3.8 to 3.9

### DIFF
--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -20,7 +20,7 @@ landing_page:
         <table class="columns">
           <tr><td>
             <ul>
-              <li>Python 3.6–3.8</li>
+              <li>Python 3.6–3.9</li>
               <li>Ubuntu 16.04 or later</li>
               <li>Windows 7 or later (with <a href="https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads">C++ redistributable</a>)</li>
             </ul>


### PR DESCRIPTION
Since Python 3.9 is officially supported, I propose to fix the version to 3.9.
Related Issues: https://github.com/tensorflow/tensorflow/issues/50973