### PR TITLE
Provided direct URL path for HyperModel sub classes

### DIFF
--- a/site/en/tutorials/keras/keras_tuner.ipynb
+++ b/site/en/tutorials/keras/keras_tuner.ipynb
@@ -190,7 +190,7 @@
         "* By using a model builder function\n",
         "* By subclassing the `HyperModel` class of the Keras Tuner API\n",
         "\n",
-        "You can also use two pre-defined `HyperModel` classes - [HyperXception](https://keras-team.github.io/keras-tuner/documentation/hypermodels/#hyperxception-class) and [HyperResNet](https://keras-team.github.io/keras-tuner/documentation/hypermodels/#hyperresnet-class) for computer vision applications.\n",
+        "You can also use two pre-defined [HyperModel](https://keras.io/api/keras_tuner/hypermodels/) classes - [HyperXception](https://keras.io/api/keras_tuner/hypermodels/hyper_xception/) and [HyperResNet](https://keras.io/api/keras_tuner/hypermodels/hyper_resnet/) for computer vision applications.\n",
         "\n",
         "In this tutorial, you use a model builder function to define the image classification model. The model builder function returns a compiled model and uses hyperparameters you define inline to hypertune the model."
       ]


### PR DESCRIPTION
Modified the path URLs by providing the exact direct path for `Hypermodels classes` - HyperXception and HyperResNet.