### PR TITLE
Removed api docs advice link

### DIFF
--- a/site/en/community/contribute/docs.md
+++ b/site/en/community/contribute/docs.md
@@ -30,7 +30,8 @@ To participate in the TensorFlow docs community:
 
 ## API reference
 
-To update reference documentation, find the
+For details, use the [TensorFlow API docs contributor guide](docs_ref.md). This
+shows you how to find the
 [source file](https://www.tensorflow.org/code/tensorflow/python/)
 and edit the symbol's
 <a href="https://www.python.org/dev/peps/pep-0257/" class="external">docstring</a>.
@@ -39,6 +40,7 @@ where the symbol is defined. Docstrings support
 <a href="https://help.github.com/en/articles/about-writing-and-formatting-on-github" class="external">Markdown</a>
 and can be (approximately) previewed using any
 <a href="http://tmpvar.com/markdown.html" class="external">Markdown previewer</a>.
+
 
 ### Versions and branches
 

--- a/site/en/community/contribute/docs_ref.md
+++ b/site/en/community/contribute/docs_ref.md
@@ -43,11 +43,12 @@ def concat(values, axis, name="concat"):
   <code here>
 ```
 
-> **Note**: TensorFlow DocTest uses TensorFlow 2 and Python 3.
+Note: TensorFlow DocTest uses TensorFlow 2 and Python 3.
 
-> For reference documentation quality and how to get involved with doc sprints and
-the community, see the
-[TensorFlow 2 API Docs advice](https://docs.google.com/document/d/1e20k9CuaZ_-hp25-sSd8E8qldxKPKQR-SkwojYr_r-U/preview). Note that, this doc will provide you some examples of how to write/edit any API Symbol Docs using a **`Task Tracker Sheet`** which is from a previous community doc sprint project and is no longer in use now but one can refer it for filing any issue or learning about the ways to edit API Symbol Docs.
+To assess reference documentation quality, see the example section of the
+[TensorFlow 2 API Docs advice](https://docs.google.com/document/d/1e20k9CuaZ_-hp25-sSd8E8qldxKPKQR-SkwojYr_r-U/preview).
+(Be aware that the Task Tracker on this sheet is no longer in use.)
+
 
 ### Make the code testable with DocTest
 


### PR DESCRIPTION
Fixes tensorflow/tensorflow#52253

Changes done in the PR :- 
1. Removed the **[API DOCS ADVICE LINK](https://docs.google.com/document/d/1e20k9CuaZ_-hp25-sSd8E8qldxKPKQR-SkwojYr_r-U/preview)** from the [API Reference Site](https://www.tensorflow.org/community/contribute/docs#api_reference) 
2. Added the link to the **note section** of [Contribute to API Documentation site](https://www.tensorflow.org/community/contribute/docs_ref) under section [Testable Docstrings](https://www.tensorflow.org/community/contribute/docs_ref#testable_docstrings)