### PR TITLE
Fixing the incorrect link in actor_critic.ipynb

### DIFF
--- a/site/en/tutorials/reinforcement_learning/actor_critic.ipynb
+++ b/site/en/tutorials/reinforcement_learning/actor_critic.ipynb
@@ -104,7 +104,7 @@
       "source": [
         "**CartPole-v0**\n",
         "\n",
-        "In the [CartPole-v0 environment](https://gym.openai.com/envs/CartPole-v0), a pole is attached to a cart moving along a frictionless track. \n",
+        "In the [CartPole-v0 environment](https://www.gymlibrary.ml/environments/classic_control/cart_pole/?highlight=cart%20pole%20v0), a pole is attached to a cart moving along a frictionless track. \n",
         "The pole starts upright and the goal of the agent is to prevent it from falling over by applying a force of -1 or +1 to the cart. \n",
         "A reward of +1 is given for every time step the pole remains upright.\n",
         "An episode ends when (1) the pole is more than 15 degrees from vertical or (2) the cart moves more than 2.4 units from the center.\n",

--- a/site/en/tutorials/reinforcement_learning/actor_critic.ipynb
+++ b/site/en/tutorials/reinforcement_learning/actor_critic.ipynb
@@ -104,7 +104,7 @@
       "source": [
         "**CartPole-v0**\n",
         "\n",
-        "In the [CartPole-v0 environment](https://www.gymlibrary.ml/environments/classic_control/cart_pole/?highlight=cart%20pole%20v0), a pole is attached to a cart moving along a frictionless track. \n",
+        "In the [CartPole-v0 environment](https://www.gymlibrary.ml/environments/classic_control/cart_pole/), a pole is attached to a cart moving along a frictionless track. \n",
         "The pole starts upright and the goal of the agent is to prevent it from falling over by applying a force of -1 or +1 to the cart. \n",
         "A reward of +1 is given for every time step the pole remains upright.\n",
         "An episode ends when (1) the pole is more than 15 degrees from vertical or (2) the cart moves more than 2.4 units from the center.\n",

--- a/site/en/tutorials/reinforcement_learning/actor_critic.ipynb
+++ b/site/en/tutorials/reinforcement_learning/actor_critic.ipynb
@@ -738,7 +738,6 @@
         "_jQ1tEQCxwRx"
       ],
       "name": "actor_critic.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
Added the correct link for `CartPole-v0 environment`.