### PR TITLE
Updated links with correct URL path

### DIFF
--- a/site/en/tutorials/keras/save_and_load.ipynb
+++ b/site/en/tutorials/keras/save_and_load.ipynb
@@ -485,7 +485,7 @@
         "id": "JtdYhvWnH2ib"
       },
       "source": [
-        "The above code stores the weights to a collection of [checkpoint](https://www.tensorflow.org/guide/checkpoint)-formatted files that contain only the trained weights in a binary format. Checkpoints contain:\n",
+        "The above code stores the weights to a collection of [checkpoint](../../guide/checkpoint.ipynb)-formatted files that contain only the trained weights in a binary format. Checkpoints contain:\n",
         "* One or more shards that contain your model's weights.\n",
         "* An index file that indicates which weights are stored in which shard.\n",
         "\n",
@@ -500,7 +500,7 @@
       "source": [
         "## Manually save weights\n",
         "\n",
-        "Manually saving weights with the `Model.save_weights` method. By default, `tf.keras`—and `save_weights` in particular—uses the TensorFlow [checkpoint](../../guide/checkpoint.ipynb) format with a `.ckpt` extension (saving in [HDF5](https://www.tensorflow.org/guide/keras/save_and_serialize#hdf5_format) with a `.h5` extension is covered in the [Save and serialize models](https://www.tensorflow.org/guide/keras/save_and_serialize#weights-only_saving_in_savedmodel_format) guide):"
+        "To save weights manually, use `tf.keras.Model.save_weights`. By default, `tf.keras`—and the `Model.save_weights` method in particular—uses the TensorFlow [Checkpoint](../../guide/checkpoint.ipynb) format with a `.ckpt` extension. To save in the HDF5 format with a `.h5` extension, refer to the [Save and load models](https://www.tensorflow.org/guide/keras/save_and_serialize) guide."
       ]
     },
     {

--- a/site/en/tutorials/keras/save_and_load.ipynb
+++ b/site/en/tutorials/keras/save_and_load.ipynb
@@ -485,7 +485,7 @@
         "id": "JtdYhvWnH2ib"
       },
       "source": [
-        "The above code stores the weights to a collection of [checkpoint](https://www.tensorflow.org/guide/saved_model#save_and_restore_variables)-formatted files that contain only the trained weights in a binary format. Checkpoints contain:\n",
+        "The above code stores the weights to a collection of [checkpoint](https://www.tensorflow.org/guide/checkpoint)-formatted files that contain only the trained weights in a binary format. Checkpoints contain:\n",
         "* One or more shards that contain your model's weights.\n",
         "* An index file that indicates which weights are stored in which shard.\n",
         "\n",
@@ -500,7 +500,7 @@
       "source": [
         "## Manually save weights\n",
         "\n",
-        "Manually saving weights with the `Model.save_weights` method. By default, `tf.keras`—and `save_weights` in particular—uses the TensorFlow [checkpoint](../../guide/checkpoint.ipynb) format with a `.ckpt` extension (saving in [HDF5](https://js.tensorflow.org/tutorials/import-keras.html) with a `.h5` extension is covered in the [Save and serialize models](https://www.tensorflow.org/guide/keras/save_and_serialize#weights-only_saving_in_savedmodel_format) guide):"
+        "Manually saving weights with the `Model.save_weights` method. By default, `tf.keras`—and `save_weights` in particular—uses the TensorFlow [checkpoint](../../guide/checkpoint.ipynb) format with a `.ckpt` extension (saving in [HDF5](https://www.tensorflow.org/guide/keras/save_and_serialize#hdf5_format) with a `.h5` extension is covered in the [Save and serialize models](https://www.tensorflow.org/guide/keras/save_and_serialize#weights-only_saving_in_savedmodel_format) guide):"
       ]
     },
     {


### PR DESCRIPTION
Updated links with the correct URL path for the `checkpoint` link in the "What are these files section?" and also for `HDF5` in the "Manually saved weights section.
Earlier, the `checkpoint` link was showing the Saved model link and `HDF5` file was showing the tensorflow.js conversion model.