### PR TITLE
typos in the subsection 'Non-strict execution'

### DIFF
--- a/site/en/guide/intro_to_graphs.ipynb
+++ b/site/en/guide/intro_to_graphs.ipynb
@@ -640,7 +640,7 @@
         "\n",
         "In particular, runtime error checking does not count as an observable effect. If an operation is skipped because it is unnecessary, it cannot raise any runtime errors.\n",
         "\n",
-        "In the following example, the \"unnecessary\" operation `tf.math.bincount` is skipped during graph execution, so the runtime error `InvalidArgumentError` is not raised as it would be in eager execution. Do not rely on an error being raised while executing a graph."
+        "In the following example, the \"unnecessary\" operation `tf.gather` is skipped during graph execution, so the runtime error `InvalidArgumentError` is not raised as it would be in eager execution. Do not rely on an error being raised while executing a graph."
       ]
     },
     {

--- a/site/en/guide/intro_to_graphs.ipynb
+++ b/site/en/guide/intro_to_graphs.ipynb
@@ -851,17 +851,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "intro_to_graphs.ipynb",
-      "private_outputs": true,
-      "provenance": [
-        {
-          "file_id": "1LJPnwsaNoC5I5fYzhscAsezuHWqP9k25",
-          "timestamp": 1628225151202
-        },
-        {
-          "file_id": "https://github.com/tensorflow/docs/blob/master/site/en/guide/intro_to_graphs.ipynb",
-          "timestamp": 1628224607807
-        }
-      ],
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
In the given examples, the unused function is tf.gather instead of tf.math.bincount.

Also, in the webpage, the output of the first example (unused_return_eager) is also wrong. It should report an error instead of a tf.Tensor as displayed in the current webpage.