### PR TITLE
Update docs to reflect new kerastuner rename

### DIFF
--- a/site/en/tutorials/keras/keras_tuner.ipynb
+++ b/site/en/tutorials/keras/keras_tuner.ipynb
@@ -128,7 +128,7 @@
       },
       "outputs": [],
       "source": [
-        "import keras_tuner as kt"
+        "import kerastuner as kt"
       ]
     },
     {


### PR DESCRIPTION
v1.0.3 of kerastuner renamed the import to be `import kerastuner` instead of `import keras_tuner`