### PR TITLE
Docs: fix typo in transfer learning tutorial

### DIFF
--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -427,7 +427,7 @@
         "## Create the base model from the pre-trained convnets\n",
         "You will create the base model from the **MobileNet V2** model developed at Google. This is pre-trained on the ImageNet dataset, a large dataset consisting of 1.4M images and 1000 classes. ImageNet is a research training dataset with a wide variety of categories like `jackfruit` and `syringe`. This base of knowledge will help us classify cats and dogs from our specific dataset.\n",
         "\n",
-        "First, you need to pick which layer of MobileNet V2 you will use for feature extraction. The very last classification layer (on \"top\", as most diagrams of machine learning models go from bottom to top) is not very useful.  Instead, you will follow the common practice to depend on the very last layer before the flatten operation. This layer is called the \"bottleneck layer\". The bottleneck layer features retain more generality as compared to the final/top layer.\n",
+        "First, you need to pick which layer of MobileNet V2 you will use for feature extraction. The very last classification layer (on \"top\", as most diagrams of machine learning models go from bottom to top) is not very useful. Instead, you will follow the common practice to depend on the very last layer before the flatten operation. This layer is called the \"bottleneck layer\". The bottleneck layer features retain more generality as compared to the final/top layer.\n",
         "\n",
         "First, instantiate a MobileNet V2 model pre-loaded with weights trained on ImageNet. By specifying the **include_top=False** argument, you load a network that doesn't include the classification layers at the top, which is ideal for feature extraction."
       ]
@@ -574,7 +574,7 @@
         "id": "O1p0OJBR6dOT"
       },
       "source": [
-        "Apply a `tf.keras.layers.Dense` layer to convert these features into a single prediction per image. You don't need an activation function here because this prediction will be treated as a `logit`, or a raw prediction value.  Positive numbers predict class 1, negative numbers predict class 0."
+        "Apply a `tf.keras.layers.Dense` layer to convert these features into a single prediction per image. You don't need an activation function here because this prediction will be treated as a `logit`, or a raw prediction value. Positive numbers predict class 1, negative numbers predict class 0."
       ]
     },
     {
@@ -596,7 +596,7 @@
         "id": "HXvz-ZkTa9b3"
       },
       "source": [
-        "Build a model by chaining together the data augmentation, rescaling, base_model and feature extractor layers using the [Keras Functional API](https://www.tensorflow.org/guide/keras/functional). As previously mentioned, use `training=False` as our model contains a `BatchNormalization` layer."
+        "Build a model by chaining together the data augmentation, rescaling, `base_model` and feature extractor layers using the [Keras Functional API](https://www.tensorflow.org/guide/keras/functional). As previously mentioned, use `training=False` as our model contains a `BatchNormalization` layer."
       ]
     },
     {
@@ -659,7 +659,7 @@
         "id": "lxOcmVr0ydFZ"
       },
       "source": [
-        "The 2.5M parameters in MobileNet are frozen, but there are 1.2K _trainable_ parameters in the Dense layer.  These are divided between two `tf.Variable` objects, the weights and biases."
+        "The 2.5 million parameters in MobileNet are frozen, but there are 1.2 thousand _trainable_ parameters in the Dense layer. These are divided between two `tf.Variable` objects, the weights and biases."
       ]
     },
     {
@@ -730,7 +730,7 @@
       "source": [
         "### Learning curves\n",
         "\n",
-        "Let's take a look at the learning curves of the training and validation accuracy/loss when using the MobileNet V2 base model as a fixed feature extractor."
+        "Let's take a look at the learning curves of the training and validation accuracy/loss when using the MobileNetV2 base model as a fixed feature extractor."
       ]
     },
     {
@@ -785,7 +785,7 @@
       },
       "source": [
         "## Fine tuning\n",
-        "In the feature extraction experiment, you were only training a few layers on top of an MobileNet V2 base model. The weights of the pre-trained network were **not** updated during training.\n",
+        "In the feature extraction experiment, you were only training a few layers on top of an MobileNetV2 base model. The weights of the pre-trained network were **not** updated during training.\n",
         "\n",
         "One way to increase performance even further is to train (or \"fine-tune\") the weights of the top layers of the pre-trained model alongside the training of the classifier you added. The training process will force the weights to be tuned from generic feature maps to features associated specifically with the dataset.\n",
         "\n",
@@ -929,9 +929,9 @@
         "id": "TfXEmsxQf6eP"
       },
       "source": [
-        "Let's take a look at the learning curves of the training and validation accuracy/loss when fine-tuning the last few layers of the MobileNet V2 base model and training the classifier on top of it. The validation loss is much higher than the training loss, so you may get some overfitting.\n",
+        "Let's take a look at the learning curves of the training and validation accuracy/loss when fine-tuning the last few layers of the MobileNetV2 base model and training the classifier on top of it. The validation loss is much higher than the training loss, so you may get some overfitting.\n",
         "\n",
-        "You may also get some overfitting as the new training set is relatively small and similar to the original MobileNet V2 datasets.\n"
+        "You may also get some overfitting as the new training set is relatively small and similar to the original MobileNetV2 datasets.\n"
       ]
     },
     {

--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -337,7 +337,7 @@
         "id": "s9SlcbhrarOO"
       },
       "source": [
-        "Note: These layers are active only during training, when you call `model.fit`. They are inactive when the model is used in inference mode in `model.evaulate` or `model.fit`."
+        "Note: These layers are active only during training, when you call `model.fit`. They are inactive when the model is used in inference mode in `model.evaluate` or `model.fit`."
       ]
     },
     {

--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -337,7 +337,7 @@
         "id": "s9SlcbhrarOO"
       },
       "source": [
-        "Note: These layers are active only during training, when you call `model.fit`. They are inactive when the model is used in inference mode in `model.evaluate` or `model.fit`."
+        "Note: These layers are active only during training, when you call `Model.fit`. They are inactive when the model is used in inference mode in `Model.evaluate` or `Model.fit`."
       ]
     },
     {


### PR DESCRIPTION
Fix type "evaulate" to "evaluate"