### PR TITLE
Fix invalid Unicode sequence in bib file

### DIFF
--- a/site/en/about/bib.md
+++ b/site/en/about/bib.md
@@ -43,7 +43,7 @@ title={ {TensorFlow}: Large-Scale Machine Learning on Heterogeneous Systems},
 url={https://www.tensorflow.org/},
 note={Software available from tensorflow.org},
 author={
-    Mart\'{\i}n~Abadi and
+    Mart\'{i}n~Abadi and
     Ashish~Agarwal and
     Paul~Barham and
     Eugene~Brevdo and


### PR DESCRIPTION
There is an extra backslash `\` character near an accented i in the bib
file that causes an invalid unicode character error when citing the 2015
tensorflow white paper in LaTeX