### PR TITLE
Functions reference fixed

### DIFF
--- a/site/en/guide/intro_to_graphs.ipynb
+++ b/site/en/guide/intro_to_graphs.ipynb
@@ -606,7 +606,7 @@
         "id": "PUR7qC_bquCn"
       },
       "source": [
-        "`print` is a *Python side effect*, and there are [other differences](function#limitations) that you should be aware of when converting a function into a `Function`."
+        "`print` is a *Python side effect*, and there are [other differences](https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/guide/function.ipynb#scrollTo=i2MVoIVaNApG) that you should be aware of when converting a function into a `Function`."
       ]
     },
     {

--- a/site/en/guide/intro_to_graphs.ipynb
+++ b/site/en/guide/intro_to_graphs.ipynb
@@ -606,7 +606,7 @@
         "id": "PUR7qC_bquCn"
       },
       "source": [
-        "`print` is a *Python side effect*, and there are [other differences](https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/guide/function.ipynb#scrollTo=i2MVoIVaNApG) that you should be aware of when converting a function into a `Function`."
+        "`print` is a *Python side effect*, and there are [other differences](./function.ipynb#limitations) that you should be aware of when converting a function into a `Function`."
       ]
     },
     {

--- a/site/en/guide/intro_to_graphs.ipynb
+++ b/site/en/guide/intro_to_graphs.ipynb
@@ -606,7 +606,7 @@
         "id": "PUR7qC_bquCn"
       },
       "source": [
-        "`print` is a *Python side effect*, and there are other differences that you should be aware of when converting a function into a `Function`. Learn more in the _Limitations_ section of the [Better performance with tf.function](./function.ipynb) guide."
+        "`print` is a *Python side effect*, and there are other differences that you should be aware of when converting a function into a `Function`. Learn more in the _Limitations_ section of the [Better performance with tf.function](./function.ipynb#limitations) guide."
       ]
     },
     {

--- a/site/en/guide/intro_to_graphs.ipynb
+++ b/site/en/guide/intro_to_graphs.ipynb
@@ -606,7 +606,7 @@
         "id": "PUR7qC_bquCn"
       },
       "source": [
-        "`print` is a *Python side effect*, and there are other differences that you should be aware of when converting a function into a `Function`. Learn more in the _Limitations_ section of the [Better performance with tf.function](function.ipynb) guide."
+        "`print` is a *Python side effect*, and there are other differences that you should be aware of when converting a function into a `Function`. Learn more in the _Limitations_ section of the [Better performance with tf.function](./function.ipynb) guide."
       ]
     },
     {

--- a/site/en/guide/intro_to_graphs.ipynb
+++ b/site/en/guide/intro_to_graphs.ipynb
@@ -606,7 +606,7 @@
         "id": "PUR7qC_bquCn"
       },
       "source": [
-        "`print` is a *Python side effect*, and there are [other differences](./function.ipynb#limitations) that you should be aware of when converting a function into a `Function`."
+        "`print` is a *Python side effect*, and there are other differences that you should be aware of when converting a function into a `Function`. Learn more in the _Limitations_ section of the [Better performance with tf.function](function.ipynb) guide."
       ]
     },
     {


### PR DESCRIPTION
The reference to functions was broken. I changed the link to [this one](https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/guide/function.ipynb#scrollTo=i2MVoIVaNApG)