### PR TITLE
Fixed some typo errors and updated one direct link

### DIFF
--- a/site/en/tutorials/customization/basics.ipynb
+++ b/site/en/tutorials/customization/basics.ipynb
@@ -106,7 +106,7 @@
       "source": [
         "## Tensors\n",
         "\n",
-        "A Tensor is a multi-dimensional array. Similar to NumPy `ndarray` objects, `tf.Tensor` objects have a data type and a shape. Additionally, `tf.Tensor` can reside in accelerator memory (like a GPU). TensorFlow offers a rich library of operations (for example, `tf.math.add`, `tf.linalg.matmul`, and `tf.linalg.inv`) that consume and produce `tf.Tensor`. These operations automatically convert built-in Python types. For example:\n"
+        "A Tensor is a multi-dimensional array. Similar to NumPy `ndarray` objects, `tf.Tensor` objects have a data type and a shape. Additionally, `tf.Tensor`s can reside in accelerator memory (like a GPU). TensorFlow offers a rich library of operations (for example, `tf.math.add`, `tf.linalg.matmul`, and `tf.linalg.inv`) that consume and produce `tf.Tensor`s. These operations automatically convert built-in Python types. For example:\n"
       ]
     },
     {
@@ -156,7 +156,7 @@
         "id": "eBPw8e8vrsom"
       },
       "source": [
-        "The most obvious differences between NumPy arrays and `tf.Tensor` are:\n",
+        "The most obvious differences between NumPy arrays and `tf.Tensor`s are:\n",
         "\n",
         "1. Tensors can be backed by accelerator memory (like GPU, TPU).\n",
         "2. Tensors are immutable."

--- a/site/en/tutorials/customization/basics.ipynb
+++ b/site/en/tutorials/customization/basics.ipynb
@@ -106,7 +106,7 @@
       "source": [
         "## Tensors\n",
         "\n",
-        "A Tensor is a multi-dimensional array. Similar to NumPy `ndarray` objects, `tf.Tensor` objects have a data type and a shape. Additionally, `tf.Tensor`s can reside in accelerator memory (like a GPU). TensorFlow offers a rich library of operations (for example, `tf.math.add`, `tf.linalg.matmul`, and `tf.linalg.inv`) that consume and produce `tf.Tensor`s. These operations automatically convert built-in Python types. For example:\n"
+        "A Tensor is a multi-dimensional array. Similar to NumPy `ndarray` objects, `tf.Tensor` objects have a data type and a shape. Additionally, `tf.Tensor` can reside in accelerator memory (like a GPU). TensorFlow offers a rich library of operations (for example, `tf.math.add`, `tf.linalg.matmul`, and `tf.linalg.inv`) that consume and produce `tf.Tensor`. These operations automatically convert built-in Python types. For example:\n"
       ]
     },
     {
@@ -156,7 +156,7 @@
         "id": "eBPw8e8vrsom"
       },
       "source": [
-        "The most obvious differences between NumPy arrays and `tf.Tensor`s are:\n",
+        "The most obvious differences between NumPy arrays and `tf.Tensor` are:\n",
         "\n",
         "1. Tensors can be backed by accelerator memory (like GPU, TPU).\n",
         "2. Tensors are immutable."
@@ -239,7 +239,7 @@
       "source": [
         "### Device names\n",
         "\n",
-        "The `Tensor.device` property provides a fully qualified string name of the device hosting the contents of the tensor. This name encodes many details, such as an identifier of the network address of the host on which this program is executing and the device within that host. This is required for distributed execution of a TensorFlow program. The string ends with `GPU:<N>` if the tensor is placed on the `N`-th GPU on the host."
+        "The [`Tensor.device`](https://www.tensorflow.org/api_docs/python/tf/Tensor#attributes) property provides a fully qualified string name of the device hosting the contents of the tensor. This name encodes many details, such as an identifier of the network address of the host on which this program is executing and the device within that host. This is required for distributed execution of a TensorFlow program. The string ends with `GPU:<N>` if the tensor is placed on the `N`-th GPU on the host."
       ]
     },
     {


### PR DESCRIPTION
Fixed typo error by removing 's' from `tf.tensor` and provided a direct link to access the `tf.tensor` attribute 'device' using `Tensor.device`.