### PR TITLE
Fixed some typo errors along with one link update

### DIFF
--- a/site/en/tutorials/customization/basics.ipynb
+++ b/site/en/tutorials/customization/basics.ipynb
@@ -298,7 +298,7 @@
       "source": [
         "## Datasets\n",
         "\n",
-       "This section uses the `tf.data.Dataset` API to build a pipeline for feeding data to your model. `tf.data.Dataset` is used to build performant, complex input pipelines from simple, re-usable pieces that will feed your model's training or evaluation loops. (Refer to the [tf.data: Build TensorFlow input pipelines](../../guide/data.ipynb) guide to learn more.)"
+        "This section uses the `tf.data.Dataset` API to build a pipeline for feeding data to your model. `tf.data.Dataset` is used to build performant, complex input pipelines from simple, re-usable pieces that will feed your model's training or evaluation loops. (Refer to the [tf.data: Build TensorFlow input pipelines](../../guide/data.ipynb) guide to learn more.)"
       ]
     },
     {

--- a/site/en/tutorials/customization/basics.ipynb
+++ b/site/en/tutorials/customization/basics.ipynb
@@ -298,7 +298,7 @@
       "source": [
         "## Datasets\n",
         "\n",
-        "This section uses the [`tf.data.Dataset` API](https://www.tensorflow.org/api_docs/python/tf/data/Dataset) to build a pipeline for feeding data to your model. `tf.data.Dataset` is used to build performant, complex input pipelines from simple, re-usable pieces that will feed your model's training or evaluation loops."
+       "This section uses the `tf.data.Dataset` API to build a pipeline for feeding data to your model. `tf.data.Dataset` is used to build performant, complex input pipelines from simple, re-usable pieces that will feed your model's training or evaluation loops. (Refer to the [tf.data: Build TensorFlow input pipelines](../../guide/data.ipynb) guide to learn more.)"
       ]
     },
     {

--- a/site/en/tutorials/customization/basics.ipynb
+++ b/site/en/tutorials/customization/basics.ipynb
@@ -106,7 +106,7 @@
       "source": [
         "## Tensors\n",
         "\n",
-        "A Tensor is a multi-dimensional array. Similar to NumPy `ndarray` objects, `tf.Tensor` objects have a data type and a shape. Additionally, `tf.Tensor`s can reside in accelerator memory (like a GPU). TensorFlow offers a rich library of operations (for example, `tf.math.add`, `tf.linalg.matmul`, and `tf.linalg.inv`) that consume and produce `tf.Tensor`s. These operations automatically convert built-in Python types. For example:\n"
+        "A Tensor is a multi-dimensional array. Similar to NumPy `ndarray` objects, `tf.Tensor` objects have a data type and a shape. Additionally, `tf.Tensor` can reside in accelerator memory (like a GPU). TensorFlow offers a rich library of operations (for example, `tf.math.add`, `tf.linalg.matmul`, and `tf.linalg.inv`) that consume and produce `tf.Tensor`. These operations automatically convert built-in Python types. For example:\n"
       ]
     },
     {
@@ -156,7 +156,7 @@
         "id": "eBPw8e8vrsom"
       },
       "source": [
-        "The most obvious differences between NumPy arrays and `tf.Tensor`s are:\n",
+        "The most obvious differences between NumPy arrays and `tf.Tensor` are:\n",
         "\n",
         "1. Tensors can be backed by accelerator memory (like GPU, TPU).\n",
         "2. Tensors are immutable."
@@ -170,7 +170,7 @@
       "source": [
         "### NumPy compatibility\n",
         "\n",
-        "Converting between a TensorFlow `tf.Tensor`s and a NumPy `ndarray` is easy:\n",
+        "Converting between a TensorFlow `tf.Tensor` and a NumPy `ndarray` is easy:\n",
         "\n",
         "* TensorFlow operations automatically convert NumPy ndarrays to Tensors.\n",
         "* NumPy operations automatically convert Tensors to NumPy ndarrays.\n",
@@ -298,7 +298,7 @@
       "source": [
         "## Datasets\n",
         "\n",
-        "This section uses the [`tf.data.Dataset` API](../../guide/data.ipynb) to build a pipeline for feeding data to your model. `tf.data.Dataset` is used to build performant, complex input pipelines from simple, re-usable pieces that will feed your model's training or evaluation loops."
+        "This section uses the [`tf.data.Dataset` API](https://www.tensorflow.org/api_docs/python/tf/data/Dataset) to build a pipeline for feeding data to your model. `tf.data.Dataset` is used to build performant, complex input pipelines from simple, re-usable pieces that will feed your model's training or evaluation loops."
       ]
     },
     {

--- a/site/en/tutorials/customization/basics.ipynb
+++ b/site/en/tutorials/customization/basics.ipynb
@@ -106,7 +106,7 @@
       "source": [
         "## Tensors\n",
         "\n",
-        "A Tensor is a multi-dimensional array. Similar to NumPy `ndarray` objects, `tf.Tensor` objects have a data type and a shape. Additionally, `tf.Tensor` can reside in accelerator memory (like a GPU). TensorFlow offers a rich library of operations (for example, `tf.math.add`, `tf.linalg.matmul`, and `tf.linalg.inv`) that consume and produce `tf.Tensor`. These operations automatically convert built-in Python types. For example:\n"
+        "A Tensor is a multi-dimensional array. Similar to NumPy `ndarray` objects, `tf.Tensor` objects have a data type and a shape. Additionally, `tf.Tensor`s can reside in accelerator memory (like a GPU). TensorFlow offers a rich library of operations (for example, `tf.math.add`, `tf.linalg.matmul`, and `tf.linalg.inv`) that consume and produce `tf.Tensor`s. These operations automatically convert built-in Python types. For example:\n"
       ]
     },
     {
@@ -156,7 +156,7 @@
         "id": "eBPw8e8vrsom"
       },
       "source": [
-        "The most obvious differences between NumPy arrays and `tf.Tensor` are:\n",
+        "The most obvious differences between NumPy arrays and `tf.Tensor`s are:\n",
         "\n",
         "1. Tensors can be backed by accelerator memory (like GPU, TPU).\n",
         "2. Tensors are immutable."


### PR DESCRIPTION
Fixed typo errors by removing additional 's' in the name `tf.tensor`s to `tf.tensor`. 
Also updated the correct URL link for `tf.data.dataset` API.