### PR TITLE
Fixed typos in image segmentation tutorial

### DIFF
--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -231,7 +231,7 @@
         "id": "T9hGHyg8L3Y1"
       },
       "source": [
-        "The following class performs a simple augmentation of randoly-flipping an image.\n",
+        "The following class performs a simple augmentation by randomly-flipping an image.\n",
         "See the [image augmentation tutorial](https://www.tensorflow.org/tutorials/images/data_augmentation) for more on image augmentation.\n"
       ]
     },
@@ -449,7 +449,7 @@
         "\n",
         "Now, all that is left to do is to compile and train the model. \n",
         "\n",
-        "SInce this is a multiclass classification problem a `CetegforicalCrossentropy` with `from_logits=True` is the standard loss function. Use `losses.SparseCategoricalCrossentropy(from_logits=True)` since the labels are scalar integers instead of vecrtors of scores fror scores for each class .for each pixel. \n",
+        "SInce this is a multiclass classification problem a `CategoricalCrossentropy` with `from_logits=True` is the standard loss function. Use `losses.SparseCategoricalCrossentropy(from_logits=True)` since the labels are scalar integers instead of vectors of scores for each pixel of every class. \n",
         "\n",
         "When running inference, the label assigned to the pixel is the channel with the highest value. This is what the `create_mask` function is doing."
       ]

--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -651,7 +651,7 @@
         "id": "eqtFPqqu2kxP"
       },
       "source": [
-        "Semantic segmentation datasets can be highly imbalanced meaning that particular class pixels can be present more inside images than that of other classes. Since segmentation problems can be treated as per-pixel classification problems we can deal with the imbalance problem by weighing the loss function to account for this. It's a simple and elegant way to deal with this problem. See the [imbalanced classes tutorial](https://www.tensorflow.org/tutorials/structured_data/imbalanced_data).\n",
+        "Semantic segmentation datasets can be highly imbalanced meaning that particular class pixels can be present more inside images than that of other classes. Since segmentation problems can be treated as per-pixel classification problems, you can deal with the imbalance problem by weighing the loss function to account for this. It's a simple and elegant way to deal with this problem. See the [imbalanced classes tutorial](https://www.tensorflow.org/tutorials/structured_data/imbalanced_data).\n",
         "\n",
         "To [avoid ambiguity](https://github.com/keras-team/keras/issues/3653#issuecomment-243939748), `Model.fit` does not support the `class_weight` argument for inputs with 3+ dimensions."
       ]


### PR DESCRIPTION
##Link to the mentioned documentation
https://www.tensorflow.org/tutorials/images/segmentation