### PR TITLE
Update outdated link to Git development workflow

### DIFF
--- a/site/en/community/contribute/code.md
+++ b/site/en/community/contribute/code.md
@@ -162,7 +162,7 @@ up to date.
 Additional `git` and GitHub resources:
 
 *   [Git documentation](https://git-scm.com/documentation)
-*   [Git development workflow](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html)
+*   [Git development workflow](https://docs.scipy.org/doc/numpy/dev/development_workflow.html)
 *   [Resolving merge conflicts](https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/).
 
 


### PR DESCRIPTION
**Motivation**: Went going to https://www.tensorflow.org/community/contribute/code, a link is outdated/broken. 

**Solution:** Replace with an existing link with the same contents. 

Note: when searching for "https://docs.scipy.org/doc/numpy/" inside of this repo, there are other links which are similar