### PR TITLE
Fix typo in music generation

### DIFF
--- a/site/en/tutorials/audio/music_generation.ipynb
+++ b/site/en/tutorials/audio/music_generation.ipynb
@@ -857,7 +857,7 @@
         "id": "iGQn32q-hdK2"
       },
       "source": [
-        "The model will have three outputs, one for each note variable. For `pitch` and `duration`, you will use a custom loss function based on mean squared error that encourages the model to output non-negative values."
+        "The model will have three outputs, one for each note variable. For `step` and `duration`, you will use a custom loss function based on mean squared error that encourages the model to output non-negative values."
       ]
     },
     {


### PR DESCRIPTION
In the docs for [Music Generation using RNN](https://www.tensorflow.org/tutorials/audio/music_generation). The doc states that,

> For `pitch` and `duration`, you will use a custom loss function based on mean squared error that encourages the model to output non-negative values"

but if we look at the code given in the doc (pasted below for reference) we can see that the custom loss function is used not for `pitch` instead, it's used for `step` and `duration`. It makes sense that way since `step` and `duration` should not be negative. Pitch is not using a custom loss function instead they used `SparseCategoricalCrossentropy`.

```python
loss = {
      'pitch': tf.keras.losses.SparseCategoricalCrossentropy(
          from_logits=True),
      'step': mse_with_positive_pressure,
      'duration': mse_with_positive_pressure,
}
```