### PR TITLE
Update transfer_learning.ipynb

### DIFF
--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -862,7 +862,7 @@
       "outputs": [],
       "source": [
         "model.compile(loss=tf.keras.losses.BinaryCrossentropy(from_logits=True),\n",
-        "              optimizer = tf.keras.optimizers.RMSprop(lr=base_learning_rate/10),\n",
+        "              optimizer = tf.keras.optimizers.RMSprop(learning_rate=base_learning_rate/10),\n",
         "              metrics=['accuracy'])"
       ]
     },


### PR DESCRIPTION
Changed `lr` to `learning_rate`, which removes a deprecation warning.