### PR TITLE
`tf.SparseTensor` to `tf.sparse.SparseTensor` in sparse_tensor guide

### DIFF
--- a/site/en/guide/sparse_tensor.ipynb
+++ b/site/en/guide/sparse_tensor.ipynb
@@ -79,7 +79,7 @@
       "source": [
         "## Sparse tensors in TensorFlow\n",
         "\n",
-        "TensorFlow represents sparse tensors through the `tf.SparseTensor` object. Currently, sparse tensors in TensorFlow are encoded using the coordinate list (COO) format. This encoding format is optimized for hyper-sparse matrices such as embeddings.\n",
+        "TensorFlow represents sparse tensors through the `tf.sparse.SparseTensor` object. Currently, sparse tensors in TensorFlow are encoded using the coordinate list (COO) format. This encoding format is optimized for hyper-sparse matrices such as embeddings.\n",
         "\n",
         "The COO encoding for sparse tensors is comprised of:\n",
         "\n",
@@ -87,9 +87,9 @@
         "  * `indices`: A 2D tensor with shape `[N, rank]`, containing the indices of the nonzero values.\n",
         "  * `dense_shape`: A 1D tensor with shape `[rank]`, specifying the shape of the tensor.\n",
         "\n",
-        "A ***nonzero*** value in the context of a `tf.SparseTensor` is a value that's not explicitly encoded. It is possible to explicitly include zero values in the `values` of a COO sparse matrix, but these \"explicit zeros\" are generally not included when referring to nonzero values in a sparse tensor.\n",
+        "A ***nonzero*** value in the context of a `tf.sparse.SparseTensor` is a value that's not explicitly encoded. It is possible to explicitly include zero values in the `values` of a COO sparse matrix, but these \"explicit zeros\" are generally not included when referring to nonzero values in a sparse tensor.\n",
         "\n",
-        "Note: `tf.SparseTensor` does not require that indices/values be in any particular order, but several ops assume that they're in row-major order. Use `tf.sparse.reorder` to create a copy of the sparse tensor that is sorted in the canonical row-major order. "
+        "Note: `tf.sparse.SparseTensor` does not require that indices/values be in any particular order, but several ops assume that they're in row-major order. Use `tf.sparse.reorder` to create a copy of the sparse tensor that is sorted in the canonical row-major order. "
       ]
     },
     {
@@ -98,7 +98,7 @@
         "id": "6Aq7ruwlyz79"
       },
       "source": [
-        "## Creating a `tf.SparseTensor`\n",
+        "## Creating a `tf.sparse.SparseTensor`\n",
         "\n",
         "Construct sparse tensors by directly specifying their `values`, `indices`, and `dense_shape`."
       ]
@@ -122,7 +122,7 @@
       },
       "outputs": [],
       "source": [
-        "st1 = tf.SparseTensor(indices=[[0, 3], [2, 4]],\n",
+        "st1 = tf.sparse.SparseTensor(indices=[[0, 3], [2, 4]],\n",
         "                      values=[10, 20],\n",
         "                      dense_shape=[3, 10])"
       ]
@@ -252,11 +252,11 @@
       },
       "outputs": [],
       "source": [
-        "st_a = tf.SparseTensor(indices=[[0, 2], [3, 4]],\n",
+        "st_a = tf.sparse.SparseTensor(indices=[[0, 2], [3, 4]],\n",
         "                       values=[31, 2], \n",
         "                       dense_shape=[4, 10])\n",
         "\n",
-        "st_b = tf.SparseTensor(indices=[[0, 2], [7, 0]],\n",
+        "st_b = tf.sparse.SparseTensor(indices=[[0, 2], [7, 0]],\n",
         "                       values=[56, 38],\n",
         "                       dense_shape=[4, 10])\n",
         "\n",
@@ -282,7 +282,7 @@
       },
       "outputs": [],
       "source": [
-        "st_c = tf.SparseTensor(indices=([0, 1], [1, 0], [1, 1]),\n",
+        "st_c = tf.sparse.SparseTensor(indices=([0, 1], [1, 0], [1, 1]),\n",
         "                       values=[13, 15, 17],\n",
         "                       dense_shape=(2,2))\n",
         "\n",
@@ -309,14 +309,14 @@
       },
       "outputs": [],
       "source": [
-        "sparse_pattern_A = tf.SparseTensor(indices = [[2,4], [3,3], [3,4], [4,3], [4,4], [5,4]],\n",
+        "sparse_pattern_A = tf.sparse.SparseTensor(indices = [[2,4], [3,3], [3,4], [4,3], [4,4], [5,4]],\n",
         "                         values = [1,1,1,1,1,1],\n",
         "                         dense_shape = [8,5])\n",
-        "sparse_pattern_B = tf.SparseTensor(indices = [[0,2], [1,1], [1,3], [2,0], [2,4], [2,5], [3,5], \n",
+        "sparse_pattern_B = tf.sparse.SparseTensor(indices = [[0,2], [1,1], [1,3], [2,0], [2,4], [2,5], [3,5], \n",
         "                                              [4,5], [5,0], [5,4], [5,5], [6,1], [6,3], [7,2]],\n",
         "                         values = [1,1,1,1,1,1,1,1,1,1,1,1,1,1],\n",
         "                         dense_shape = [8,6])\n",
-        "sparse_pattern_C = tf.SparseTensor(indices = [[3,0], [4,0]],\n",
+        "sparse_pattern_C = tf.sparse.SparseTensor(indices = [[3,0], [4,0]],\n",
         "                         values = [1,1],\n",
         "                         dense_shape = [8,6])\n",
         "\n",
@@ -381,7 +381,7 @@
       },
       "outputs": [],
       "source": [
-        "st2_plus_5 = tf.SparseTensor(\n",
+        "st2_plus_5 = tf.sparse.SparseTensor(\n",
         "    st2.indices,\n",
         "    st2.values + 5,\n",
         "    st2.dense_shape)\n",
@@ -394,7 +394,7 @@
         "id": "GFhO2ZZ53ga1"
       },
       "source": [
-        "## Using `tf.SparseTensor` with other TensorFlow APIs\n",
+        "## Using `tf.sparse.SparseTensor` with other TensorFlow APIs\n",
         "\n",
         "Sparse tensors work transparently with these TensorFlow APIs:\n",
         "\n",
@@ -449,7 +449,7 @@
         "y = tf.keras.layers.Dense(4)(x)\n",
         "model = tf.keras.Model(x, y)\n",
         "\n",
-        "sparse_data = tf.SparseTensor(\n",
+        "sparse_data = tf.sparse.SparseTensor(\n",
         "    indices = [(0,0),(0,1),(0,2),\n",
         "               (4,3),(5,0),(5,1)],\n",
         "    values = [1,1,1,1,1,1],\n",
@@ -569,9 +569,9 @@
         "\n",
         "`tf.train.Example` is a standard protobuf encoding for TensorFlow data. When using sparse tensors with `tf.train.Example`, you can:\n",
         "\n",
-        "* Read variable-length data into a `tf.SparseTensor` using `tf.io.VarLenFeature`. However, you should consider using `tf.io.RaggedFeature` instead.\n",
+        "* Read variable-length data into a `tf.sparse.SparseTensor` using `tf.io.VarLenFeature`. However, you should consider using `tf.io.RaggedFeature` instead.\n",
         "\n",
-        "* Read arbitrary sparse data into a `tf.SparseTensor` using `tf.io.SparseFeature`, which uses three separate feature keys to store the `indices`, `values`, and `dense_shape`."
+        "* Read arbitrary sparse data into a `tf.sparse.SparseTensor` using `tf.io.SparseFeature`, which uses three separate feature keys to store the `indices`, `values`, and `dense_shape`."
       ]
     },
     {
@@ -597,7 +597,7 @@
         "def f(x,y):\n",
         "  return tf.sparse.sparse_dense_matmul(x,y)\n",
         "\n",
-        "a = tf.SparseTensor(indices=[[0, 3], [2, 4]],\n",
+        "a = tf.sparse.SparseTensor(indices=[[0, 3], [2, 4]],\n",
         "                    values=[15, 25],\n",
         "                    dense_shape=[3, 10])\n",
         "\n",
@@ -616,11 +616,11 @@
       "source": [
         "## Distinguishing missing values from zero values\n",
         "\n",
-        "Most ops on `tf.SparseTensor`s treat missing values and explicit zero values identically. This is by design — a `tf.SparseTensor` is supposed to act just like a dense tensor.\n",
+        "Most ops on `tf.sparse.SparseTensor`s treat missing values and explicit zero values identically. This is by design — a `tf.sparse.SparseTensor` is supposed to act just like a dense tensor.\n",
         "\n",
         "However, there are a few cases where it can be useful to distinguish zero values from missing values. In particular, this allows for one way to encode missing/unknown data in your training data. For example, consider a use case where you have a tensor of scores (that can have any floating point value from -Inf to +Inf), with some missing scores. You can encode this tensor using a sparse tensor where the explicit zeros are known zero scores but the implicit zero values actually represent missing data and not zero. \n",
         "\n",
-        "Note: This is generally not the intended usage of `tf.SparseTensor`s; and you might want to also consier other techniques for encoding this such as for example using a separate mask tensor that identifies the locations of known/unknown values. However, exercise caution while using this approach, since most sparse operations will treat explicit and implicit zero values identically."
+        "Note: This is generally not the intended usage of `tf.sparse.SparseTensor`s; and you might want to also consier other techniques for encoding this such as for example using a separate mask tensor that identifies the locations of known/unknown values. However, exercise caution while using this approach, since most sparse operations will treat explicit and implicit zero values identically."
       ]
     },
     {

--- a/site/en/guide/sparse_tensor.ipynb
+++ b/site/en/guide/sparse_tensor.ipynb
@@ -680,8 +680,7 @@
   "metadata": {
     "colab": {
       "collapsed_sections": [],
-      "name": "sparse_tensor_guide.ipynb",
-      "provenance": [],
+      "name": "sparse_tensor.ipynb",
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
`tf.SparseTensor` is currently an alias for `tf.sparse.SparseTensor`. Hence replaced with the more consistent alias.