### PR TITLE
Updating the x_test to x_test_noisy

### DIFF
--- a/site/en/tutorials/generative/autoencoder.ipynb
+++ b/site/en/tutorials/generative/autoencoder.ipynb
@@ -492,7 +492,7 @@
       },
       "outputs": [],
       "source": [
-        "encoded_imgs = autoencoder.encoder(x_test).numpy()\n",
+        "encoded_imgs = autoencoder.encoder(x_test_noisy).numpy()\n",
         "decoded_imgs = autoencoder.decoder(encoded_imgs).numpy()"
       ]
     },


### PR DESCRIPTION
Please update the **`encoded_imgs = autoencoder.encoder(x_test).numpy()`** to **`encoded_imgs = autoencoder.encoder(x_test_noisy).numpy()`**
Fixes [#55487](https://github.com/tensorflow/tensorflow/issues/55487)