### PR TITLE
Update text_classification.ipynb

### DIFF
--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -650,8 +650,7 @@
         "\n",
         "1. The first layer is an `Embedding` layer. This layer takes the integer-encoded reviews and looks up an embedding vector for each word-index. These vectors are learned as the model trains. The vectors add a dimension to the output array. The resulting dimensions are: `(batch, sequence, embedding)`.  To learn more about embeddings, check out the [Word embeddings](https://www.tensorflow.org/text/guide/word_embeddings) tutorial.\n",
         "2. Next, a `GlobalAveragePooling1D` layer returns a fixed-length output vector for each example by averaging over the sequence dimension. This allows the model to handle input of variable length, in the simplest way possible.\n",
-        "3. This fixed-length output vector is piped through a fully-connected (`Dense`) layer with 16 hidden units. \n",
-        "4. The last layer is densely connected with a single output node."
+        "3. The last layer is densely connected with a single output node."
       ]
     },
     {


### PR DESCRIPTION
This line was a mistake and probably comes from this page: https://www.tensorflow.org/text/guide/word_embeddings (the model is almost the same except for the Dense(16, activation='relu') layer).