### PR TITLE
Remove a hard coded constant for the image classification tutorial.

### DIFF
--- a/site/en/tutorials/images/classification.ipynb
+++ b/site/en/tutorials/images/classification.ipynb
@@ -529,7 +529,7 @@
       },
       "outputs": [],
       "source": [
-        "num_classes = 5\n",
+        "num_classes = len(class_names)\n",
         "\n",
         "model = Sequential([\n",
         "  layers.Rescaling(1./255, input_shape=(img_height, img_width, 3)),\n",


### PR DESCRIPTION
The constant can be inferred from other parts of the code.  Making this change allows for this example to be generalized more easily.