### PR TITLE
Update custom_training_walkthrough.ipynb

### DIFF
--- a/site/en/tutorials/customization/custom_training_walkthrough.ipynb
+++ b/site/en/tutorials/customization/custom_training_walkthrough.ipynb
@@ -464,7 +464,7 @@
         "id": "uRZmchElo481"
       },
       "source": [
-        "Taking the `tf.argmax` across classes gives us the predicted class index. But, the model hasn't been trained yet, so these aren't good predictions:"
+        "Taking the `tf.math.argmax` across classes gives us the predicted class index. But, the model hasn't been trained yet, so these aren't good predictions:"
       ]
     },
     {


### PR DESCRIPTION
Changed the naming from 'tf.argmax' to  'tf.math.argmax' in the documentation.