### PR TITLE
Updated TextVectorization

### DIFF
--- a/site/en/tutorials/load_data/text.ipynb
+++ b/site/en/tutorials/load_data/text.ipynb
@@ -109,7 +109,7 @@
         "from tensorflow.keras import losses\n",
         "from tensorflow.keras import preprocessing\n",
         "from tensorflow.keras import utils\n",
-        "from tensorflow.keras.layers.experimental.preprocessing import TextVectorization\n",
+        "from tensorflow.keras.layers import TextVectorization\n",
         "\n",
         "import tensorflow_datasets as tfds\n",
         "import tensorflow_text as tf_text"
@@ -355,19 +355,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "HSDO9JZYrK-O"
-      },
-      "source": [
-        "Note: The Preprocessing APIs used in this section are experimental in TensorFlow 2.3 and subject to change."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "N6fRti45Rlj8"
       },
       "source": [
-        "Next, you will standardize, tokenize, and vectorize the data using the `preprocessing.TextVectorization` layer.\n",
+        "Next, you will standardize, tokenize, and vectorize the data using the `TextVectorization` layer.\n",
         "* Standardization refers to preprocessing the text, typically to remove punctuation or HTML elements to simplify the dataset.\n",
         "\n",
         "* Tokenization refers to splitting strings into tokens (for example, splitting a sentence into individual words by splitting on whitespace).\n",

--- a/site/en/tutorials/load_data/text.ipynb
+++ b/site/en/tutorials/load_data/text.ipynb
@@ -358,7 +358,7 @@
         "id": "N6fRti45Rlj8"
       },
       "source": [
-        "Next, you will standardize, tokenize, and vectorize the data using the `TextVectorization` layer.\n",
+        "Next, you will standardize, tokenize, and vectorize the data using the `layers.TextVectorization` layer.\n",
         "* Standardization refers to preprocessing the text, typically to remove punctuation or HTML elements to simplify the dataset.\n",
         "\n",
         "* Tokenization refers to splitting strings into tokens (for example, splitting a sentence into individual words by splitting on whitespace).\n",

--- a/site/en/tutorials/load_data/text.ipynb
+++ b/site/en/tutorials/load_data/text.ipynb
@@ -2,16 +2,21 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "source": [
-        "##### Copyright 2018 The TensorFlow Authors.\n"
-      ],
       "metadata": {
         "id": "DweYe9FcbMK_"
-      }
+      },
+      "source": [
+        "##### Copyright 2018 The TensorFlow Authors.\n"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "AVV2e0XKbJeX"
+      },
+      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -24,24 +29,22 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ],
-      "outputs": [],
-      "metadata": {
-        "cellView": "form",
-        "id": "AVV2e0XKbJeX"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "# Load text"
-      ],
       "metadata": {
         "id": "sZfSvVcDo6GQ"
-      }
+      },
+      "source": [
+        "# Load text"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "giK0nMbZFnoR"
+      },
       "source": [
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
         "  <td>\n",
@@ -57,42 +60,43 @@
         "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/load_data/text.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
         "  </td>\n",
         "</table>"
-      ],
-      "metadata": {
-        "id": "giK0nMbZFnoR"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "dwlfPb11GH8J"
+      },
       "source": [
         "This tutorial demonstrates two ways to load and preprocess text.\n",
         "\n",
         "+ First, you will use Keras utilities and layers. If you are new to TensorFlow, you should start with these.\n",
         "\n",
         "+ Next, you will use lower-level utilities like `tf.data.TextLineDataset` to load text files, and `tf.text` to preprocess the data for finer-grain control."
-      ],
-      "metadata": {
-        "id": "dwlfPb11GH8J"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "sa6IKWvADqH7"
+      },
+      "outputs": [],
       "source": [
         "# Be sure you're using the stable versions of both tf and tf-text, for binary compatibility.\n",
         "!pip uninstall -y tensorflow tf-nightly keras\n",
         "\n",
         "!pip install -q -U tf-nightly\n",
         "!pip install -q -U tensorflow-text-nightly"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "sa6IKWvADqH7"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "baYFZMW_bJHh"
+      },
+      "outputs": [],
       "source": [
         "import collections\n",
         "import pathlib\n",
@@ -109,37 +113,37 @@
         "\n",
         "import tensorflow_datasets as tfds\n",
         "import tensorflow_text as tf_text"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "baYFZMW_bJHh"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "Az-d_K5_HQ5k"
+      },
       "source": [
         "## Example 1: Predict the tag for a Stack Overflow question\n",
         "\n",
         "As a first example, you will download a dataset of programming questions from Stack Overflow. Each question (\"How do I sort a dictionary by value?\") is labeled with exactly one tag (`Python`, `CSharp`, `JavaScript`, or `Java`). Your task is to develop a model that predicts the tag for a question. This is an example of multi-class classification, an important and widely applicable kind of machine learning problem."
-      ],
-      "metadata": {
-        "id": "Az-d_K5_HQ5k"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "tjC3yLa5IjP7"
+      },
       "source": [
         "### Download and explore the dataset\n",
         "\n",
         "Next, you will download the dataset, and explore the directory structure."
-      ],
-      "metadata": {
-        "id": "tjC3yLa5IjP7"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "8ELgzA6SHTuV"
+      },
+      "outputs": [],
       "source": [
         "data_url = 'https://storage.googleapis.com/download.tensorflow.org/data/stack_overflow_16k.tar.gz'\n",
         "dataset_dir = utils.get_file(\n",
@@ -149,59 +153,58 @@
         "    cache_subdir='')\n",
         "\n",
         "dataset_dir = pathlib.Path(dataset_dir).parent"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "8ELgzA6SHTuV"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "source": [
-        "list(dataset_dir.iterdir())"
-      ],
-      "outputs": [],
       "metadata": {
         "id": "jIrPl5fUH2gb"
-      }
+      },
+      "outputs": [],
+      "source": [
+        "list(dataset_dir.iterdir())"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "fEoV7YByJoWQ"
+      },
+      "outputs": [],
       "source": [
         "train_dir = dataset_dir/'train'\n",
         "list(train_dir.iterdir())"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "fEoV7YByJoWQ"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "The `train/csharp`, `train/java`, `train/python` and `train/javascript` directories contain many text files, each of which is a Stack Overflow question. Print a file and inspect the data."
-      ],
       "metadata": {
         "id": "3mxAN17MhEh0"
-      }
+      },
+      "source": [
+        "The `train/csharp`, `train/java`, `train/python` and `train/javascript` directories contain many text files, each of which is a Stack Overflow question. Print a file and inspect the data."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "Go1vTSGdJu08"
+      },
+      "outputs": [],
       "source": [
         "sample_file = train_dir/'python/1755.txt'\n",
         "with open(sample_file) as f:\n",
         "  print(f.read())"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "Go1vTSGdJu08"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "deWBTkpJiO7D"
+      },
       "source": [
         "### Load the dataset\n",
         "\n",
@@ -224,23 +227,24 @@
         "......1.txt\n",
         "......2.txt\n",
         "```"
-      ],
-      "metadata": {
-        "id": "deWBTkpJiO7D"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "When running a machine learning experiment, it is a best practice to divide your dataset into three splits: [train](https://developers.google.com/machine-learning/glossary#training_set), [validation](https://developers.google.com/machine-learning/glossary#validation_set), and [test](https://developers.google.com/machine-learning/glossary#test-set). The Stack Overflow dataset has already been divided into train and test, but it lacks a validation set. Create a validation set using an 80:20 split of the training data by using the `validation_split` argument below."
-      ],
       "metadata": {
         "id": "Dyl6JTAjlbQV"
-      }
+      },
+      "source": [
+        "When running a machine learning experiment, it is a best practice to divide your dataset into three splits: [train](https://developers.google.com/machine-learning/glossary#training_set), [validation](https://developers.google.com/machine-learning/glossary#validation_set), and [test](https://developers.google.com/machine-learning/glossary#test-set). The Stack Overflow dataset has already been divided into train and test, but it lacks a validation set. Create a validation set using an 80:20 split of the training data by using the `validation_split` argument below."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "qqyliMw8N-az"
+      },
+      "outputs": [],
       "source": [
         "batch_size = 32\n",
         "seed = 42\n",
@@ -251,72 +255,72 @@
         "    validation_split=0.2,\n",
         "    subset='training',\n",
         "    seed=seed)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "qqyliMw8N-az"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "DMI_gPLfloD7"
+      },
       "source": [
         "As you can see above, there are 8,000 examples in the training folder, of which you will use 80% (or 6,400) for training. As you will see in a moment, you can train a model by passing a `tf.data.Dataset` directly to `model.fit`. First, iterate over the dataset and print out a few examples, to get a feel for the data.\n",
         "\n",
         "Note: To increase the difficulty of the classification problem, the dataset author replaced occurrences of the words *Python*, *CSharp*, *JavaScript*, or *Java* in the programming question with the word *blank*."
-      ],
-      "metadata": {
-        "id": "DMI_gPLfloD7"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "_JMTyZ6Glt_C"
+      },
+      "outputs": [],
       "source": [
         "for text_batch, label_batch in raw_train_ds.take(1):\n",
         "  for i in range(10):\n",
         "    print(\"Question: \", text_batch.numpy()[i])\n",
         "    print(\"Label:\", label_batch.numpy()[i])"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "_JMTyZ6Glt_C"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "The labels are `0`, `1`, `2` or `3`. To see which of these correspond to which string label, you can check the `class_names` property on the dataset.\n"
-      ],
       "metadata": {
         "id": "jCZGl4Q5l2sS"
-      }
+      },
+      "source": [
+        "The labels are `0`, `1`, `2` or `3`. To see which of these correspond to which string label, you can check the `class_names` property on the dataset.\n"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "gIpCS7YjmGkj"
+      },
+      "outputs": [],
       "source": [
         "for i, label in enumerate(raw_train_ds.class_names):\n",
         "  print(\"Label\", i, \"corresponds to\", label)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "gIpCS7YjmGkj"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "oUsdn-37qol9"
+      },
       "source": [
         "Next, you will create a validation and test dataset. You will use the remaining 1,600 reviews from the training set for validation.\n",
         "\n",
         "Note:  When using the `validation_split` and `subset` arguments, make sure to either specify a random seed, or to pass `shuffle=False`, so that the validation and training splits have no overlap."
-      ],
-      "metadata": {
-        "id": "oUsdn-37qol9"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "x7m6sCWJQuYt"
+      },
+      "outputs": [],
       "source": [
         "raw_val_ds = preprocessing.text_dataset_from_directory(\n",
         "    train_dir,\n",
@@ -324,36 +328,35 @@
         "    validation_split=0.2,\n",
         "    subset='validation',\n",
         "    seed=seed)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "x7m6sCWJQuYt"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "BXMZc7fMQwKE"
+      },
+      "outputs": [],
       "source": [
         "test_dir = dataset_dir/'test'\n",
         "raw_test_ds = preprocessing.text_dataset_from_directory(\n",
         "    test_dir, batch_size=batch_size)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "BXMZc7fMQwKE"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Prepare the dataset for training"
-      ],
       "metadata": {
         "id": "Xdt-ATrGRGDL"
-      }
+      },
+      "source": [
+        "### Prepare the dataset for training"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "N6fRti45Rlj8"
+      },
       "source": [
         "Next, you will standardize, tokenize, and vectorize the data using the `layers.TextVectorization` layer.\n",
         "* Standardization refers to preprocessing the text, typically to remove punctuation or HTML elements to simplify the dataset.\n",
@@ -372,38 +375,39 @@
         "\n",
         "\n",
         "You will build two modes to learn more about these. First, you will use the `binary` model to build a bag-of-words model. Next, you will use the `int` mode with a 1D ConvNet."
-      ],
-      "metadata": {
-        "id": "N6fRti45Rlj8"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "voaC43rZR0jc"
+      },
+      "outputs": [],
       "source": [
         "VOCAB_SIZE = 10000\n",
         "\n",
         "binary_vectorize_layer = TextVectorization(\n",
         "    max_tokens=VOCAB_SIZE,\n",
         "    output_mode='binary')"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "voaC43rZR0jc"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "For `int` mode, in addition to maximum vocabulary size, you need to set an explicit maximum sequence length, which will cause the layer to pad or truncate sequences to exactly sequence_length values."
-      ],
       "metadata": {
         "id": "ifDPFxuf2Hfz"
-      }
+      },
+      "source": [
+        "For `int` mode, in addition to maximum vocabulary size, you need to set an explicit maximum sequence length, which will cause the layer to pad or truncate sequences to exactly sequence_length values."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "XWsY01Zl2aRe"
+      },
+      "outputs": [],
       "source": [
         "MAX_SEQUENCE_LENGTH = 250\n",
         "\n",
@@ -411,145 +415,145 @@
         "    max_tokens=VOCAB_SIZE,\n",
         "    output_mode='int',\n",
         "    output_sequence_length=MAX_SEQUENCE_LENGTH)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "XWsY01Zl2aRe"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "ts6h9b5atD-Y"
+      },
       "source": [
         "Next, you will call `adapt` to fit the state of the preprocessing layer to the dataset. This will cause the model to build an index of strings to integers.\n",
         "\n",
         "Note: it's important to only use your training data when calling adapt (using the test set would leak information)."
-      ],
-      "metadata": {
-        "id": "ts6h9b5atD-Y"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "yTXsdDEqSf9e"
+      },
+      "outputs": [],
       "source": [
         "# Make a text-only dataset (without labels), then call adapt\n",
         "train_text = raw_train_ds.map(lambda text, labels: text)\n",
         "binary_vectorize_layer.adapt(train_text)\n",
         "int_vectorize_layer.adapt(train_text)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "yTXsdDEqSf9e"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "See the result of using these layers to preprocess data:"
-      ],
       "metadata": {
         "id": "XKVO6Jg7Sls0"
-      }
+      },
+      "source": [
+        "See the result of using these layers to preprocess data:"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "RngfPyArSsvM"
+      },
+      "outputs": [],
       "source": [
         "def binary_vectorize_text(text, label):\n",
         "  text = tf.expand_dims(text, -1)\n",
         "  return binary_vectorize_layer(text), label"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "RngfPyArSsvM"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "_1W54wf0LhQ0"
+      },
+      "outputs": [],
       "source": [
         "def int_vectorize_text(text, label):\n",
         "  text = tf.expand_dims(text, -1)\n",
         "  return int_vectorize_layer(text), label"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "_1W54wf0LhQ0"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "Vi_sElMiSmXe"
+      },
+      "outputs": [],
       "source": [
         "# Retrieve a batch (of 32 reviews and labels) from the dataset\n",
         "text_batch, label_batch = next(iter(raw_train_ds))\n",
         "first_question, first_label = text_batch[0], label_batch[0]\n",
         "print(\"Question\", first_question)\n",
         "print(\"Label\", first_label)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "Vi_sElMiSmXe"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "UGukZoYv2v3v"
+      },
+      "outputs": [],
       "source": [
         "print(\"'binary' vectorized question:\", \n",
         "      binary_vectorize_text(first_question, first_label)[0])"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "UGukZoYv2v3v"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "Lu07FsIw2yH5"
+      },
+      "outputs": [],
       "source": [
         "print(\"'int' vectorized question:\",\n",
         "      int_vectorize_text(first_question, first_label)[0])"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "Lu07FsIw2yH5"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "As you can see above, `binary` mode returns an array denoting which tokens exist at least once in the input, while `int` mode replaces each token by an integer, thus preserving their order. You can lookup the token (string) that each integer corresponds to by calling `.get_vocabulary()` on the layer."
-      ],
       "metadata": {
         "id": "wgjeF9PdS7tN"
-      }
+      },
+      "source": [
+        "As you can see above, `binary` mode returns an array denoting which tokens exist at least once in the input, while `int` mode replaces each token by an integer, thus preserving their order. You can lookup the token (string) that each integer corresponds to by calling `.get_vocabulary()` on the layer."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "WpBnTZilS8wt"
+      },
+      "outputs": [],
       "source": [
         "print(\"1289 ---> \", int_vectorize_layer.get_vocabulary()[1289])\n",
         "print(\"313 ---> \", int_vectorize_layer.get_vocabulary()[313])\n",
         "print(\"Vocabulary size: {}\".format(len(int_vectorize_layer.get_vocabulary())))"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "WpBnTZilS8wt"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "You are nearly ready to train your model. As a final preprocessing step, you will apply the `TextVectorization` layers you created earlier to the train, validation, and test dataset."
-      ],
       "metadata": {
         "id": "0kHgPE_YwHvp"
-      }
+      },
+      "source": [
+        "You are nearly ready to train your model. As a final preprocessing step, you will apply the `TextVectorization` layers you created earlier to the train, validation, and test dataset."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "46LeHmnD55wJ"
+      },
+      "outputs": [],
       "source": [
         "binary_train_ds = raw_train_ds.map(binary_vectorize_text)\n",
         "binary_val_ds = raw_val_ds.map(binary_vectorize_text)\n",
@@ -558,14 +562,13 @@
         "int_train_ds = raw_train_ds.map(int_vectorize_text)\n",
         "int_val_ds = raw_val_ds.map(int_vectorize_text)\n",
         "int_test_ds = raw_test_ds.map(int_vectorize_text)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "46LeHmnD55wJ"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "NHuAF8hYfP5Z"
+      },
       "source": [
         "### Configure the dataset for performance\n",
         "\n",
@@ -576,28 +579,29 @@
         "`.prefetch()` overlaps data preprocessing and model execution while training. \n",
         "\n",
         "You can learn more about both methods, as well as how to cache data to disk in the [data performance guide](https://www.tensorflow.org/guide/data_performance)."
-      ],
-      "metadata": {
-        "id": "NHuAF8hYfP5Z"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "PabA9DFIfSz7"
+      },
+      "outputs": [],
       "source": [
         "AUTOTUNE = tf.data.AUTOTUNE\n",
         "\n",
         "def configure_dataset(dataset):\n",
         "  return dataset.cache().prefetch(buffer_size=AUTOTUNE)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "PabA9DFIfSz7"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "J8GcJLvb3JH0"
+      },
+      "outputs": [],
       "source": [
         "binary_train_ds = configure_dataset(binary_train_ds)\n",
         "binary_val_ds = configure_dataset(binary_val_ds)\n",
@@ -606,26 +610,26 @@
         "int_train_ds = configure_dataset(int_train_ds)\n",
         "int_val_ds = configure_dataset(int_val_ds)\n",
         "int_test_ds = configure_dataset(int_test_ds)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "J8GcJLvb3JH0"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "NYGb7z_bfpGm"
+      },
       "source": [
         "### Train the model\n",
         "\n",
         "It's time to create your neural network. For the `binary` vectorized data, train a simple bag-of-words linear model:"
-      ],
-      "metadata": {
-        "id": "NYGb7z_bfpGm"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "2q8iAU-VMzaN"
+      },
+      "outputs": [],
       "source": [
         "binary_model = tf.keras.Sequential([layers.Dense(4)])\n",
         "binary_model.compile(\n",
@@ -634,24 +638,24 @@
         "    metrics=['accuracy'])\n",
         "history = binary_model.fit(\n",
         "    binary_train_ds, validation_data=binary_val_ds, epochs=10)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "2q8iAU-VMzaN"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Next, you will use the `int` vectorized layer to build a 1D ConvNet."
-      ],
       "metadata": {
         "id": "EwidD-SwNIkz"
-      }
+      },
+      "source": [
+        "Next, you will use the `int` vectorized layer to build a 1D ConvNet."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "5ztw2XH_LbVz"
+      },
+      "outputs": [],
       "source": [
         "def create_model(vocab_size, num_labels):\n",
         "  model = tf.keras.Sequential([\n",
@@ -661,15 +665,15 @@
         "      layers.Dense(num_labels)\n",
         "  ])\n",
         "  return model"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "5ztw2XH_LbVz"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "s9rG1cFRL31Z"
+      },
+      "outputs": [],
       "source": [
         "# vocab_size is VOCAB_SIZE + 1 since 0 is used additionally for padding.\n",
         "int_model = create_model(vocab_size=VOCAB_SIZE + 1, num_labels=4)\n",
@@ -678,92 +682,92 @@
         "    optimizer='adam',\n",
         "    metrics=['accuracy'])\n",
         "history = int_model.fit(int_train_ds, validation_data=int_val_ds, epochs=5)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "s9rG1cFRL31Z"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Compare the two models:"
-      ],
       "metadata": {
         "id": "x3J9Eeuv97zE"
-      }
+      },
+      "source": [
+        "Compare the two models:"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "N8ViDXw99v_u"
+      },
+      "outputs": [],
       "source": [
         "print(\"Linear model on binary vectorized data:\")\n",
         "print(binary_model.summary())"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "N8ViDXw99v_u"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "P9BOeoCwborD"
+      },
+      "outputs": [],
       "source": [
         "print(\"ConvNet model on int vectorized data:\")\n",
         "print(int_model.summary())"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "P9BOeoCwborD"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Evaluate both models on the test data:"
-      ],
       "metadata": {
         "id": "zYYW9tUdCtTy"
-      }
+      },
+      "source": [
+        "Evaluate both models on the test data:"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "5dTc4nZqf7fK"
+      },
+      "outputs": [],
       "source": [
         "binary_loss, binary_accuracy = binary_model.evaluate(binary_test_ds)\n",
         "int_loss, int_accuracy = int_model.evaluate(int_test_ds)\n",
         "\n",
         "print(\"Binary model accuracy: {:2.2%}\".format(binary_accuracy))\n",
         "print(\"Int model accuracy: {:2.2%}\".format(int_accuracy))"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "5dTc4nZqf7fK"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Note: This example dataset represents a rather simple classification problem. More complex datasets and problems bring out subtle but significant differences in preprocessing strategies and model architectures. Be sure to try out different hyperparameters and epochs to compare various approaches."
-      ],
       "metadata": {
         "id": "F9dhj8Hey9DS"
-      }
+      },
+      "source": [
+        "Note: This example dataset represents a rather simple classification problem. More complex datasets and problems bring out subtle but significant differences in preprocessing strategies and model architectures. Be sure to try out different hyperparameters and epochs to compare various approaches."
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "h9GaXTsIgP-3"
+      },
       "source": [
         "### Export the model\n",
         "\n",
         "In the code above, you applied the `TextVectorization` layer to the dataset before feeding text to the model. If you want to make your model capable of processing raw strings (for example, to simplify deploying it), you can include the `TextVectorization` layer inside your model. To do so, you can create a new model using the weights you just trained."
-      ],
-      "metadata": {
-        "id": "h9GaXTsIgP-3"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "_bRe3KX8gRCX"
+      },
+      "outputs": [],
       "source": [
         "export_model = tf.keras.Sequential(\n",
         "    [binary_vectorize_layer, binary_model,\n",
@@ -777,47 +781,47 @@
         "# Test it with `raw_test_ds`, which yields raw strings\n",
         "loss, accuracy = export_model.evaluate(raw_test_ds)\n",
         "print(\"Accuracy: {:2.2%}\".format(binary_accuracy))"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "_bRe3KX8gRCX"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Now your model can take raw strings as input and predict a score for each label using `model.predict`. Define a function to find the label with the maximum score:"
-      ],
       "metadata": {
         "id": "m2eqTVBP4DUN"
-      }
+      },
+      "source": [
+        "Now your model can take raw strings as input and predict a score for each label using `model.predict`. Define a function to find the label with the maximum score:"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "GU53uRXz45iO"
+      },
+      "outputs": [],
       "source": [
         "def get_string_labels(predicted_scores_batch):\n",
         "  predicted_int_labels = tf.argmax(predicted_scores_batch, axis=1)\n",
         "  predicted_labels = tf.gather(raw_train_ds.class_names, predicted_int_labels)\n",
         "  return predicted_labels"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "GU53uRXz45iO"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Run inference on new data"
-      ],
       "metadata": {
         "id": "yqnWc7Nn5eou"
-      }
+      },
+      "source": [
+        "### Run inference on new data"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "BOR2MupW1_zS"
+      },
+      "outputs": [],
       "source": [
         "inputs = [\n",
         "    \"how do I extract keys from a dict into a list?\",  # python\n",
@@ -828,45 +832,44 @@
         "for input, label in zip(inputs, predicted_labels):\n",
         "  print(\"Question: \", input)\n",
         "  print(\"Predicted label: \", label.numpy())"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "BOR2MupW1_zS"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "0QDVfii_4slI"
+      },
       "source": [
         "Including the text preprocessing logic inside your model enables you to export a model for production that simplifies deployment, and reduces the potential for [train/test skew](https://developers.google.com/machine-learning/guides/rules-of-ml#training-serving_skew).\n",
         "\n",
         "There is a performance difference to keep in mind when choosing where to apply your `TextVectorization` layer. Using it outside of your model enables you to do asynchronous CPU processing and buffering of your data when training on GPU. So, if you're training your model on the GPU, you probably want to go with this option to get the best performance while developing your model, then switch to including the TextVectorization layer inside your model when you're ready to prepare for deployment.\n",
         "\n",
         "Visit this [tutorial](https://www.tensorflow.org/tutorials/keras/save_and_load) to learn more about saving models."
-      ],
-      "metadata": {
-        "id": "0QDVfii_4slI"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Example 2: Predict the author of Illiad translations \n"
-      ],
       "metadata": {
         "id": "p4cvuFzavTRy"
-      }
+      },
+      "source": [
+        "## Example 2: Predict the author of Illiad translations \n"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "The following provides an example of using `tf.data.TextLineDataset` to load examples from text files, and `tf.text` to preprocess the data. In this example, you will use three different English translations of the same work, Homer's Illiad, and train a model to identify the translator given a single line of text."
-      ],
       "metadata": {
         "id": "fOlJ22508RIe"
-      }
+      },
+      "source": [
+        "The following provides an example of using `tf.data.TextLineDataset` to load examples from text files, and `tf.text` to preprocess the data. In this example, you will use three different English translations of the same work, Homer's Illiad, and train a model to identify the translator given a single line of text."
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "-pCgKbOSk7kU"
+      },
       "source": [
         "### Download and explore the dataset\n",
         "\n",
@@ -879,14 +882,15 @@
         "- [Samuel Butler](https://en.wikipedia.org/wiki/Samuel_Butler_%28novelist%29) — [text](https://storage.googleapis.com/download.tensorflow.org/data/illiad/butler.txt)\n",
         "\n",
         "The text files used in this tutorial have undergone some typical preprocessing tasks like removing document header and footer, line numbers and chapter titles. Download these lightly munged files locally."
-      ],
-      "metadata": {
-        "id": "-pCgKbOSk7kU"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "4YlKQthEYlFw"
+      },
+      "outputs": [],
       "source": [
         "DIRECTORY_URL = 'https://storage.googleapis.com/download.tensorflow.org/data/illiad/'\n",
         "FILE_NAMES = ['cowper.txt', 'derby.txt', 'butler.txt']\n",
@@ -896,40 +900,40 @@
         "\n",
         "parent_dir = pathlib.Path(text_dir).parent\n",
         "list(parent_dir.iterdir())"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "4YlKQthEYlFw"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "M8PHK5J_cXE5"
+      },
       "source": [
         "### Load the dataset\n",
         "\n",
         "You will use `TextLineDataset`, which is designed to create a `tf.data.Dataset` from a text file in which each example is a line of text from the original file, whereas `text_dataset_from_directory` treats all contents of a file as a single example. `TextLineDataset` is useful for text data that is primarily line-based (for example, poetry or error logs). \n",
         "\n",
         "Iterate through these files, loading each one into its own dataset. Each example needs to be individually labeled, so use `tf.data.Dataset.map` to apply a labeler function to each one. This will iterate over every example in the dataset, returning (`example, label`) pairs."
-      ],
-      "metadata": {
-        "id": "M8PHK5J_cXE5"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "YIIWIdPXgk7I"
+      },
+      "outputs": [],
       "source": [
         "def labeler(example, index):\n",
         "  return example, tf.cast(index, tf.int64)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "YIIWIdPXgk7I"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "8Ajx7AmZnEg3"
+      },
+      "outputs": [],
       "source": [
         "labeled_data_sets = []\n",
         "\n",
@@ -937,37 +941,37 @@
         "  lines_dataset = tf.data.TextLineDataset(str(parent_dir/file_name))\n",
         "  labeled_dataset = lines_dataset.map(lambda ex: labeler(ex, i))\n",
         "  labeled_data_sets.append(labeled_dataset)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "8Ajx7AmZnEg3"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Next, you'll combine these labeled datasets into a single dataset, and shuffle it.\n"
-      ],
       "metadata": {
         "id": "wPOsVK1e9NGM"
-      }
+      },
+      "source": [
+        "Next, you'll combine these labeled datasets into a single dataset, and shuffle it.\n"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "6jAeYkTIi9-2"
+      },
+      "outputs": [],
       "source": [
         "BUFFER_SIZE = 50000\n",
         "BATCH_SIZE = 64\n",
         "VALIDATION_SIZE = 5000"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "6jAeYkTIi9-2"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "Qd544E-Sh63L"
+      },
+      "outputs": [],
       "source": [
         "all_labeled_data = labeled_data_sets[0]\n",
         "for labeled_dataset in labeled_data_sets[1:]:\n",
@@ -975,115 +979,115 @@
         "\n",
         "all_labeled_data = all_labeled_data.shuffle(\n",
         "    BUFFER_SIZE, reshuffle_each_iteration=False)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "Qd544E-Sh63L"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Print out a few examples as before. The dataset hasn't been batched yet, hence each entry in `all_labeled_data` corresponds to one data point:"
-      ],
       "metadata": {
         "id": "r4JEHrJXeG5k"
-      }
+      },
+      "source": [
+        "Print out a few examples as before. The dataset hasn't been batched yet, hence each entry in `all_labeled_data` corresponds to one data point:"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "gywKlN0xh6u5"
+      },
+      "outputs": [],
       "source": [
         "for text, label in all_labeled_data.take(10):\n",
         "  print(\"Sentence: \", text.numpy())\n",
         "  print(\"Label:\", label.numpy())"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "gywKlN0xh6u5"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "5rrpU2_sfDh0"
+      },
       "source": [
         "### Prepare the dataset for training\n",
         "\n",
         "Instead of using the Keras `TextVectorization` layer to preprocess the text dataset, you will now use the [`tf.text` API](https://www.tensorflow.org/tutorials/tensorflow_text/intro) to standardize and tokenize the data, build a vocabulary and use `StaticVocabularyTable` to map tokens to integers to feed to the model.\n",
         "\n",
         "While tf.text provides various tokenizers, you will use the `UnicodeScriptTokenizer` to tokenize the dataset. Define a function to convert the text to lower-case and tokenize it. You will use `tf.data.Dataset.map` to apply the tokenization to the dataset."
-      ],
-      "metadata": {
-        "id": "5rrpU2_sfDh0"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "source": [
-        "tokenizer = tf_text.UnicodeScriptTokenizer()"
-      ],
-      "outputs": [],
       "metadata": {
         "id": "v4DpQW-Y12rm"
-      }
+      },
+      "outputs": [],
+      "source": [
+        "tokenizer = tf_text.UnicodeScriptTokenizer()"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "pz8xEj0ugu51"
+      },
+      "outputs": [],
       "source": [
         "def tokenize(text, unused_label):\n",
         "  lower_case = tf_text.case_fold_utf8(text)\n",
         "  return tokenizer.tokenize(lower_case)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "pz8xEj0ugu51"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "source": [
-        "tokenized_ds = all_labeled_data.map(tokenize)"
-      ],
-      "outputs": [],
       "metadata": {
         "id": "vzUrAzOq31QL"
-      }
+      },
+      "outputs": [],
+      "source": [
+        "tokenized_ds = all_labeled_data.map(tokenize)"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "You can iterate over the dataset and print out a few tokenized examples.\n"
-      ],
       "metadata": {
         "id": "jx4Q2i8XLV7o"
-      }
+      },
+      "source": [
+        "You can iterate over the dataset and print out a few tokenized examples.\n"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "g2mkWri7LiGq"
+      },
+      "outputs": [],
       "source": [
         "for text_batch in tokenized_ds.take(5):\n",
         "  print(\"Tokens: \", text_batch.numpy())"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "g2mkWri7LiGq"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Next, you will build a vocabulary by sorting tokens by frequency and keeping the top `VOCAB_SIZE` tokens."
-      ],
       "metadata": {
         "id": "JPd4PsskJ_Xt"
-      }
+      },
+      "source": [
+        "Next, you will build a vocabulary by sorting tokens by frequency and keeping the top `VOCAB_SIZE` tokens."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "YkHtbGnDh6mg"
+      },
+      "outputs": [],
       "source": [
         "tokenized_ds = configure_dataset(tokenized_ds)\n",
         "\n",
@@ -1098,24 +1102,24 @@
         "vocab_size = len(vocab)\n",
         "print(\"Vocab size: \", vocab_size)\n",
         "print(\"First five vocab entries:\", vocab[:5])"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "YkHtbGnDh6mg"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "To convert the tokens into integers, use the `vocab` set to create a `StaticVocabularyTable`. You will map tokens to integers in the range [`2`, `vocab_size + 2`]. As with the `TextVectorization` layer, `0` is reserved to denote padding and `1` is reserved to denote an out-of-vocabulary (OOV) token."
-      ],
       "metadata": {
         "id": "PyKSsaNAKi17"
-      }
+      },
+      "source": [
+        "To convert the tokens into integers, use the `vocab` set to create a `StaticVocabularyTable`. You will map tokens to integers in the range [`2`, `vocab_size + 2`]. As with the `TextVectorization` layer, `0` is reserved to denote padding and `1` is reserved to denote an out-of-vocabulary (OOV) token."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "kCBo2yFHD7y6"
+      },
+      "outputs": [],
       "source": [
         "keys = vocab\n",
         "values = range(2, len(vocab) + 2)  # reserve 0 for padding, 1 for OOV\n",
@@ -1125,199 +1129,199 @@
         "\n",
         "num_oov_buckets = 1\n",
         "vocab_table = tf.lookup.StaticVocabularyTable(init, num_oov_buckets)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "kCBo2yFHD7y6"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Finally, define a fuction to standardize, tokenize and vectorize the dataset using the tokenizer and lookup table:"
-      ],
       "metadata": {
         "id": "Z5F-EiBpOADE"
-      }
+      },
+      "source": [
+        "Finally, define a fuction to standardize, tokenize and vectorize the dataset using the tokenizer and lookup table:"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "HcIQ7LOTh6eT"
+      },
+      "outputs": [],
       "source": [
         "def preprocess_text(text, label):\n",
         "  standardized = tf_text.case_fold_utf8(text)\n",
         "  tokenized = tokenizer.tokenize(standardized)\n",
         "  vectorized = vocab_table.lookup(tokenized)\n",
         "  return vectorized, label"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "HcIQ7LOTh6eT"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "You can try this on a single example to see the output:"
-      ],
       "metadata": {
         "id": "v6S5Qyabi-vo"
-      }
+      },
+      "source": [
+        "You can try this on a single example to see the output:"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "jgxPZaxUuTbk"
+      },
+      "outputs": [],
       "source": [
         "example_text, example_label = next(iter(all_labeled_data))\n",
         "print(\"Sentence: \", example_text.numpy())\n",
         "vectorized_text, example_label = preprocess_text(example_text, example_label)\n",
         "print(\"Vectorized sentence: \", vectorized_text.numpy())"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "jgxPZaxUuTbk"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Now run the preprocess function on the dataset using `tf.data.Dataset.map`."
-      ],
       "metadata": {
         "id": "p9qHM0v8k_Mg"
-      }
+      },
+      "source": [
+        "Now run the preprocess function on the dataset using `tf.data.Dataset.map`."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "source": [
-        "all_encoded_data = all_labeled_data.map(preprocess_text)"
-      ],
-      "outputs": [],
       "metadata": {
         "id": "KmQVsAgJ-RM0"
-      }
+      },
+      "outputs": [],
+      "source": [
+        "all_encoded_data = all_labeled_data.map(preprocess_text)"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Split the dataset into train and test\n"
-      ],
       "metadata": {
         "id": "_YZToSXSm0qr"
-      }
+      },
+      "source": [
+        "### Split the dataset into train and test\n"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "The Keras `TextVectorization` layer also batches and pads the vectorized data. Padding is required because the examples inside of a batch need to be the same size and shape, but the examples in these datasets are not all the same size — each line of text has a different number of words. `tf.data.Dataset` supports splitting and padded-batching datasets: "
-      ],
       "metadata": {
         "id": "itxIJwkrUXgv"
-      }
+      },
+      "source": [
+        "The Keras `TextVectorization` layer also batches and pads the vectorized data. Padding is required because the examples inside of a batch need to be the same size and shape, but the examples in these datasets are not all the same size — each line of text has a different number of words. `tf.data.Dataset` supports splitting and padded-batching datasets: "
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "r-rmbijQh6bf"
+      },
+      "outputs": [],
       "source": [
         "train_data = all_encoded_data.skip(VALIDATION_SIZE).shuffle(BUFFER_SIZE)\n",
         "validation_data = all_encoded_data.take(VALIDATION_SIZE)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "r-rmbijQh6bf"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "qTP0IwHBCn0Q"
+      },
+      "outputs": [],
       "source": [
         "train_data = train_data.padded_batch(BATCH_SIZE)\n",
         "validation_data = validation_data.padded_batch(BATCH_SIZE)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "qTP0IwHBCn0Q"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Now, `validation_data` and `train_data` are not collections of (`example, label`) pairs, but collections of batches. Each batch is a pair of (*many examples*, *many labels*) represented as arrays. To illustrate:"
-      ],
       "metadata": {
         "id": "m-wmFq8uW1zS"
-      }
+      },
+      "source": [
+        "Now, `validation_data` and `train_data` are not collections of (`example, label`) pairs, but collections of batches. Each batch is a pair of (*many examples*, *many labels*) represented as arrays. To illustrate:"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "kMslWfuwoqpB"
+      },
+      "outputs": [],
       "source": [
         "sample_text, sample_labels = next(iter(validation_data))\n",
         "print(\"Text batch shape: \", sample_text.shape)\n",
         "print(\"Label batch shape: \", sample_labels.shape)\n",
         "print(\"First text example: \", sample_text[0])\n",
         "print(\"First label example: \", sample_labels[0])"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "kMslWfuwoqpB"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Since you use `0` for padding and `1` for out-of-vocabulary (OOV) tokens, the vocabulary size has increased by two."
-      ],
       "metadata": {
         "id": "UI4I6_Sa0vWu"
-      }
+      },
+      "source": [
+        "Since you use `0` for padding and `1` for out-of-vocabulary (OOV) tokens, the vocabulary size has increased by two."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "source": [
-        "vocab_size += 2"
-      ],
-      "outputs": [],
       "metadata": {
         "id": "u21LlkO8QGRX"
-      }
+      },
+      "outputs": [],
+      "source": [
+        "vocab_size += 2"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Configure the datasets for better performance as before."
-      ],
       "metadata": {
         "id": "h44Ox11OYLP-"
-      }
+      },
+      "source": [
+        "Configure the datasets for better performance as before."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "BpT0b_7mYRXV"
+      },
+      "outputs": [],
       "source": [
         "train_data = configure_dataset(train_data)\n",
         "validation_data = configure_dataset(validation_data)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "BpT0b_7mYRXV"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "K8SUhGFNsmRi"
+      },
       "source": [
         "### Train the model\n",
         "You can train a model on this dataset as before."
-      ],
-      "metadata": {
-        "id": "K8SUhGFNsmRi"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "QJgI1pow2YR9"
+      },
+      "outputs": [],
       "source": [
         "model = create_model(vocab_size=vocab_size, num_labels=3)\n",
         "model.compile(\n",
@@ -1325,47 +1329,47 @@
         "    loss=losses.SparseCategoricalCrossentropy(from_logits=True),\n",
         "    metrics=['accuracy'])\n",
         "history = model.fit(train_data, validation_data=validation_data, epochs=3)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "QJgI1pow2YR9"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "KTPCYf_Jh6TH"
+      },
+      "outputs": [],
       "source": [
         "loss, accuracy = model.evaluate(validation_data)\n",
         "\n",
         "print(\"Loss: \", loss)\n",
         "print(\"Accuracy: {:2.2%}\".format(accuracy))"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "KTPCYf_Jh6TH"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Export the model"
-      ],
       "metadata": {
         "id": "_knIsO-r4pHb"
-      }
+      },
+      "source": [
+        "### Export the model"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "To make the model capable to taking raw strings as input, you will create a `TextVectorization` layer that performs the same steps as your custom preprocessing function. Since you already trained a vocabulary, you can use `set_vocaublary` instead of `adapt` which trains a new vocabulary."
-      ],
       "metadata": {
         "id": "FEuMLJA_Xiwo"
-      }
+      },
+      "source": [
+        "To make the model capable to taking raw strings as input, you will create a `TextVectorization` layer that performs the same steps as your custom preprocessing function. Since you already trained a vocabulary, you can use `set_vocaublary` instead of `adapt` which trains a new vocabulary."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "_ODkRXbk6aHb"
+      },
+      "outputs": [],
       "source": [
         "preprocess_layer = TextVectorization(\n",
         "    max_tokens=vocab_size,\n",
@@ -1374,15 +1378,15 @@
         "    output_mode='int',\n",
         "    output_sequence_length=MAX_SEQUENCE_LENGTH)\n",
         "preprocess_layer.set_vocabulary(vocab)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "_ODkRXbk6aHb"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "G-Cvd27y4qwt"
+      },
+      "outputs": [],
       "source": [
         "export_model = tf.keras.Sequential(\n",
         "    [preprocess_layer, model,\n",
@@ -1392,15 +1396,15 @@
         "    loss=losses.SparseCategoricalCrossentropy(from_logits=False),\n",
         "    optimizer='adam',\n",
         "    metrics=['accuracy'])"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "G-Cvd27y4qwt"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "Pyg0B4zsc-UD"
+      },
+      "outputs": [],
       "source": [
         "# Create a test dataset of raw strings\n",
         "test_ds = all_labeled_data.take(VALIDATION_SIZE).batch(BATCH_SIZE)\n",
@@ -1408,33 +1412,33 @@
         "loss, accuracy = export_model.evaluate(test_ds)\n",
         "print(\"Loss: \", loss)\n",
         "print(\"Accuracy: {:2.2%}\".format(accuracy))"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "Pyg0B4zsc-UD"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "The loss and accuracy for the model on encoded validation set and the exported model on the raw validation set are the same, as expected."
-      ],
       "metadata": {
         "id": "o6Mm0Y9QYQwE"
-      }
+      },
+      "source": [
+        "The loss and accuracy for the model on encoded validation set and the exported model on the raw validation set are the same, as expected."
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Run inference on new data"
-      ],
       "metadata": {
         "id": "Stk2BP8GE-qo"
-      }
+      },
+      "source": [
+        "### Run inference on new data"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "-w1fQGJPD2Yh"
+      },
+      "outputs": [],
       "source": [
         "inputs = [\n",
         "    \"Join'd to th' Ionians with their flowing robes,\",  # Label: 1\n",
@@ -1446,33 +1450,33 @@
         "for input, label in zip(inputs, predicted_labels):\n",
         "  print(\"Question: \", input)\n",
         "  print(\"Predicted label: \", label.numpy())"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "-w1fQGJPD2Yh"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Downloading more datasets using TensorFlow Datasets (TFDS)\n"
-      ],
       "metadata": {
         "id": "9eA8TVdnA-3L"
-      }
+      },
+      "source": [
+        "## Downloading more datasets using TensorFlow Datasets (TFDS)\n"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "You can download many more datasets from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/overview). As an example, you will download the [IMDB Large Movie Review dataset](https://www.tensorflow.org/datasets/catalog/imdb_reviews), and use it to train a model for sentiment classification."
-      ],
       "metadata": {
         "id": "2QFSxfZ3Vqsn"
-      }
+      },
+      "source": [
+        "You can download many more datasets from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/overview). As an example, you will download the [IMDB Large Movie Review dataset](https://www.tensorflow.org/datasets/catalog/imdb_reviews), and use it to train a model for sentiment classification."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "NzC65LOaVw0B"
+      },
+      "outputs": [],
       "source": [
         "train_ds = tfds.load(\n",
         "    'imdb_reviews',\n",
@@ -1480,15 +1484,15 @@
         "    batch_size=BATCH_SIZE,\n",
         "    shuffle_files=True,\n",
         "    as_supervised=True)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "NzC65LOaVw0B"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "XKGkgPBkFh0k"
+      },
+      "outputs": [],
       "source": [
         "val_ds = tfds.load(\n",
         "    'imdb_reviews',\n",
@@ -1496,58 +1500,58 @@
         "    batch_size=BATCH_SIZE,\n",
         "    shuffle_files=True,\n",
         "    as_supervised=True)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "XKGkgPBkFh0k"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Print a few examples."
-      ],
       "metadata": {
         "id": "BQjf3YZAb5Ne"
-      }
+      },
+      "source": [
+        "Print a few examples."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "Bq1w8MnfWt2C"
+      },
+      "outputs": [],
       "source": [
         "for review_batch, label_batch in val_ds.take(1):\n",
         "  for i in range(5):\n",
         "    print(\"Review: \", review_batch[i].numpy())\n",
         "    print(\"Label: \", label_batch[i].numpy())"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "Bq1w8MnfWt2C"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "q-lVaukyb75k"
+      },
       "source": [
         "You can now preprocess the data and train a model as before. \n",
         "\n",
         "Note: You will use `losses.BinaryCrossentropy` instead of `losses.SparseCategoricalCrossentropy` for your model since this is a binary classification problem."
-      ],
-      "metadata": {
-        "id": "q-lVaukyb75k"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Prepare the dataset for training"
-      ],
       "metadata": {
         "id": "ciz2CxAsZw3Z"
-      }
+      },
+      "source": [
+        "### Prepare the dataset for training"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "UzT_t9ihZLH4"
+      },
+      "outputs": [],
       "source": [
         "vectorize_layer = TextVectorization(\n",
         "    max_tokens=VOCAB_SIZE,\n",
@@ -1557,122 +1561,122 @@
         "# Make a text-only dataset (without labels), then call adapt\n",
         "train_text = train_ds.map(lambda text, labels: text)\n",
         "vectorize_layer.adapt(train_text)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "UzT_t9ihZLH4"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "zz-Xrd_ZZ4tB"
+      },
+      "outputs": [],
       "source": [
         "def vectorize_text(text, label):\n",
         "  text = tf.expand_dims(text, -1)\n",
         "  return vectorize_layer(text), label"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "zz-Xrd_ZZ4tB"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "ycn0Itd6g5aF"
+      },
+      "outputs": [],
       "source": [
         "train_ds = train_ds.map(vectorize_text)\n",
         "val_ds = val_ds.map(vectorize_text)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "ycn0Itd6g5aF"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "jc11jQTlZ5lj"
+      },
+      "outputs": [],
       "source": [
         "# Configure datasets for performance as before\n",
         "train_ds = configure_dataset(train_ds)\n",
         "val_ds = configure_dataset(val_ds)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "jc11jQTlZ5lj"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Train the model"
-      ],
       "metadata": {
         "id": "SQzoYkaGZ82Z"
-      }
+      },
+      "source": [
+        "### Train the model"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "B9IOTLkyZ-a7"
+      },
+      "outputs": [],
       "source": [
         "model = create_model(vocab_size=VOCAB_SIZE + 1, num_labels=1)\n",
         "model.summary()"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "B9IOTLkyZ-a7"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "xLnDs5dhaBAk"
+      },
+      "outputs": [],
       "source": [
         "model.compile(\n",
         "    loss=losses.BinaryCrossentropy(from_logits=True),\n",
         "    optimizer='adam',\n",
         "    metrics=['accuracy'])"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "xLnDs5dhaBAk"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "source": [
-        "history = model.fit(train_ds, validation_data=val_ds, epochs=3)"
-      ],
-      "outputs": [],
       "metadata": {
         "id": "rq59QpNzaDMa"
-      }
+      },
+      "outputs": [],
+      "source": [
+        "history = model.fit(train_ds, validation_data=val_ds, epochs=3)"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "gCMWCEtyaEbR"
+      },
+      "outputs": [],
       "source": [
         "loss, accuracy = model.evaluate(val_ds)\n",
         "\n",
         "print(\"Loss: \", loss)\n",
         "print(\"Accuracy: {:2.2%}\".format(accuracy))"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "gCMWCEtyaEbR"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Export the model"
-      ],
       "metadata": {
         "id": "jGtqLXVnaaFy"
-      }
+      },
+      "source": [
+        "### Export the model"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "yE9WZARZaZr1"
+      },
+      "outputs": [],
       "source": [
         "export_model = tf.keras.Sequential(\n",
         "    [vectorize_layer, model,\n",
@@ -1682,15 +1686,15 @@
         "    loss=losses.SparseCategoricalCrossentropy(from_logits=False),\n",
         "    optimizer='adam',\n",
         "    metrics=['accuracy'])"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "yE9WZARZaZr1"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "bhF8tDH-afoC"
+      },
+      "outputs": [],
       "source": [
         "# 0 --> negative review\n",
         "# 1 --> positive review\n",
@@ -1705,22 +1709,18 @@
         "for input, label in zip(inputs, predicted_labels):\n",
         "  print(\"Question: \", input)\n",
         "  print(\"Predicted label: \", label)"
-      ],
-      "outputs": [],
-      "metadata": {
-        "id": "bhF8tDH-afoC"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "q1KSXDFPWiPN"
+      },
       "source": [
         "## Conclusion\n",
         "\n",
         "This tutorial demonstrated several ways to load and preprocess text. As a next step, you can explore additional tutorials on the website, or download new datasets from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/overview)."
-      ],
-      "metadata": {
-        "id": "q1KSXDFPWiPN"
-      }
+      ]
     }
   ],
   "metadata": {
@@ -1736,5 +1736,5 @@
     }
   },
   "nbformat": 4,
-  "nbformat_minor": 2
+  "nbformat_minor": 0
 }

--- a/site/en/tutorials/load_data/text.ipynb
+++ b/site/en/tutorials/load_data/text.ipynb
@@ -2,21 +2,16 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "DweYe9FcbMK_"
-      },
       "source": [
         "##### Copyright 2018 The TensorFlow Authors.\n"
-      ]
+      ],
+      "metadata": {
+        "id": "DweYe9FcbMK_"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "id": "AVV2e0XKbJeX"
-      },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -29,22 +24,24 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "cellView": "form",
+        "id": "AVV2e0XKbJeX"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "sZfSvVcDo6GQ"
-      },
       "source": [
         "# Load text"
-      ]
+      ],
+      "metadata": {
+        "id": "sZfSvVcDo6GQ"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "giK0nMbZFnoR"
-      },
       "source": [
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
         "  <td>\n",
@@ -60,43 +57,42 @@
         "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/load_data/text.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
         "  </td>\n",
         "</table>"
-      ]
+      ],
+      "metadata": {
+        "id": "giK0nMbZFnoR"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "dwlfPb11GH8J"
-      },
       "source": [
         "This tutorial demonstrates two ways to load and preprocess text.\n",
         "\n",
         "+ First, you will use Keras utilities and layers. If you are new to TensorFlow, you should start with these.\n",
         "\n",
         "+ Next, you will use lower-level utilities like `tf.data.TextLineDataset` to load text files, and `tf.text` to preprocess the data for finer-grain control."
-      ]
+      ],
+      "metadata": {
+        "id": "dwlfPb11GH8J"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "sa6IKWvADqH7"
-      },
-      "outputs": [],
       "source": [
         "# Be sure you're using the stable versions of both tf and tf-text, for binary compatibility.\n",
         "!pip uninstall -y tensorflow tf-nightly keras\n",
         "\n",
         "!pip install -q -U tf-nightly\n",
         "!pip install -q -U tensorflow-text-nightly"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "sa6IKWvADqH7"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "baYFZMW_bJHh"
-      },
-      "outputs": [],
       "source": [
         "import collections\n",
         "import pathlib\n",
@@ -113,37 +109,37 @@
         "\n",
         "import tensorflow_datasets as tfds\n",
         "import tensorflow_text as tf_text"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "baYFZMW_bJHh"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "Az-d_K5_HQ5k"
-      },
       "source": [
         "## Example 1: Predict the tag for a Stack Overflow question\n",
         "\n",
         "As a first example, you will download a dataset of programming questions from Stack Overflow. Each question (\"How do I sort a dictionary by value?\") is labeled with exactly one tag (`Python`, `CSharp`, `JavaScript`, or `Java`). Your task is to develop a model that predicts the tag for a question. This is an example of multi-class classification, an important and widely applicable kind of machine learning problem."
-      ]
+      ],
+      "metadata": {
+        "id": "Az-d_K5_HQ5k"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "tjC3yLa5IjP7"
-      },
       "source": [
         "### Download and explore the dataset\n",
         "\n",
         "Next, you will download the dataset, and explore the directory structure."
-      ]
+      ],
+      "metadata": {
+        "id": "tjC3yLa5IjP7"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "8ELgzA6SHTuV"
-      },
-      "outputs": [],
       "source": [
         "data_url = 'https://storage.googleapis.com/download.tensorflow.org/data/stack_overflow_16k.tar.gz'\n",
         "dataset_dir = utils.get_file(\n",
@@ -153,58 +149,59 @@
         "    cache_subdir='')\n",
         "\n",
         "dataset_dir = pathlib.Path(dataset_dir).parent"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "8ELgzA6SHTuV"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "jIrPl5fUH2gb"
-      },
-      "outputs": [],
       "source": [
         "list(dataset_dir.iterdir())"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "jIrPl5fUH2gb"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "fEoV7YByJoWQ"
-      },
-      "outputs": [],
       "source": [
         "train_dir = dataset_dir/'train'\n",
         "list(train_dir.iterdir())"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "fEoV7YByJoWQ"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "3mxAN17MhEh0"
-      },
       "source": [
         "The `train/csharp`, `train/java`, `train/python` and `train/javascript` directories contain many text files, each of which is a Stack Overflow question. Print a file and inspect the data."
-      ]
+      ],
+      "metadata": {
+        "id": "3mxAN17MhEh0"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "Go1vTSGdJu08"
-      },
-      "outputs": [],
       "source": [
         "sample_file = train_dir/'python/1755.txt'\n",
         "with open(sample_file) as f:\n",
         "  print(f.read())"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "Go1vTSGdJu08"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "deWBTkpJiO7D"
-      },
       "source": [
         "### Load the dataset\n",
         "\n",
@@ -227,24 +224,23 @@
         "......1.txt\n",
         "......2.txt\n",
         "```"
-      ]
+      ],
+      "metadata": {
+        "id": "deWBTkpJiO7D"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "Dyl6JTAjlbQV"
-      },
       "source": [
         "When running a machine learning experiment, it is a best practice to divide your dataset into three splits: [train](https://developers.google.com/machine-learning/glossary#training_set), [validation](https://developers.google.com/machine-learning/glossary#validation_set), and [test](https://developers.google.com/machine-learning/glossary#test-set). The Stack Overflow dataset has already been divided into train and test, but it lacks a validation set. Create a validation set using an 80:20 split of the training data by using the `validation_split` argument below."
-      ]
+      ],
+      "metadata": {
+        "id": "Dyl6JTAjlbQV"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "qqyliMw8N-az"
-      },
-      "outputs": [],
       "source": [
         "batch_size = 32\n",
         "seed = 42\n",
@@ -255,72 +251,72 @@
         "    validation_split=0.2,\n",
         "    subset='training',\n",
         "    seed=seed)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "qqyliMw8N-az"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "DMI_gPLfloD7"
-      },
       "source": [
         "As you can see above, there are 8,000 examples in the training folder, of which you will use 80% (or 6,400) for training. As you will see in a moment, you can train a model by passing a `tf.data.Dataset` directly to `model.fit`. First, iterate over the dataset and print out a few examples, to get a feel for the data.\n",
         "\n",
         "Note: To increase the difficulty of the classification problem, the dataset author replaced occurrences of the words *Python*, *CSharp*, *JavaScript*, or *Java* in the programming question with the word *blank*."
-      ]
+      ],
+      "metadata": {
+        "id": "DMI_gPLfloD7"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "_JMTyZ6Glt_C"
-      },
-      "outputs": [],
       "source": [
         "for text_batch, label_batch in raw_train_ds.take(1):\n",
         "  for i in range(10):\n",
         "    print(\"Question: \", text_batch.numpy()[i])\n",
         "    print(\"Label:\", label_batch.numpy()[i])"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "_JMTyZ6Glt_C"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "jCZGl4Q5l2sS"
-      },
       "source": [
         "The labels are `0`, `1`, `2` or `3`. To see which of these correspond to which string label, you can check the `class_names` property on the dataset.\n"
-      ]
+      ],
+      "metadata": {
+        "id": "jCZGl4Q5l2sS"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "gIpCS7YjmGkj"
-      },
-      "outputs": [],
       "source": [
         "for i, label in enumerate(raw_train_ds.class_names):\n",
         "  print(\"Label\", i, \"corresponds to\", label)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "gIpCS7YjmGkj"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "oUsdn-37qol9"
-      },
       "source": [
         "Next, you will create a validation and test dataset. You will use the remaining 1,600 reviews from the training set for validation.\n",
         "\n",
         "Note:  When using the `validation_split` and `subset` arguments, make sure to either specify a random seed, or to pass `shuffle=False`, so that the validation and training splits have no overlap."
-      ]
+      ],
+      "metadata": {
+        "id": "oUsdn-37qol9"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "x7m6sCWJQuYt"
-      },
-      "outputs": [],
       "source": [
         "raw_val_ds = preprocessing.text_dataset_from_directory(\n",
         "    train_dir,\n",
@@ -328,35 +324,36 @@
         "    validation_split=0.2,\n",
         "    subset='validation',\n",
         "    seed=seed)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "x7m6sCWJQuYt"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "BXMZc7fMQwKE"
-      },
-      "outputs": [],
       "source": [
         "test_dir = dataset_dir/'test'\n",
         "raw_test_ds = preprocessing.text_dataset_from_directory(\n",
         "    test_dir, batch_size=batch_size)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "BXMZc7fMQwKE"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "Xdt-ATrGRGDL"
-      },
       "source": [
         "### Prepare the dataset for training"
-      ]
+      ],
+      "metadata": {
+        "id": "Xdt-ATrGRGDL"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "N6fRti45Rlj8"
-      },
       "source": [
         "Next, you will standardize, tokenize, and vectorize the data using the `layers.TextVectorization` layer.\n",
         "* Standardization refers to preprocessing the text, typically to remove punctuation or HTML elements to simplify the dataset.\n",
@@ -375,39 +372,38 @@
         "\n",
         "\n",
         "You will build two modes to learn more about these. First, you will use the `binary` model to build a bag-of-words model. Next, you will use the `int` mode with a 1D ConvNet."
-      ]
+      ],
+      "metadata": {
+        "id": "N6fRti45Rlj8"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "voaC43rZR0jc"
-      },
-      "outputs": [],
       "source": [
         "VOCAB_SIZE = 10000\n",
         "\n",
         "binary_vectorize_layer = TextVectorization(\n",
         "    max_tokens=VOCAB_SIZE,\n",
         "    output_mode='binary')"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "voaC43rZR0jc"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ifDPFxuf2Hfz"
-      },
       "source": [
         "For `int` mode, in addition to maximum vocabulary size, you need to set an explicit maximum sequence length, which will cause the layer to pad or truncate sequences to exactly sequence_length values."
-      ]
+      ],
+      "metadata": {
+        "id": "ifDPFxuf2Hfz"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "XWsY01Zl2aRe"
-      },
-      "outputs": [],
       "source": [
         "MAX_SEQUENCE_LENGTH = 250\n",
         "\n",
@@ -415,145 +411,145 @@
         "    max_tokens=VOCAB_SIZE,\n",
         "    output_mode='int',\n",
         "    output_sequence_length=MAX_SEQUENCE_LENGTH)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "XWsY01Zl2aRe"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ts6h9b5atD-Y"
-      },
       "source": [
         "Next, you will call `adapt` to fit the state of the preprocessing layer to the dataset. This will cause the model to build an index of strings to integers.\n",
         "\n",
         "Note: it's important to only use your training data when calling adapt (using the test set would leak information)."
-      ]
+      ],
+      "metadata": {
+        "id": "ts6h9b5atD-Y"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "yTXsdDEqSf9e"
-      },
-      "outputs": [],
       "source": [
         "# Make a text-only dataset (without labels), then call adapt\n",
         "train_text = raw_train_ds.map(lambda text, labels: text)\n",
         "binary_vectorize_layer.adapt(train_text)\n",
         "int_vectorize_layer.adapt(train_text)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "yTXsdDEqSf9e"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "XKVO6Jg7Sls0"
-      },
       "source": [
         "See the result of using these layers to preprocess data:"
-      ]
+      ],
+      "metadata": {
+        "id": "XKVO6Jg7Sls0"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "RngfPyArSsvM"
-      },
-      "outputs": [],
       "source": [
         "def binary_vectorize_text(text, label):\n",
         "  text = tf.expand_dims(text, -1)\n",
         "  return binary_vectorize_layer(text), label"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "RngfPyArSsvM"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "_1W54wf0LhQ0"
-      },
-      "outputs": [],
       "source": [
         "def int_vectorize_text(text, label):\n",
         "  text = tf.expand_dims(text, -1)\n",
         "  return int_vectorize_layer(text), label"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "_1W54wf0LhQ0"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "Vi_sElMiSmXe"
-      },
-      "outputs": [],
       "source": [
         "# Retrieve a batch (of 32 reviews and labels) from the dataset\n",
         "text_batch, label_batch = next(iter(raw_train_ds))\n",
         "first_question, first_label = text_batch[0], label_batch[0]\n",
         "print(\"Question\", first_question)\n",
         "print(\"Label\", first_label)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "Vi_sElMiSmXe"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "UGukZoYv2v3v"
-      },
-      "outputs": [],
       "source": [
         "print(\"'binary' vectorized question:\", \n",
         "      binary_vectorize_text(first_question, first_label)[0])"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "UGukZoYv2v3v"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "Lu07FsIw2yH5"
-      },
-      "outputs": [],
       "source": [
         "print(\"'int' vectorized question:\",\n",
         "      int_vectorize_text(first_question, first_label)[0])"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "Lu07FsIw2yH5"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "wgjeF9PdS7tN"
-      },
       "source": [
         "As you can see above, `binary` mode returns an array denoting which tokens exist at least once in the input, while `int` mode replaces each token by an integer, thus preserving their order. You can lookup the token (string) that each integer corresponds to by calling `.get_vocabulary()` on the layer."
-      ]
+      ],
+      "metadata": {
+        "id": "wgjeF9PdS7tN"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "WpBnTZilS8wt"
-      },
-      "outputs": [],
       "source": [
         "print(\"1289 ---> \", int_vectorize_layer.get_vocabulary()[1289])\n",
         "print(\"313 ---> \", int_vectorize_layer.get_vocabulary()[313])\n",
         "print(\"Vocabulary size: {}\".format(len(int_vectorize_layer.get_vocabulary())))"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "WpBnTZilS8wt"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "0kHgPE_YwHvp"
-      },
       "source": [
         "You are nearly ready to train your model. As a final preprocessing step, you will apply the `TextVectorization` layers you created earlier to the train, validation, and test dataset."
-      ]
+      ],
+      "metadata": {
+        "id": "0kHgPE_YwHvp"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "46LeHmnD55wJ"
-      },
-      "outputs": [],
       "source": [
         "binary_train_ds = raw_train_ds.map(binary_vectorize_text)\n",
         "binary_val_ds = raw_val_ds.map(binary_vectorize_text)\n",
@@ -562,13 +558,14 @@
         "int_train_ds = raw_train_ds.map(int_vectorize_text)\n",
         "int_val_ds = raw_val_ds.map(int_vectorize_text)\n",
         "int_test_ds = raw_test_ds.map(int_vectorize_text)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "46LeHmnD55wJ"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "NHuAF8hYfP5Z"
-      },
       "source": [
         "### Configure the dataset for performance\n",
         "\n",
@@ -579,29 +576,28 @@
         "`.prefetch()` overlaps data preprocessing and model execution while training. \n",
         "\n",
         "You can learn more about both methods, as well as how to cache data to disk in the [data performance guide](https://www.tensorflow.org/guide/data_performance)."
-      ]
+      ],
+      "metadata": {
+        "id": "NHuAF8hYfP5Z"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "PabA9DFIfSz7"
-      },
-      "outputs": [],
       "source": [
         "AUTOTUNE = tf.data.AUTOTUNE\n",
         "\n",
         "def configure_dataset(dataset):\n",
         "  return dataset.cache().prefetch(buffer_size=AUTOTUNE)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "PabA9DFIfSz7"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "J8GcJLvb3JH0"
-      },
-      "outputs": [],
       "source": [
         "binary_train_ds = configure_dataset(binary_train_ds)\n",
         "binary_val_ds = configure_dataset(binary_val_ds)\n",
@@ -610,25 +606,26 @@
         "int_train_ds = configure_dataset(int_train_ds)\n",
         "int_val_ds = configure_dataset(int_val_ds)\n",
         "int_test_ds = configure_dataset(int_test_ds)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "J8GcJLvb3JH0"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "NYGb7z_bfpGm"
-      },
       "source": [
         "### Train the model\n",
-        "It's time to create our neural network. For the `binary` vectorized data, train a simple bag-of-words linear model:"
-      ]
+        "\n",
+        "It's time to create your neural network. For the `binary` vectorized data, train a simple bag-of-words linear model:"
+      ],
+      "metadata": {
+        "id": "NYGb7z_bfpGm"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "2q8iAU-VMzaN"
-      },
-      "outputs": [],
       "source": [
         "binary_model = tf.keras.Sequential([layers.Dense(4)])\n",
         "binary_model.compile(\n",
@@ -637,24 +634,24 @@
         "    metrics=['accuracy'])\n",
         "history = binary_model.fit(\n",
         "    binary_train_ds, validation_data=binary_val_ds, epochs=10)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "2q8iAU-VMzaN"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "EwidD-SwNIkz"
-      },
       "source": [
         "Next, you will use the `int` vectorized layer to build a 1D ConvNet."
-      ]
+      ],
+      "metadata": {
+        "id": "EwidD-SwNIkz"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "5ztw2XH_LbVz"
-      },
-      "outputs": [],
       "source": [
         "def create_model(vocab_size, num_labels):\n",
         "  model = tf.keras.Sequential([\n",
@@ -664,15 +661,15 @@
         "      layers.Dense(num_labels)\n",
         "  ])\n",
         "  return model"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "5ztw2XH_LbVz"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "s9rG1cFRL31Z"
-      },
-      "outputs": [],
       "source": [
         "# vocab_size is VOCAB_SIZE + 1 since 0 is used additionally for padding.\n",
         "int_model = create_model(vocab_size=VOCAB_SIZE + 1, num_labels=4)\n",
@@ -681,92 +678,92 @@
         "    optimizer='adam',\n",
         "    metrics=['accuracy'])\n",
         "history = int_model.fit(int_train_ds, validation_data=int_val_ds, epochs=5)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "s9rG1cFRL31Z"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "x3J9Eeuv97zE"
-      },
       "source": [
         "Compare the two models:"
-      ]
+      ],
+      "metadata": {
+        "id": "x3J9Eeuv97zE"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "N8ViDXw99v_u"
-      },
-      "outputs": [],
       "source": [
         "print(\"Linear model on binary vectorized data:\")\n",
         "print(binary_model.summary())"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "N8ViDXw99v_u"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "P9BOeoCwborD"
-      },
-      "outputs": [],
       "source": [
         "print(\"ConvNet model on int vectorized data:\")\n",
         "print(int_model.summary())"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "P9BOeoCwborD"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "zYYW9tUdCtTy"
-      },
       "source": [
         "Evaluate both models on the test data:"
-      ]
+      ],
+      "metadata": {
+        "id": "zYYW9tUdCtTy"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "5dTc4nZqf7fK"
-      },
-      "outputs": [],
       "source": [
         "binary_loss, binary_accuracy = binary_model.evaluate(binary_test_ds)\n",
         "int_loss, int_accuracy = int_model.evaluate(int_test_ds)\n",
         "\n",
         "print(\"Binary model accuracy: {:2.2%}\".format(binary_accuracy))\n",
         "print(\"Int model accuracy: {:2.2%}\".format(int_accuracy))"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "5dTc4nZqf7fK"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "F9dhj8Hey9DS"
-      },
       "source": [
         "Note: This example dataset represents a rather simple classification problem. More complex datasets and problems bring out subtle but significant differences in preprocessing strategies and model architectures. Be sure to try out different hyperparameters and epochs to compare various approaches."
-      ]
+      ],
+      "metadata": {
+        "id": "F9dhj8Hey9DS"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "h9GaXTsIgP-3"
-      },
       "source": [
         "### Export the model\n",
         "\n",
         "In the code above, you applied the `TextVectorization` layer to the dataset before feeding text to the model. If you want to make your model capable of processing raw strings (for example, to simplify deploying it), you can include the `TextVectorization` layer inside your model. To do so, you can create a new model using the weights you just trained."
-      ]
+      ],
+      "metadata": {
+        "id": "h9GaXTsIgP-3"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "_bRe3KX8gRCX"
-      },
-      "outputs": [],
       "source": [
         "export_model = tf.keras.Sequential(\n",
         "    [binary_vectorize_layer, binary_model,\n",
@@ -780,47 +777,47 @@
         "# Test it with `raw_test_ds`, which yields raw strings\n",
         "loss, accuracy = export_model.evaluate(raw_test_ds)\n",
         "print(\"Accuracy: {:2.2%}\".format(binary_accuracy))"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "_bRe3KX8gRCX"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "m2eqTVBP4DUN"
-      },
       "source": [
         "Now your model can take raw strings as input and predict a score for each label using `model.predict`. Define a function to find the label with the maximum score:"
-      ]
+      ],
+      "metadata": {
+        "id": "m2eqTVBP4DUN"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "GU53uRXz45iO"
-      },
-      "outputs": [],
       "source": [
         "def get_string_labels(predicted_scores_batch):\n",
         "  predicted_int_labels = tf.argmax(predicted_scores_batch, axis=1)\n",
         "  predicted_labels = tf.gather(raw_train_ds.class_names, predicted_int_labels)\n",
         "  return predicted_labels"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "GU53uRXz45iO"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "yqnWc7Nn5eou"
-      },
       "source": [
         "### Run inference on new data"
-      ]
+      ],
+      "metadata": {
+        "id": "yqnWc7Nn5eou"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "BOR2MupW1_zS"
-      },
-      "outputs": [],
       "source": [
         "inputs = [\n",
         "    \"how do I extract keys from a dict into a list?\",  # python\n",
@@ -831,44 +828,45 @@
         "for input, label in zip(inputs, predicted_labels):\n",
         "  print(\"Question: \", input)\n",
         "  print(\"Predicted label: \", label.numpy())"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "BOR2MupW1_zS"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "0QDVfii_4slI"
-      },
       "source": [
         "Including the text preprocessing logic inside your model enables you to export a model for production that simplifies deployment, and reduces the potential for [train/test skew](https://developers.google.com/machine-learning/guides/rules-of-ml#training-serving_skew).\n",
         "\n",
         "There is a performance difference to keep in mind when choosing where to apply your `TextVectorization` layer. Using it outside of your model enables you to do asynchronous CPU processing and buffering of your data when training on GPU. So, if you're training your model on the GPU, you probably want to go with this option to get the best performance while developing your model, then switch to including the TextVectorization layer inside your model when you're ready to prepare for deployment.\n",
         "\n",
         "Visit this [tutorial](https://www.tensorflow.org/tutorials/keras/save_and_load) to learn more about saving models."
-      ]
+      ],
+      "metadata": {
+        "id": "0QDVfii_4slI"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "p4cvuFzavTRy"
-      },
       "source": [
         "## Example 2: Predict the author of Illiad translations \n"
-      ]
+      ],
+      "metadata": {
+        "id": "p4cvuFzavTRy"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "fOlJ22508RIe"
-      },
       "source": [
         "The following provides an example of using `tf.data.TextLineDataset` to load examples from text files, and `tf.text` to preprocess the data. In this example, you will use three different English translations of the same work, Homer's Illiad, and train a model to identify the translator given a single line of text."
-      ]
+      ],
+      "metadata": {
+        "id": "fOlJ22508RIe"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "-pCgKbOSk7kU"
-      },
       "source": [
         "### Download and explore the dataset\n",
         "\n",
@@ -881,15 +879,14 @@
         "- [Samuel Butler](https://en.wikipedia.org/wiki/Samuel_Butler_%28novelist%29) — [text](https://storage.googleapis.com/download.tensorflow.org/data/illiad/butler.txt)\n",
         "\n",
         "The text files used in this tutorial have undergone some typical preprocessing tasks like removing document header and footer, line numbers and chapter titles. Download these lightly munged files locally."
-      ]
+      ],
+      "metadata": {
+        "id": "-pCgKbOSk7kU"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "4YlKQthEYlFw"
-      },
-      "outputs": [],
       "source": [
         "DIRECTORY_URL = 'https://storage.googleapis.com/download.tensorflow.org/data/illiad/'\n",
         "FILE_NAMES = ['cowper.txt', 'derby.txt', 'butler.txt']\n",
@@ -899,40 +896,40 @@
         "\n",
         "parent_dir = pathlib.Path(text_dir).parent\n",
         "list(parent_dir.iterdir())"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "4YlKQthEYlFw"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "M8PHK5J_cXE5"
-      },
       "source": [
         "### Load the dataset\n",
         "\n",
         "You will use `TextLineDataset`, which is designed to create a `tf.data.Dataset` from a text file in which each example is a line of text from the original file, whereas `text_dataset_from_directory` treats all contents of a file as a single example. `TextLineDataset` is useful for text data that is primarily line-based (for example, poetry or error logs). \n",
         "\n",
         "Iterate through these files, loading each one into its own dataset. Each example needs to be individually labeled, so use `tf.data.Dataset.map` to apply a labeler function to each one. This will iterate over every example in the dataset, returning (`example, label`) pairs."
-      ]
+      ],
+      "metadata": {
+        "id": "M8PHK5J_cXE5"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "YIIWIdPXgk7I"
-      },
-      "outputs": [],
       "source": [
         "def labeler(example, index):\n",
         "  return example, tf.cast(index, tf.int64)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "YIIWIdPXgk7I"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "8Ajx7AmZnEg3"
-      },
-      "outputs": [],
       "source": [
         "labeled_data_sets = []\n",
         "\n",
@@ -940,37 +937,37 @@
         "  lines_dataset = tf.data.TextLineDataset(str(parent_dir/file_name))\n",
         "  labeled_dataset = lines_dataset.map(lambda ex: labeler(ex, i))\n",
         "  labeled_data_sets.append(labeled_dataset)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "8Ajx7AmZnEg3"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "wPOsVK1e9NGM"
-      },
       "source": [
         "Next, you'll combine these labeled datasets into a single dataset, and shuffle it.\n"
-      ]
+      ],
+      "metadata": {
+        "id": "wPOsVK1e9NGM"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "6jAeYkTIi9-2"
-      },
-      "outputs": [],
       "source": [
         "BUFFER_SIZE = 50000\n",
         "BATCH_SIZE = 64\n",
         "VALIDATION_SIZE = 5000"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "6jAeYkTIi9-2"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "Qd544E-Sh63L"
-      },
-      "outputs": [],
       "source": [
         "all_labeled_data = labeled_data_sets[0]\n",
         "for labeled_dataset in labeled_data_sets[1:]:\n",
@@ -978,115 +975,115 @@
         "\n",
         "all_labeled_data = all_labeled_data.shuffle(\n",
         "    BUFFER_SIZE, reshuffle_each_iteration=False)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "Qd544E-Sh63L"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "r4JEHrJXeG5k"
-      },
       "source": [
         "Print out a few examples as before. The dataset hasn't been batched yet, hence each entry in `all_labeled_data` corresponds to one data point:"
-      ]
+      ],
+      "metadata": {
+        "id": "r4JEHrJXeG5k"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "gywKlN0xh6u5"
-      },
-      "outputs": [],
       "source": [
         "for text, label in all_labeled_data.take(10):\n",
         "  print(\"Sentence: \", text.numpy())\n",
         "  print(\"Label:\", label.numpy())"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "gywKlN0xh6u5"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "5rrpU2_sfDh0"
-      },
       "source": [
         "### Prepare the dataset for training\n",
         "\n",
-        "Instead of using the Keras `TextVectorization` layer to preprocess our text dataset, you will now use the [`tf.text` API](https://www.tensorflow.org/tutorials/tensorflow_text/intro) to standardize and tokenize the data, build a vocabulary and use `StaticVocabularyTable` to map tokens to integers to feed to the model.\n",
+        "Instead of using the Keras `TextVectorization` layer to preprocess the text dataset, you will now use the [`tf.text` API](https://www.tensorflow.org/tutorials/tensorflow_text/intro) to standardize and tokenize the data, build a vocabulary and use `StaticVocabularyTable` to map tokens to integers to feed to the model.\n",
         "\n",
-        "While tf.text provides various tokenizers, you will use the `UnicodeScriptTokenizer` to tokenize our dataset. Define a function to convert the text to lower-case and tokenize it. You will use `tf.data.Dataset.map` to apply the tokenization to the dataset."
-      ]
+        "While tf.text provides various tokenizers, you will use the `UnicodeScriptTokenizer` to tokenize the dataset. Define a function to convert the text to lower-case and tokenize it. You will use `tf.data.Dataset.map` to apply the tokenization to the dataset."
+      ],
+      "metadata": {
+        "id": "5rrpU2_sfDh0"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "v4DpQW-Y12rm"
-      },
-      "outputs": [],
       "source": [
         "tokenizer = tf_text.UnicodeScriptTokenizer()"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "v4DpQW-Y12rm"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "pz8xEj0ugu51"
-      },
-      "outputs": [],
       "source": [
         "def tokenize(text, unused_label):\n",
         "  lower_case = tf_text.case_fold_utf8(text)\n",
         "  return tokenizer.tokenize(lower_case)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "pz8xEj0ugu51"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "vzUrAzOq31QL"
-      },
-      "outputs": [],
       "source": [
         "tokenized_ds = all_labeled_data.map(tokenize)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "vzUrAzOq31QL"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "jx4Q2i8XLV7o"
-      },
       "source": [
         "You can iterate over the dataset and print out a few tokenized examples.\n"
-      ]
+      ],
+      "metadata": {
+        "id": "jx4Q2i8XLV7o"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "g2mkWri7LiGq"
-      },
-      "outputs": [],
       "source": [
         "for text_batch in tokenized_ds.take(5):\n",
         "  print(\"Tokens: \", text_batch.numpy())"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "g2mkWri7LiGq"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "JPd4PsskJ_Xt"
-      },
       "source": [
         "Next, you will build a vocabulary by sorting tokens by frequency and keeping the top `VOCAB_SIZE` tokens."
-      ]
+      ],
+      "metadata": {
+        "id": "JPd4PsskJ_Xt"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "YkHtbGnDh6mg"
-      },
-      "outputs": [],
       "source": [
         "tokenized_ds = configure_dataset(tokenized_ds)\n",
         "\n",
@@ -1101,24 +1098,24 @@
         "vocab_size = len(vocab)\n",
         "print(\"Vocab size: \", vocab_size)\n",
         "print(\"First five vocab entries:\", vocab[:5])"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "YkHtbGnDh6mg"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "PyKSsaNAKi17"
-      },
       "source": [
         "To convert the tokens into integers, use the `vocab` set to create a `StaticVocabularyTable`. You will map tokens to integers in the range [`2`, `vocab_size + 2`]. As with the `TextVectorization` layer, `0` is reserved to denote padding and `1` is reserved to denote an out-of-vocabulary (OOV) token."
-      ]
+      ],
+      "metadata": {
+        "id": "PyKSsaNAKi17"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "kCBo2yFHD7y6"
-      },
-      "outputs": [],
       "source": [
         "keys = vocab\n",
         "values = range(2, len(vocab) + 2)  # reserve 0 for padding, 1 for OOV\n",
@@ -1128,199 +1125,199 @@
         "\n",
         "num_oov_buckets = 1\n",
         "vocab_table = tf.lookup.StaticVocabularyTable(init, num_oov_buckets)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "kCBo2yFHD7y6"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "Z5F-EiBpOADE"
-      },
       "source": [
         "Finally, define a fuction to standardize, tokenize and vectorize the dataset using the tokenizer and lookup table:"
-      ]
+      ],
+      "metadata": {
+        "id": "Z5F-EiBpOADE"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "HcIQ7LOTh6eT"
-      },
-      "outputs": [],
       "source": [
         "def preprocess_text(text, label):\n",
         "  standardized = tf_text.case_fold_utf8(text)\n",
         "  tokenized = tokenizer.tokenize(standardized)\n",
         "  vectorized = vocab_table.lookup(tokenized)\n",
         "  return vectorized, label"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "HcIQ7LOTh6eT"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "v6S5Qyabi-vo"
-      },
       "source": [
         "You can try this on a single example to see the output:"
-      ]
+      ],
+      "metadata": {
+        "id": "v6S5Qyabi-vo"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "jgxPZaxUuTbk"
-      },
-      "outputs": [],
       "source": [
         "example_text, example_label = next(iter(all_labeled_data))\n",
         "print(\"Sentence: \", example_text.numpy())\n",
         "vectorized_text, example_label = preprocess_text(example_text, example_label)\n",
         "print(\"Vectorized sentence: \", vectorized_text.numpy())"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "jgxPZaxUuTbk"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "p9qHM0v8k_Mg"
-      },
       "source": [
         "Now run the preprocess function on the dataset using `tf.data.Dataset.map`."
-      ]
+      ],
+      "metadata": {
+        "id": "p9qHM0v8k_Mg"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "KmQVsAgJ-RM0"
-      },
-      "outputs": [],
       "source": [
         "all_encoded_data = all_labeled_data.map(preprocess_text)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "KmQVsAgJ-RM0"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "_YZToSXSm0qr"
-      },
       "source": [
         "### Split the dataset into train and test\n"
-      ]
+      ],
+      "metadata": {
+        "id": "_YZToSXSm0qr"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "itxIJwkrUXgv"
-      },
       "source": [
         "The Keras `TextVectorization` layer also batches and pads the vectorized data. Padding is required because the examples inside of a batch need to be the same size and shape, but the examples in these datasets are not all the same size — each line of text has a different number of words. `tf.data.Dataset` supports splitting and padded-batching datasets: "
-      ]
+      ],
+      "metadata": {
+        "id": "itxIJwkrUXgv"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "r-rmbijQh6bf"
-      },
-      "outputs": [],
       "source": [
         "train_data = all_encoded_data.skip(VALIDATION_SIZE).shuffle(BUFFER_SIZE)\n",
         "validation_data = all_encoded_data.take(VALIDATION_SIZE)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "r-rmbijQh6bf"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "qTP0IwHBCn0Q"
-      },
-      "outputs": [],
       "source": [
         "train_data = train_data.padded_batch(BATCH_SIZE)\n",
         "validation_data = validation_data.padded_batch(BATCH_SIZE)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "qTP0IwHBCn0Q"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "m-wmFq8uW1zS"
-      },
       "source": [
         "Now, `validation_data` and `train_data` are not collections of (`example, label`) pairs, but collections of batches. Each batch is a pair of (*many examples*, *many labels*) represented as arrays. To illustrate:"
-      ]
+      ],
+      "metadata": {
+        "id": "m-wmFq8uW1zS"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "kMslWfuwoqpB"
-      },
-      "outputs": [],
       "source": [
         "sample_text, sample_labels = next(iter(validation_data))\n",
         "print(\"Text batch shape: \", sample_text.shape)\n",
         "print(\"Label batch shape: \", sample_labels.shape)\n",
         "print(\"First text example: \", sample_text[0])\n",
         "print(\"First label example: \", sample_labels[0])"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "kMslWfuwoqpB"
+      }
     },
     {
       "cell_type": "markdown",
+      "source": [
+        "Since you use `0` for padding and `1` for out-of-vocabulary (OOV) tokens, the vocabulary size has increased by two."
+      ],
       "metadata": {
         "id": "UI4I6_Sa0vWu"
-      },
-      "source": [
-        "Since we use `0` for padding and `1` for out-of-vocabulary (OOV) tokens, the vocabulary size has increased by two."
-      ]
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "u21LlkO8QGRX"
-      },
-      "outputs": [],
       "source": [
         "vocab_size += 2"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "u21LlkO8QGRX"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "h44Ox11OYLP-"
-      },
       "source": [
         "Configure the datasets for better performance as before."
-      ]
+      ],
+      "metadata": {
+        "id": "h44Ox11OYLP-"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "BpT0b_7mYRXV"
-      },
-      "outputs": [],
       "source": [
         "train_data = configure_dataset(train_data)\n",
         "validation_data = configure_dataset(validation_data)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "BpT0b_7mYRXV"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "K8SUhGFNsmRi"
-      },
       "source": [
         "### Train the model\n",
         "You can train a model on this dataset as before."
-      ]
+      ],
+      "metadata": {
+        "id": "K8SUhGFNsmRi"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "QJgI1pow2YR9"
-      },
-      "outputs": [],
       "source": [
         "model = create_model(vocab_size=vocab_size, num_labels=3)\n",
         "model.compile(\n",
@@ -1328,47 +1325,47 @@
         "    loss=losses.SparseCategoricalCrossentropy(from_logits=True),\n",
         "    metrics=['accuracy'])\n",
         "history = model.fit(train_data, validation_data=validation_data, epochs=3)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "QJgI1pow2YR9"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "KTPCYf_Jh6TH"
-      },
-      "outputs": [],
       "source": [
         "loss, accuracy = model.evaluate(validation_data)\n",
         "\n",
         "print(\"Loss: \", loss)\n",
         "print(\"Accuracy: {:2.2%}\".format(accuracy))"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "KTPCYf_Jh6TH"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "_knIsO-r4pHb"
-      },
       "source": [
         "### Export the model"
-      ]
+      ],
+      "metadata": {
+        "id": "_knIsO-r4pHb"
+      }
     },
     {
       "cell_type": "markdown",
+      "source": [
+        "To make the model capable to taking raw strings as input, you will create a `TextVectorization` layer that performs the same steps as your custom preprocessing function. Since you already trained a vocabulary, you can use `set_vocaublary` instead of `adapt` which trains a new vocabulary."
+      ],
       "metadata": {
         "id": "FEuMLJA_Xiwo"
-      },
-      "source": [
-        "To make our model capable to taking raw strings as input, you will create a `TextVectorization` layer that performs the same steps as our custom preprocessing function. Since you already trained a vocabulary, you can use `set_vocaublary` instead of `adapt` which trains a new vocabulary."
-      ]
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "_ODkRXbk6aHb"
-      },
-      "outputs": [],
       "source": [
         "preprocess_layer = TextVectorization(\n",
         "    max_tokens=vocab_size,\n",
@@ -1377,15 +1374,15 @@
         "    output_mode='int',\n",
         "    output_sequence_length=MAX_SEQUENCE_LENGTH)\n",
         "preprocess_layer.set_vocabulary(vocab)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "_ODkRXbk6aHb"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "G-Cvd27y4qwt"
-      },
-      "outputs": [],
       "source": [
         "export_model = tf.keras.Sequential(\n",
         "    [preprocess_layer, model,\n",
@@ -1395,15 +1392,15 @@
         "    loss=losses.SparseCategoricalCrossentropy(from_logits=False),\n",
         "    optimizer='adam',\n",
         "    metrics=['accuracy'])"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "G-Cvd27y4qwt"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "Pyg0B4zsc-UD"
-      },
-      "outputs": [],
       "source": [
         "# Create a test dataset of raw strings\n",
         "test_ds = all_labeled_data.take(VALIDATION_SIZE).batch(BATCH_SIZE)\n",
@@ -1411,33 +1408,33 @@
         "loss, accuracy = export_model.evaluate(test_ds)\n",
         "print(\"Loss: \", loss)\n",
         "print(\"Accuracy: {:2.2%}\".format(accuracy))"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "Pyg0B4zsc-UD"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "o6Mm0Y9QYQwE"
-      },
       "source": [
         "The loss and accuracy for the model on encoded validation set and the exported model on the raw validation set are the same, as expected."
-      ]
+      ],
+      "metadata": {
+        "id": "o6Mm0Y9QYQwE"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "Stk2BP8GE-qo"
-      },
       "source": [
         "### Run inference on new data"
-      ]
+      ],
+      "metadata": {
+        "id": "Stk2BP8GE-qo"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "-w1fQGJPD2Yh"
-      },
-      "outputs": [],
       "source": [
         "inputs = [\n",
         "    \"Join'd to th' Ionians with their flowing robes,\",  # Label: 1\n",
@@ -1449,33 +1446,33 @@
         "for input, label in zip(inputs, predicted_labels):\n",
         "  print(\"Question: \", input)\n",
         "  print(\"Predicted label: \", label.numpy())"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "-w1fQGJPD2Yh"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "9eA8TVdnA-3L"
-      },
       "source": [
         "## Downloading more datasets using TensorFlow Datasets (TFDS)\n"
-      ]
+      ],
+      "metadata": {
+        "id": "9eA8TVdnA-3L"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "2QFSxfZ3Vqsn"
-      },
       "source": [
         "You can download many more datasets from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/overview). As an example, you will download the [IMDB Large Movie Review dataset](https://www.tensorflow.org/datasets/catalog/imdb_reviews), and use it to train a model for sentiment classification."
-      ]
+      ],
+      "metadata": {
+        "id": "2QFSxfZ3Vqsn"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "NzC65LOaVw0B"
-      },
-      "outputs": [],
       "source": [
         "train_ds = tfds.load(\n",
         "    'imdb_reviews',\n",
@@ -1483,15 +1480,15 @@
         "    batch_size=BATCH_SIZE,\n",
         "    shuffle_files=True,\n",
         "    as_supervised=True)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "NzC65LOaVw0B"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "XKGkgPBkFh0k"
-      },
-      "outputs": [],
       "source": [
         "val_ds = tfds.load(\n",
         "    'imdb_reviews',\n",
@@ -1499,58 +1496,58 @@
         "    batch_size=BATCH_SIZE,\n",
         "    shuffle_files=True,\n",
         "    as_supervised=True)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "XKGkgPBkFh0k"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "BQjf3YZAb5Ne"
-      },
       "source": [
         "Print a few examples."
-      ]
+      ],
+      "metadata": {
+        "id": "BQjf3YZAb5Ne"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "Bq1w8MnfWt2C"
-      },
-      "outputs": [],
       "source": [
         "for review_batch, label_batch in val_ds.take(1):\n",
         "  for i in range(5):\n",
         "    print(\"Review: \", review_batch[i].numpy())\n",
         "    print(\"Label: \", label_batch[i].numpy())"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "Bq1w8MnfWt2C"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "q-lVaukyb75k"
-      },
       "source": [
         "You can now preprocess the data and train a model as before. \n",
         "\n",
         "Note: You will use `losses.BinaryCrossentropy` instead of `losses.SparseCategoricalCrossentropy` for your model since this is a binary classification problem."
-      ]
+      ],
+      "metadata": {
+        "id": "q-lVaukyb75k"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ciz2CxAsZw3Z"
-      },
       "source": [
         "### Prepare the dataset for training"
-      ]
+      ],
+      "metadata": {
+        "id": "ciz2CxAsZw3Z"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "UzT_t9ihZLH4"
-      },
-      "outputs": [],
       "source": [
         "vectorize_layer = TextVectorization(\n",
         "    max_tokens=VOCAB_SIZE,\n",
@@ -1560,122 +1557,122 @@
         "# Make a text-only dataset (without labels), then call adapt\n",
         "train_text = train_ds.map(lambda text, labels: text)\n",
         "vectorize_layer.adapt(train_text)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "UzT_t9ihZLH4"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "zz-Xrd_ZZ4tB"
-      },
-      "outputs": [],
       "source": [
         "def vectorize_text(text, label):\n",
         "  text = tf.expand_dims(text, -1)\n",
         "  return vectorize_layer(text), label"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "zz-Xrd_ZZ4tB"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "ycn0Itd6g5aF"
-      },
-      "outputs": [],
       "source": [
         "train_ds = train_ds.map(vectorize_text)\n",
         "val_ds = val_ds.map(vectorize_text)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "ycn0Itd6g5aF"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "jc11jQTlZ5lj"
-      },
-      "outputs": [],
       "source": [
         "# Configure datasets for performance as before\n",
         "train_ds = configure_dataset(train_ds)\n",
         "val_ds = configure_dataset(val_ds)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "jc11jQTlZ5lj"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "SQzoYkaGZ82Z"
-      },
       "source": [
         "### Train the model"
-      ]
+      ],
+      "metadata": {
+        "id": "SQzoYkaGZ82Z"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "B9IOTLkyZ-a7"
-      },
-      "outputs": [],
       "source": [
         "model = create_model(vocab_size=VOCAB_SIZE + 1, num_labels=1)\n",
         "model.summary()"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "B9IOTLkyZ-a7"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "xLnDs5dhaBAk"
-      },
-      "outputs": [],
       "source": [
         "model.compile(\n",
         "    loss=losses.BinaryCrossentropy(from_logits=True),\n",
         "    optimizer='adam',\n",
         "    metrics=['accuracy'])"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "xLnDs5dhaBAk"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "rq59QpNzaDMa"
-      },
-      "outputs": [],
       "source": [
         "history = model.fit(train_ds, validation_data=val_ds, epochs=3)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "rq59QpNzaDMa"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "gCMWCEtyaEbR"
-      },
-      "outputs": [],
       "source": [
         "loss, accuracy = model.evaluate(val_ds)\n",
         "\n",
         "print(\"Loss: \", loss)\n",
         "print(\"Accuracy: {:2.2%}\".format(accuracy))"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "gCMWCEtyaEbR"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "jGtqLXVnaaFy"
-      },
       "source": [
         "### Export the model"
-      ]
+      ],
+      "metadata": {
+        "id": "jGtqLXVnaaFy"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "yE9WZARZaZr1"
-      },
-      "outputs": [],
       "source": [
         "export_model = tf.keras.Sequential(\n",
         "    [vectorize_layer, model,\n",
@@ -1685,15 +1682,15 @@
         "    loss=losses.SparseCategoricalCrossentropy(from_logits=False),\n",
         "    optimizer='adam',\n",
         "    metrics=['accuracy'])"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "yE9WZARZaZr1"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "bhF8tDH-afoC"
-      },
-      "outputs": [],
       "source": [
         "# 0 --> negative review\n",
         "# 1 --> positive review\n",
@@ -1708,18 +1705,22 @@
         "for input, label in zip(inputs, predicted_labels):\n",
         "  print(\"Question: \", input)\n",
         "  print(\"Predicted label: \", label)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "bhF8tDH-afoC"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "q1KSXDFPWiPN"
-      },
       "source": [
         "## Conclusion\n",
         "\n",
         "This tutorial demonstrated several ways to load and preprocess text. As a next step, you can explore additional tutorials on the website, or download new datasets from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/overview)."
-      ]
+      ],
+      "metadata": {
+        "id": "q1KSXDFPWiPN"
+      }
     }
   ],
   "metadata": {
@@ -1735,5 +1736,5 @@
     }
   },
   "nbformat": 4,
-  "nbformat_minor": 0
+  "nbformat_minor": 2
 }


### PR DESCRIPTION
Changed import statement 
from tensorflow.keras.layers.experimental.preprocessing import TextVectorization
to
from tensorflow.keras.layers import TextVectorization

Removed below note section, since experimental.preprocessing.TextVectorization moved under tensorflow.keras.layers
{
      "cell_type": "markdown",
      "metadata": {
        "id": "HSDO9JZYrK-O"
      },
      "source": [
        "Note: The Preprocessing APIs used in this section are experimental in TensorFlow 2.3 and subject to change."
      ]
    },

and Changed from
preprocessing.TextVectorization
to
TextVectorization