### PR TITLE
Introduction to Autodiff: Make comments consistent with corresponding code

### DIFF
--- a/site/en/guide/autodiff.ipynb
+++ b/site/en/guide/autodiff.ipynb
@@ -508,8 +508,8 @@
         "  y = x * x\n",
         "  z = y * y\n",
         "\n",
-        "print(tape.gradient(z, x).numpy())  # 108.0 (4 * x**3 at x = 3)\n",
-        "print(tape.gradient(y, x).numpy())  # 6.0 (2 * x)"
+        "print(tape.gradient(z, x).numpy())  # [4.0, 108.0] (4 * x**3 at x = [1.0, 3.0])\n",
+        "print(tape.gradient(y, x).numpy())  # [2.0, 6.0] (2 * x at x = [1.0, 3.0])"
       ]
     },
     {


### PR DESCRIPTION
Notebook `guide/autodiff` has an example in the section "Intermediate results", which compute gradients with respect to a vector argument:

    x = tf.constant([1, 3.0])

However, the corresponding comments on the expected gradient results refer to a scalar `x`:

    print(tape.gradient(z, x).numpy())  # 108.0 (4 * x**3 at x = 3)

This patch fixes this discrepancy.