### PR TITLE
Updated build command for saved_model_cli

### DIFF
--- a/site/en/guide/saved_model.ipynb
+++ b/site/en/guide/saved_model.ipynb
@@ -77,8 +77,7 @@
         "- High-level `tf.keras.Model` API. Refer to [the keras save and serialize guide](https://www.tensorflow.org/guide/keras/save_and_serialize).\n",
         "- If you just want to save/load weights during training, refer to [the checkpoints guide](./checkpoint.ipynb).\n",
         "\n",
-        "Caution: TensorFlow models are code and it is important to be careful with untrusted code. Learn more in [Using TensorFlow securely](https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md).\n",
-        "\n"
+        "Caution: TensorFlow models are code and it is important to be careful with untrusted code. Learn more in [Using TensorFlow securely](https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md).\n"
       ]
     },
     {

--- a/site/en/guide/saved_model.ipynb
+++ b/site/en/guide/saved_model.ipynb
@@ -761,7 +761,7 @@
         "additional command to build `saved_model_cli`:\n",
         "\n",
         "```\n",
-        "$ bazel build tensorflow/python/tools:saved_model_cli\n",
+        "$ bazel build //tensorflow/python/tools:saved_model_cli\n",
         "```\n",
         "\n",
         "### Overview of commands\n",


### PR DESCRIPTION
Below command for building saved_model_cli is not working  and throwing "Build file not found " error
`bazel build tensorflow/python/tools:saved_model_cli`
replaced with 
`bazel build //tensorflow/python/tools:saved_model_cli`  to make it working.  Attaching [Gist ](https://colab.sandbox.google.com/gist/mohantym/5f2785f4c21c6b1e3fe9c5958a62418d/tensorflow-ranking.ipynb#scrollTo=Gr24fRLOQVRZ)for reference. 

