### PR TITLE
BUGFIX: Plot shape error in tf data compression tutorial

### DIFF
--- a/site/en/guide/distributed_training.ipynb
+++ b/site/en/guide/distributed_training.ipynb
@@ -900,8 +900,6 @@
         "Tce3stUlHN0L"
       ],
       "name": "distributed_training.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/site/en/guide/migrate/fault_tolerance.ipynb
+++ b/site/en/guide/migrate/fault_tolerance.ipynb
@@ -13,6 +13,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "cellView": "form",
         "id": "HMUDt0CiUJk9"
       },
       "outputs": [],
@@ -467,7 +468,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "fault_tolerance.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/site/en/tutorials/distribute/custom_training.ipynb
+++ b/site/en/tutorials/distribute/custom_training.ipynb
@@ -699,7 +699,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "custom_training.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/site/en/tutorials/generative/data_compression.ipynb
+++ b/site/en/tutorials/generative/data_compression.ipynb
@@ -303,7 +303,7 @@
       "source": [
         "(x, _), = validation_dataset.take(1)\n",
         "\n",
-        "plt.imshow(x)\n",
+        "plt.imshow(tf.squeeze(x))\n",
         "print(f\"Data type: {x.dtype}\")\n",
         "print(f\"Shape: {x.shape}\")\n"
       ]
@@ -426,7 +426,7 @@
         "print(\"distortion:\", distortion)\n",
         "\n",
         "x_tilde = tf.saturate_cast(x_tilde[0] * 255, tf.uint8)\n",
-        "plt.imshow(x_tilde)\n",
+        "plt.imshow(tf.squeeze(x_tilde))\n",
         "print(f\"Data type: {x_tilde.dtype}\")\n",
         "print(f\"Shape: {x_tilde.shape}\")\n"
       ]

--- a/site/en/tutorials/generative/data_compression.ipynb
+++ b/site/en/tutorials/generative/data_compression.ipynb
@@ -705,7 +705,7 @@
         "id": "JWo0Q-vy23tt"
       },
       "source": [
-        "Display each of 16 original digits together with its compressed binary representation, and the reconstructed digit."
+        "Display each of the 16 original digits together with its compressed binary representation, and the reconstructed digit."
       ]
     },
     {
@@ -757,7 +757,7 @@
       "source": [
         "Note that the length of the encoded string differs from the information content of each digit.\n",
         "\n",
-        "This is because the range coding process works with discretized probabilities, and has a small amount of overhead. So, especially for short strings, the correspondence is only approximate. However, range coding is **asymptotically optimal**: in the limit, the expected bit count will approach the cross entropy (the expected information content), for which the rate term in the training model is an upper bound."
+        "This is because the range coding process works with discrete probabilities, and has a small amount of overhead. So, especially for short strings, the correspondence is only approximate. However, range coding is **asymptotically optimal**: in the limit, the expected bit count will approach the cross entropy (the expected information content), for which the rate term in the training model is an upper bound."
       ]
     },
     {


### PR DESCRIPTION
**Description**
Two cells in the tensorflow data compression tutorial throw an error when run in Colab.

https://www.tensorflow.org/tutorials/generative/data_compression

**To Reproduce:**
Steps to reproduce the behavior:
1. Go to [the tutorial on colab](https://colab.sandbox.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/generative/data_compression.ipynb)
2. Two cells: `plt.imshow(x)` and `plt.imshow(x_tilde)` 
3. They throw an Error: `Invalid shape (28, 28, 1) for image data` 

**Resolution:**
Simply putting a `tf.squeeze()` so that e.g. `plt.imshow(x)` -> `plt.imshow(tf.squeeze(x))` will resolve the issue.