### PR TITLE
Updated tf.keras.models.Sequential name with tf.keras.Sequential

### DIFF
--- a/site/en/tutorials/keras/save_and_load.ipynb
+++ b/site/en/tutorials/keras/save_and_load.ipynb
@@ -217,7 +217,7 @@
       "source": [
         "# Define a simple sequential model\n",
         "def create_model():\n",
-        "  model = tf.keras.models.Sequential([\n",
+        "  model = tf.keras.Sequential([\n",
         "    keras.layers.Dense(512, activation='relu', input_shape=(784,)),\n",
         "    keras.layers.Dropout(0.2),\n",
         "    keras.layers.Dense(10)\n",


### PR DESCRIPTION
As now the Sequential API is directly inherited from Keras, So I have modified the "tf.keras.models.Sequential" API name with the new updated name as "tf.keras.Sequential" and ran the entire code successfully after modification.