### PR TITLE
Fix the Bazel version error in tested_build_configuration

### DIFF
--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -419,7 +419,7 @@ Success: TensorFlow is now installed.
 
 <table>
 <tr><th>Version</th><th>Python version</th><th>Compiler</th><th>Build tools</th></tr>
-<tr><td>tensorflow-2.8.0</td><td>3.7-3.10</td><td>GCC 7.3.1</td><td>Bazel 4.2.1</td></tr>
+<tr><td>tensorflow-2.8.0</td><td>3.7-3.10</td><td>GCC 7.3.1</td><td>Bazel 4.2.2</td></tr>
 <tr><td>tensorflow-2.7.0</td><td>3.7-3.9</td><td>GCC 7.3.1</td><td>Bazel 3.7.2</td></tr>
 <tr><td>tensorflow-2.6.0</td><td>3.6-3.9</td><td>GCC 7.3.1</td><td>Bazel 3.7.2</td></tr>
 <tr><td>tensorflow-2.5.0</td><td>3.6-3.9</td><td>GCC 7.3.1</td><td>Bazel 3.7.2</td></tr>


### PR DESCRIPTION
Tensorflow version 2.8.0 build requires:

> The project you're trying to build requires Bazel 4.2.2


Specified version on [`tensorflow/configure.py`](https://github.com/tensorflow/tensorflow/blob/master/configure.py#L48) is `_TF_MIN_BAZEL_VERSION = '4.2.2'`