### PR TITLE
Typo in tensorflow_docs.plot __init__.py

### DIFF
--- a/site/en/tutorials/generative/pix2pix.ipynb
+++ b/site/en/tutorials/generative/pix2pix.ipynb
@@ -1342,8 +1342,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "pix2pix.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/tools/tensorflow_docs/plots/__init__.py
+++ b/tools/tensorflow_docs/plots/__init__.py
@@ -31,7 +31,8 @@ def _smooth(values, std):
 
   Args:
     values: A 1D array of values to smooth.
-    std: The standard deviation of the Gaussian distribution. The units are array elements.
+    std: The standard deviation of the Gaussian distribution. The units are
+    array elements.
 
   Returns:
     The smoothed array.

--- a/tools/tensorflow_docs/plots/__init__.py
+++ b/tools/tensorflow_docs/plots/__init__.py
@@ -25,13 +25,13 @@ COLOR_CYCLE = prop_cycle.by_key()['color']
 
 
 def _smooth(values, std):
-  """Smooths a list of values by convolving with a gaussian.
+  """Smooths a list of values by convolving with a Gaussian distribution.
 
   Assumes equal spacing.
 
   Args:
     values: A 1D array of values to smooth.
-    std: The standard devistion of the gaussian. The units are array elements.
+    std: The standard deviation of the Gaussian distribution. The units are array elements.
 
   Returns:
     The smoothed array.
@@ -50,7 +50,7 @@ def _smooth(values, std):
 
 
 class HistoryPlotter(object):
-  """A class for plotting named set of keras-histories.
+  """A class for plotting a named set of Keras-histories.
 
   The class maintains colors for each key from plot to plot.
   """
@@ -61,15 +61,15 @@ class HistoryPlotter(object):
     self.smoothing_std = smoothing_std
 
   def plot(self, histories, metric=None, smoothing_std=None):
-    """Plots a {name: history} dictionary of keras histories.
+    """Plots a {name: history} dictionary of Keras histories.
 
     Colors are assigned to the name-key, and maintained from call to call.
     Training metrics are shown as a solid line, validation metrics dashed.
 
     Args:
-      histories: {name: history} dictionary of keras histories.
+      histories: {name: history} a dictionary of Keras histories.
       metric: which metric to plot from all the histories.
-      smoothing_std: the standard-deviaation of the smoothing kernel applied
+      smoothing_std: the standard deviation of the smoothing kernel applied
         before plotting. The units are in array-indices.
     """
     if metric is None:
@@ -78,7 +78,7 @@ class HistoryPlotter(object):
       smoothing_std = self.smoothing_std
 
     for name, history in histories.items():
-      # Remember name->color asociations.
+      # Remember name->color associations.
       if name in self.color_table:
         color = self.color_table[name]
       else:

--- a/tools/tensorflow_docs/plots/__init__.py
+++ b/tools/tensorflow_docs/plots/__init__.py
@@ -25,13 +25,13 @@ COLOR_CYCLE = prop_cycle.by_key()['color']
 
 
 def _smooth(values, std):
-  """Smooths a list of values by convolving with a gussian.
+  """Smooths a list of values by convolving with a gaussian.
 
   Assumes equal spacing.
 
   Args:
     values: A 1D array of values to smooth.
-    std: The standard devistion of the gussian. The units are array elements.
+    std: The standard devistion of the gaussian. The units are array elements.
 
   Returns:
     The smoothed array.


### PR DESCRIPTION
A small typo in docstring of function _smooth in tensorflow_docs.plot __init__.py
Changed gussian to gaussian.