### PR TITLE
Avoid log of zero in plot_spectrogram

### DIFF
--- a/site/en/tutorials/audio/simple_audio.ipynb
+++ b/site/en/tutorials/audio/simple_audio.ipynb
@@ -443,8 +443,8 @@
       "source": [
         "def plot_spectrogram(spectrogram, ax):\n",
         "  # Convert to frequencies to log scale and transpose so that the time is\n",
-        "  # represented in the x-axis (columns).\n",
-        "  log_spec = np.log(spectrogram.T)\n",
+        "  # represented in the x-axis (columns). An epsilon is added to avoid log of zero.\n",
+        "  log_spec = np.log(spectrogram.T+np.finfo(float).eps)\n",
         "  height = log_spec.shape[0]\n",
         "  width = log_spec.shape[1]\n",
         "  X = np.linspace(0, np.size(spectrogram), num=width, dtype=int)\n",


### PR DESCRIPTION
Adding an epsilon to the spectrogram before taking the log to avoid log of zero. Minor change, but it avoids confusion for students learning from the tutorial.