### PR TITLE
Fix dead link that pointed towards Classification on imbalanced data 

### DIFF
--- a/site/en/guide/data.ipynb
+++ b/site/en/guide/data.ipynb
@@ -2422,7 +2422,7 @@
         "\n",
         "When working with a dataset that is very class-imbalanced, you may want to resample the dataset. `tf.data` provides two methods to do this. The credit card fraud dataset is a good example of this sort of problem.\n",
         "\n",
-        "Note: See [Imbalanced Data](../tutorials/keras/imbalanced_data.ipynb) for a full tutorial.\n"
+        "Note: See [Classification on imbalanced data](../tutorials/structured_data/imbalanced_data) for a full tutorial.\n"
       ]
     },
     {

--- a/site/en/guide/data.ipynb
+++ b/site/en/guide/data.ipynb
@@ -2422,7 +2422,7 @@
         "\n",
         "When working with a dataset that is very class-imbalanced, you may want to resample the dataset. `tf.data` provides two methods to do this. The credit card fraud dataset is a good example of this sort of problem.\n",
         "\n",
-        "Note: See [Classification on imbalanced data](../tutorials/structured_data/imbalanced_data) for a full tutorial.\n"
+        "Note: See [Classification on imbalanced data](../tutorials/structured_data/imbalanced_data.ipynb) for a full tutorial.\n"
       ]
     },
     {


### PR DESCRIPTION
This link used to point to a tutorial that no longer exists. [Classification on imbalanced data](https://www.tensorflow.org/tutorials/structured_data/imbalanced_data.ipynb) is the updated version of that now-dead tutorial.

Hope this is all up to scratch!