### PR TITLE
fixed function def report in Basic training loops

### DIFF
--- a/site/en/guide/basic_training_loops.ipynb
+++ b/site/en/guide/basic_training_loops.ipynb
@@ -355,7 +355,7 @@
         "\n",
         "# Define a training loop\n",
         "def report(model, loss):\n",
-        "  return f\"W = {model.w.numpy():1.2f}, b = {model.b.numpy():1.2f}, loss={current_loss:2.5f}\"\n",
+        "  return f\"W = {model.w.numpy():1.2f}, b = {model.b.numpy():1.2f}, loss={loss:2.5f}\"\n",
         "\n",
         "\n",
         "def training_loop(model, x, y):\n",


### PR DESCRIPTION
The function `def report` used the global variable `current_loss` instead of the functions parameter `loss`. This issue resulted in a wrong status printing:

![image](https://user-images.githubusercontent.com/64093357/155559040-318b3320-1588-48d6-b674-560eea3ad652.png)
