### PR TITLE
Update transfer_learning.ipynb

### DIFF
--- a/site/en/r1/tutorials/images/transfer_learning.ipynb
+++ b/site/en/r1/tutorials/images/transfer_learning.ipynb
@@ -364,7 +364,7 @@
       },
       "outputs": [],
       "source": [
-        "model.compile(optimizer=tf.keras.optimizers.RMSprop(lr=0.0001),\n",
+        "model.compile(optimizer=tf.keras.optimizers.RMSprop(learning_rate=0.0001),\n",
         "              loss='binary_crossentropy',\n",
         "              metrics=['accuracy'])"
       ]
@@ -569,7 +569,7 @@
       },
       "outputs": [],
       "source": [
-        "model.compile(optimizer = tf.keras.optimizers.RMSprop(lr=2e-5),\n",
+        "model.compile(optimizer = tf.keras.optimizers.RMSprop(learning_rate=2e-5),\n",
         "              loss='binary_crossentropy',\n",
         "              metrics=['accuracy'])"
       ]


### PR DESCRIPTION
Changed `lr` to `learning_rate`, which removes a deprecation warning.