### PR TITLE
Typo fix

### DIFF
--- a/site/en/guide/extension_type.ipynb
+++ b/site/en/guide/extension_type.ipynb
@@ -87,7 +87,7 @@
       "source": [
         "## Extension types\n",
         "\n",
-        "User-defined types can make projects more readable, modular, maintainable. However, most TensorFlow APIs have very limited support for user-defined Python types. This includes both high-level APIs (such as [Keras](https://www.tensorflow.org/guide/keras/overview), [tf.function](https://www.tensorflow.org/guide/function), [tf.SavedModel](https://www.tensorflow.org/guide/saved_model)) and lower-level APIs (such as `tf.while_loop` and `tf.concat`).  TensorFlow **extension types** can be used to create user-defined object-oriented types that work seamlessly with TensorFlow's APIs. To create an extension type, simply define a Python class with `tf.experimental.ExtensionType` as its base, and use [type annotations](https://www.python.org/dev/peps/pep-0484/) to specify the type for each field."
+        "User-defined types can make projects more readable, modular, maintainable. However, most TensorFlow APIs have very limited support for user-defined Python types. This includes both high-level APIs (such as [Keras](https://www.tensorflow.org/guide/keras/overview), [tf.function](https://www.tensorflow.org/guide/function), [`tf.SavedModel`](https://www.tensorflow.org/guide/saved_model)) and lower-level APIs (such as `tf.while_loop` and `tf.concat`). TensorFlow **extension types** can be used to create user-defined object-oriented types that work seamlessly with TensorFlow's APIs. To create an extension type, simply define a Python class with `tf.experimental.ExtensionType` as its base, and use [type annotations](https://www.python.org/dev/peps/pep-0484/) to specify the type for each field."
       ]
     },
     {
@@ -121,7 +121,7 @@
         "id": "FiaNXPa7pNK-"
       },
       "source": [
-        "The `tf.experimental.ExtensionType` base class works similarly to [`typing.NamedTuple`](https://docs.python.org/3/library/typing.html#typing.NamedTuple) and [`@dataclasses.dataclass`](https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass) from the standard Python library.  In particular, it automatically adds a constructor and special methods (such as `__repr__` and `__eq__`) based on the field type annotations."
+        "The `tf.experimental.ExtensionType` base class works similarly to [`typing.NamedTuple`](https://docs.python.org/3/library/typing.html#typing.NamedTuple) and [`@dataclasses.dataclass`](https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass) from the standard Python library. In particular, it automatically adds a constructor and special methods (such as `__repr__` and `__eq__`) based on the field type annotations."
       ]
     },
     {
@@ -132,9 +132,9 @@
       "source": [
         "Typically, extension types tend to fall into one of two categories:\n",
         "\n",
-        "* ***Data structures***, which group together a collection of related values, and can provide useful operations based on those values.  Data structures may be fairly general (such as the `TensorGraph` example above); or they may be highly customized to a specific model.\n",
+        "* ***Data structures***, which group together a collection of related values, and can provide useful operations based on those values. Data structures may be fairly general (such as the `TensorGraph` example above); or they may be highly customized to a specific model.\n",
         "\n",
-        "* ***Tensor-like types***, which specialize or extend the concept of \"Tensor.\"  Types in this category have a `rank`, a `shape`, and usually a `dtype`; and it makes sense to use them with Tensor operations (such as `tf.stack`, `tf.add`, or `tf.matmul`).  `MaskedTensor` and `CSRSparseMatrix` are examples of tensor-like types."
+        "* ***Tensor-like types***, which specialize or extend the concept of \"Tensor.\" Types in this category have a `rank`, a `shape`, and usually a `dtype`; and it makes sense to use them with Tensor operations (such as `tf.stack`, `tf.add`, or `tf.matmul`). `MaskedTensor` and `CSRSparseMatrix` are examples of tensor-like types."
       ]
     },
     {
@@ -148,15 +148,15 @@
         "Extension types are supported by the following TensorFlow APIs:\n",
         "\n",
         "* **Keras**: Extension types can be used as inputs and outputs for Keras `Models` and `Layers`.\n",
-        "* **tf.data.Dataset**: Extension types can be included in `Datasets`, and returned by dataset `Iterators`.\n",
-        "* **Tensorflow hub**: Extension types can be used as inputs and outputs for `tf.hub` modules.\n",
+        "* **`tf.data.Dataset`**: Extension types can be included in `Datasets`, and returned by dataset `Iterators`.\n",
+        "* **TensorFlow Hub**: Extension types can be used as inputs and outputs for `tf.hub` modules.\n",
         "* **SavedModel**: Extension types can be used as inputs and outputs for `SavedModel` functions.\n",
-        "* **tf.function**: Extension types can be used as arguments and return values for functions wrapped with the `@tf.function` decorator.\n",
-        "* **while loops**: Extension types can be used as loop variables in `tf.while_loop`, and can be used as arguments and return values for the while-loop's body.\n",
-        "* **conditionals**: Extension types can be conditionally selected using `tf.cond` and `tf.case`.\n",
-        "* **py_function**: Extension types can be used as arguments and return values for the `func` argument to `tf.py_function`.\n",
-        "* **Tensor ops**: Extension types can be extended to support most TensorFlow ops that accept Tensor inputs (e.g., `tf.matmul`, `tf.gather`, and `tf.reduce_sum`). See the \"*Dispatch*\" section below for more information.\n",
-        "* **distribution strategy**: Extension types can be used as per-replica values.\n",
+        "* **`tf.function`**: Extension types can be used as arguments and return values for functions wrapped with the `@tf.function` decorator.\n",
+        "* **While loops**: Extension types can be used as loop variables in `tf.while_loop`, and can be used as arguments and return values for the while-loop's body.\n",
+        "* **Conditionals**: Extension types can be conditionally selected using `tf.cond` and `tf.case`.\n",
+        "* **`tf.py_function`**: Extension types can be used as arguments and return values for the `func` argument to `tf.py_function`.\n",
+        "* **Tensor ops**: Extension types can be extended to support most TensorFlow ops that accept Tensor inputs (such as `tf.matmul`, `tf.gather`, and `tf.reduce_sum`). Go to the \"*Dispatch*\" section below for more information.\n",
+        "* **Distribution strategy**: Extension types can be used as per-replica values.\n",
         "\n",
         "For more details, see the section on \"TensorFlow APIs that support ExtensionTypes\" below.\n"
       ]
@@ -178,7 +178,7 @@
       "source": [
         "### Field types\n",
         "\n",
-        "All fields (aka instance variables) must be declared, and a type annotation must be provided for each field.  The following type annotations are supported:\n",
+        "All fields—instance variables—must be declared, and a type annotation must be provided for each field. The following type annotations are supported:\n",
         "\n",
         "Type | Example\n",
         "---- | -------\n",
@@ -186,15 +186,15 @@
         "Python floats | `f: float`\n",
         "Python strings | `s: str`\n",
         "Python booleans | `b: bool`\n",
-        "Python None | `n: None`\n",
+        "Python `None` | `n: None`\n",
         "[Tensor shapes](https://www.tensorflow.org/api_docs/python/tf/TensorShape) | `shape: tf.TensorShape`\n",
-        "[Tensor dtypes](https://www.tensorflow.org/api_docs/python/tf/dtypes/DType) | `dtype: tf.DType`\n",
+        "[Tensor `dtype`s](https://www.tensorflow.org/api_docs/python/tf/dtypes/DType) | `dtype: tf.DType`\n",
         "[Tensors](https://www.tensorflow.org/api_docs/python/tf/Tensor) | `t: tf.Tensor`\n",
         "[Extension types](https://www.tensorflow.org/api_docs/python/tf/experimental/ExtensionType) | `mt: MyMaskedTensor`\n",
-        "[Ragged Tensors](https://www.tensorflow.org/api_docs/python/tf/RaggedTensor) | `rt: tf.RaggedTensor`\n",
-        "[Sparse Tensors](https://www.tensorflow.org/api_docs/python/tf/sparse/SparseTensor) | `st: tf.SparseTensor`\n",
-        "[Indexed Slices](https://www.tensorflow.org/api_docs/python/tf/IndexedSlices) | `s: tf.IndexedSlices`\n",
-        "[Optional Tensors](https://www.tensorflow.org/api_docs/python/tf/experimental/Optional) | `o: tf.experimental.Optional`\n",
+        "[Ragged tensors](https://www.tensorflow.org/api_docs/python/tf/RaggedTensor) | `rt: tf.RaggedTensor`\n",
+        "[Sparse tensors](https://www.tensorflow.org/api_docs/python/tf/sparse/SparseTensor) | `st: tf.SparseTensor`\n",
+        "[Indexed slices](https://www.tensorflow.org/api_docs/python/tf/IndexedSlices) | `s: tf.IndexedSlices`\n",
+        "[Optional tensors](https://www.tensorflow.org/api_docs/python/tf/experimental/Optional) | `o: tf.experimental.Optional`\n",
         "[Type unions](https://docs.python.org/3/library/typing.html#typing.Union) | `int_or_float: typing.Union[int, float]`\n",
         "[Tuples](https://docs.python.org/3/library/typing.html#typing.Tuple) | `params: typing.Tuple[int, float, tf.Tensor, int]`\n",
         "[Var-length tuples](https://docs.python.org/3/library/typing.html#typing.Tuple) | `lengths: typing.Tuple[int, ...]`\n",
@@ -210,8 +210,8 @@
       "source": [
         "### Mutability\n",
         "\n",
-        "Extension types are required to be immutable.  This ensures that they can be properly tracked by TensorFlow's graph-tracing mechanisms.\n",
-        "If you find yourself wanting to mutate an extension type value, consider  instead defining methods that transform values.  For example, rather than defining a `set_mask` method to mutate a `MaskedTensor`, you could define a `replace_mask` method that returns a new `MaskedTensor`:"
+        "Extension types are required to be immutable. This ensures that they can be properly tracked by TensorFlow's graph-tracing mechanisms.\n",
+        "If you find yourself wanting to mutate an extension type value, consider instead defining methods that transform values. For example, rather than defining a `set_mask` method to mutate a `MaskedTensor`, you could define a `replace_mask` method that returns a new `MaskedTensor`:"
       ]
     },
     {
@@ -249,7 +249,7 @@
         "* A nested `TypeSpec`.\n",
         "* Tensor API dispatch support.\n",
         "\n",
-        "See the \"Customizing ExtensionTypes\" section below for more information on customizing this functionality."
+        "Go to the \"Customizing `ExtensionType`s\" section below for more information on customizing this functionality."
       ]
     },
     {
@@ -259,7 +259,7 @@
       },
       "source": [
         "### Constructor\n",
-        "The constructor added by `ExtensionType` takes each field as a named argument (in the order they were listed in the class definition).  This constructor will type-check each parameter, and convert them where necessary.  In particular, `Tensor` fields are converted using `tf.convert_to_tensor`; `Tuple` fields are converted to `tuple`s; and `Mapping` fields are converted to immutable dicts."
+        "The constructor added by `ExtensionType` takes each field as a named argument (in the order they were listed in the class definition). This constructor will type-check each parameter, and convert them where necessary. In particular, `Tensor` fields are converted using `tf.convert_to_tensor`; `Tuple` fields are converted to `tuple`s; and `Mapping` fields are converted to immutable dicts."
       ]
     },
     {
@@ -279,7 +279,7 @@
         "                  mask=[[True, True, False], [True, False, True]])\n",
         "\n",
         "# Fields are type-checked and converted to the declared types.\n",
-        "# E.g., mt.values is converted to a Tensor.\n",
+        "# For example, `mt.values` is converted to a Tensor.\n",
         "print(mt.values)"
       ]
     },
@@ -372,7 +372,7 @@
       "source": [
         "### Equality operators\n",
         "\n",
-        "`ExtensionType` adds default equality operators (`__eq__` and `__ne__`) that consider two values equal if they have the same type and all their fields are equal.  Tensor fields are considered equal if they have the same shape and are elementwise equal for all elements."
+        "`ExtensionType` adds default equality operators (`__eq__` and `__ne__`) that consider two values equal if they have the same type and all their fields are equal. Tensor fields are considered equal if they have the same shape and are elementwise equal for all elements."
       ]
     },
     {
@@ -407,7 +407,7 @@
       "source": [
         "### Validation method\n",
         "\n",
-        "`ExtensionType` adds a `__validate__` method, which can be overridden to perform validation checks on fields.  It is run after the constructor is called, and after fields have been type-checked and converted to their declared types, so it can assume that all fields have their declared types.\n",
+        "`ExtensionType` adds a `__validate__` method, which can be overridden to perform validation checks on fields. It is run after the constructor is called, and after fields have been type-checked and converted to their declared types, so it can assume that all fields have their declared types.\n",
         "\n",
         "The following example updates `MaskedTensor` to validate the `shape`s and `dtype`s of its fields:"
       ]
@@ -438,7 +438,7 @@
       "outputs": [],
       "source": [
         "try:\n",
-        "  MaskedTensor([1, 2, 3], [0, 1, 0])  # wrong dtype for mask.\n",
+        "  MaskedTensor([1, 2, 3], [0, 1, 0])  # Wrong `dtype` for mask.\n",
         "except AssertionError as e:\n",
         "  print(f\"Got expected AssertionError: {e}\")"
       ]
@@ -531,7 +531,7 @@
         "\n",
         "Each `ExtensionType` class has a corresponding `TypeSpec` class, which is created automatically and stored as `<extension_type_name>.Spec`.\n",
         "\n",
-        "This class captures all the information from a value *except* for the values of any nested tensors.  In particular, the `TypeSpec` for a value is created by replacing any nested Tensor, ExtensionType, or CompositeTensor with its `TypeSpec`.\n"
+        "This class captures all the information from a value *except* for the values of any nested tensors. In particular, the `TypeSpec` for a value is created by replacing any nested Tensor, ExtensionType, or CompositeTensor with its `TypeSpec`.\n"
       ]
     },
     {
@@ -548,7 +548,7 @@
         "\n",
         "anne = Player(\"Anne\", {\"height\": 8.3, \"speed\": 28.1})\n",
         "anne_spec = tf.type_spec_from_value(anne)\n",
-        "print(anne_spec.name)  # Records dtype and shape, but not the string value.\n",
+        "print(anne_spec.name)  # Records `dtype` and `shape`, but not the string value.\n",
         "print(anne_spec.attributes)  # Records keys and TensorSpecs for values."
       ]
     },
@@ -652,13 +652,13 @@
         "id": "gX613uRk0qLz"
       },
       "source": [
-        "## Customizing ExtensionTypes\n",
+        "## Customizing `ExtensionType`s\n",
         "\n",
         "In addition to simply declaring fields and their types, extension types may:\n",
         "\n",
         "* Override the default printable representation (`__repr__`).\n",
         "* Define methods.\n",
-        "* Define classmethods and staticmethods.\n",
+        "* Define `classmethod`s and `staticmethod`s.\n",
         "* Define properties.\n",
         "* Override the default constructor (`__init__`).\n",
         "* Override the default equality operator (`__eq__`).\n",
@@ -675,7 +675,7 @@
       "source": [
         "### Overriding the default printable representation\n",
         "\n",
-        "You can override this default string conversion operator for extension types.  The following example updates the `MaskedTensor` class to generate a more readable string representation when values are printed in Eager mode."
+        "You can override this default string conversion operator for extension types. The following example updates the `MaskedTensor` class to generate a more readable string representation when values are printed in Eager mode."
       ]
     },
     {
@@ -719,7 +719,7 @@
       "source": [
         "### Defining methods\n",
         "\n",
-        "Extension types may define methods, just like any normal Python class.  For example, the `MaskedTensor` type could define a `with_default` method that returns a copy of `self` with masked values replaced by a given `default` value.  Methods may optionally be annotated with the `@tf.function` decorator."
+        "Extension types may define methods, just like any normal Python class. For example, the `MaskedTensor` type could define a `with_default` method that returns a copy of `self` with masked values replaced by a given `default` value. Methods may optionally be annotated with the `@tf.function` decorator."
       ]
     },
     {
@@ -746,9 +746,9 @@
         "id": "Qwd_gGKp9RP0"
       },
       "source": [
-        "### Defining classmethods and staticmethods\n",
+        "### Defining `classmethod`s and `staticmethod`s\n",
         "\n",
-        "Extension types may define methods using the `@classmethod` and `@staticmethod` decorators.  For example, the `MaskedTensor` type could define a factory method that masks any element with a given value:"
+        "Extension types may define methods using the `@classmethod` and `@staticmethod` decorators. For example, the `MaskedTensor` type could define a factory method that masks any element with a given value:"
       ]
     },
     {
@@ -781,7 +781,7 @@
       },
       "source": [
         "### Defining properties\n",
-        "Extension types may define properties using the `@property` decorator, just like any normal Python class.  For example, the `MaskedTensor` type could define a `dtype` property that's a shorthand for the dtype of the values:"
+        "Extension types may define properties using the `@property` decorator, just like any normal Python class. For example, the `MaskedTensor` type could define a `dtype` property that's a shorthand for the `dtype` of the values:"
       ]
     },
     {
@@ -811,7 +811,7 @@
       "source": [
         "### Overriding the default constructor\n",
         "\n",
-        "You can override the default constructor for extension types.  Custom constructors must set a value for every declared field; and after the custom constructor returns, all fields will be type-checked, and values will be converted as described above."
+        "You can override the default constructor for extension types. Custom constructors must set a value for every declared field; and after the custom constructor returns, all fields will be type-checked, and values will be converted as described above."
       ]
     },
     {
@@ -838,7 +838,7 @@
         "id": "qyQxMlwLFQt7"
       },
       "source": [
-        "Alternatively, you might consider leaving the default constructor as-is, but adding one or more factory methods.  E.g.:"
+        "Alternatively, you might consider leaving the default constructor as-is, but adding one or more factory methods. For example:"
       ]
     },
     {
@@ -868,7 +868,7 @@
       "source": [
         "### Overriding the default equality operator (`__eq__`)\n",
         "\n",
-        "You can override the default `__eq__` operator for extension types.  The follow example updates `MaskedTensor` to ignore masked elements when comparing for equality."
+        "You can override the default `__eq__` operator for extension types. The following example updates `MaskedTensor` to ignore masked elements when comparing for equality."
       ]
     },
     {
@@ -913,7 +913,7 @@
       "source": [
         "### Using forward references\n",
         "\n",
-        "If the type for a field has not been defined yet, you may use a string containing the name of the type instead.  In the following example, the string `\"Node\"` is used to annotate the `children` field because the `Node` type hasn't been (fully) defined yet.\n"
+        "If the type for a field has not been defined yet, you may use a string containing the name of the type instead. In the following example, the string `\"Node\"` is used to annotate the `children` field because the `Node` type hasn't been (fully) defined yet.\n"
       ]
     },
     {
@@ -939,7 +939,7 @@
       "source": [
         "### Defining subclasses\n",
         "\n",
-        "Extension types may be subclassed using the standard Python syntax.  Extension type subclasses may add new fields, methods, and properties; and may override the constructor, the printable representation, and the equality operator.  The following example defines a basic `TensorGraph` class that uses three `Tensor` fields to encode a set of edges between nodes.  It then defines a subclass that adds a `Tensor` field to record a \"feature value\" for each node.  The subclass also defines a method to propagage the feature values along the edges."
+        "Extension types may be subclassed using the standard Python syntax. Extension type subclasses may add new fields, methods, and properties; and may override the constructor, the printable representation, and the equality operator. The following example defines a basic `TensorGraph` class that uses three `Tensor` fields to encode a set of edges between nodes. It then defines a subclass that adds a `Tensor` field to record a \"feature value\" for each node. The subclass also defines a method to propagate the feature values along the edges."
       ]
     },
     {
@@ -981,7 +981,7 @@
       "source": [
         "### Defining private fields\n",
         "\n",
-        "An extension type's fields may be marked private by prefixing them with an underscore (following standard Python conventions).  This does not impact the way that TensorFlow treats the fields in any way; but simply serves as a signal to any users of the extension type that those fields are private.\n"
+        "An extension type's fields may be marked private by prefixing them with an underscore (following standard Python conventions). This does not impact the way that TensorFlow treats the fields in any way; but simply serves as a signal to any users of the extension type that those fields are private.\n"
       ]
     },
     {
@@ -990,15 +990,15 @@
         "id": "oMdH7ORqh8Pl"
       },
       "source": [
-        "### Customizing the ExtensionType's `TypeSpec`\n",
+        "### Customizing the `ExtensionType`'s `TypeSpec`\n",
         "\n",
-        "Each `ExtensionType` class has a corresponding `TypeSpec` class, which is created automatically and stored as `<extension_type_name>.Spec`.  For more information, see the section \"Nested TypeSpec\" above.\n",
+        "Each `ExtensionType` class has a corresponding `TypeSpec` class, which is created automatically and stored as `<extension_type_name>.Spec`. For more information, see the section \"Nested TypeSpec\" above.\n",
         "\n",
-        "To customize the `TypeSpec`, simply define your own nested class named `Spec`, and `ExtensionType` will use that as the basis for the automatically constructed `TypeSpec`.  You can customize the `Spec` class by:\n",
+        "To customize the `TypeSpec`, simply define your own nested class named `Spec`, and `ExtensionType` will use that as the basis for the automatically constructed `TypeSpec`. You can customize the `Spec` class by:\n",
         "\n",
         "* Overriding the default printable representation.\n",
         "* Overriding the default constructor.\n",
-        "* Defining methods, classmethods, staticmethods, and properties.\n",
+        "* Defining methods, `classmethod`s, `staticmethod`s, and properties.\n",
         "\n",
         "The following example customizes the `MaskedTensor.Spec` class to make it easier to use:"
       ]
@@ -1053,7 +1053,7 @@
       "source": [
         "## Tensor API dispatch\n",
         "\n",
-        "Extension types can be \"tensor-like\", in the sense that they specialize or extend the interface defined by the `tf.Tensor` type.  Examples of tensor-like extension types include `RaggedTensor`, `SparseTensor`, and `MaskedTensor`.  ***Dispatch decorators*** can be used to override the default behavior of TensorFlow operations when applied to tensor-like extension types.  TensorFlow currently defines three dispatch decorators:\n",
+        "Extension types can be \"tensor-like\", in the sense that they specialize or extend the interface defined by the `tf.Tensor` type. Examples of tensor-like extension types include `RaggedTensor`, `SparseTensor`, and `MaskedTensor`. ***Dispatch decorators*** can be used to override the default behavior of TensorFlow operations when applied to tensor-like extension types. TensorFlow currently defines three dispatch decorators:\n",
         "\n",
         "* `@tf.experimental.dispatch_for_api(tf_api)`\n",
         "* `@tf.experimental.dispatch_for_unary_elementwise_api(x_type)`\n",
@@ -1068,7 +1068,7 @@
       "source": [
         "### Dispatch for a single API\n",
         "\n",
-        "The `tf.experimental.dispatch_for_api` decorator overrides the default behavior of a specified TensorFlow operation when it is called with the specified signature.  For example, you can use this decorator to specify how `tf.stack` should process `MaskedTensor` values:"
+        "The `tf.experimental.dispatch_for_api` decorator overrides the default behavior of a specified TensorFlow operation when it is called with the specified signature. For example, you can use this decorator to specify how `tf.stack` should process `MaskedTensor` values:"
       ]
     },
     {
@@ -1159,9 +1159,9 @@
       "source": [
         "### Dispatch for all unary elementwise APIs\n",
         "\n",
-        "The `tf.experimental.dispatch_for_unary_elementwise_apis` decorator overrides the default behavior of ***all*** unary elementwise ops (such as `tf.math.cos`) whenever the value for the first argument (typically named `x`) matches the type annotation `x_type`.  The decorated function should take two arguments:\n",
+        "The `tf.experimental.dispatch_for_unary_elementwise_apis` decorator overrides the default behavior of ***all*** unary elementwise ops (such as `tf.math.cos`) whenever the value for the first argument (typically named `x`) matches the type annotation `x_type`. The decorated function should take two arguments:\n",
         "\n",
-        "* `api_func`: A function that takes a single parameter and performs the elementwise operation (e.g., `tf.abs`).\n",
+        "* `api_func`: A function that takes a single parameter and performs the elementwise operation (for example, `tf.abs`).\n",
         "* `x`: The first argument to the elementwise operation.\n",
         "\n",
         "The following example updates all unary elementwise operations to handle the `MaskedTensor` type:"
@@ -1255,7 +1255,7 @@
         "id": "txTGg9pzG0Ux"
       },
       "source": [
-        "For a list of the elementwise APIs that are overridden, see the API documentation for `tf.experimental.dispatch_for_unary_elementwise_apis` and `tf.experimental.dispatch_for_binary_elementwise_apis`."
+        "For a list of the elementwise APIs that are overridden, go to the API documentation for `tf.experimental.dispatch_for_unary_elementwise_apis` and `tf.experimental.dispatch_for_binary_elementwise_apis`."
       ]
     },
     {
@@ -1264,9 +1264,9 @@
         "id": "UseRtohYKiE5"
       },
       "source": [
-        "## Batchable ExtensionTypes\n",
+        "## Batchable `ExtensionType`s\n",
         "\n",
-        "An `ExtensionType` is *batchable* if a single instance can be used to represent a batch of values.  Typically, this is accomplished by adding batch dimensions to all nested `Tensor`s.  The following TensorFlow APIs require that any extension type inputs be batchable:\n",
+        "An `ExtensionType` is *batchable* if a single instance can be used to represent a batch of values. Typically, this is accomplished by adding batch dimensions to all nested `Tensor`s. The following TensorFlow APIs require that any extension type inputs be batchable:\n",
         "\n",
         "* `tf.data.Dataset` (`batch`, `unbatch`, `from_tensor_slices`)\n",
         "* `tf.Keras` (`fit`, `evaluate`, `predict`)\n",
@@ -1279,10 +1279,10 @@
         "id": "hWPauKGj_yRz"
       },
       "source": [
-        "By default, `BatchableExtensionType` creates batched values by batching any nested `Tensor`s, `CompositeTensor`s, and `ExtensionType`s.  If this is not appropriate for your class, then you will need to use `tf.experimental.ExtensionTypeBatchEncoder` to override this default behavior.  For example, it would not be appropriate to create a batch of `tf.SparseTensor` values by simply stacking individual sparse tensors' `values`, `indices`, and `dense_shape` fields -- in most cases, you can't stack these tensors, since they have incompatible shapes; and even if you could, the result would not be a valid `SparseTensor`.\n",
+        "By default, `BatchableExtensionType` creates batched values by batching any nested `Tensor`s, `CompositeTensor`s, and `ExtensionType`s. If this is not appropriate for your class, then you will need to use `tf.experimental.ExtensionTypeBatchEncoder` to override this default behavior. For example, it would not be appropriate to create a batch of `tf.SparseTensor` values by simply stacking individual sparse tensors' `values`, `indices`, and `dense_shape` fields -- in most cases, you can't stack these tensors, since they have incompatible shapes; and even if you could, the result would not be a valid `SparseTensor`.\n",
         "\n",
         "\n",
-        "**Note**: `BatchableExtensionType`s do *not* automatically define dispatchers for `tf.stack`, `tf.concat`, `tf.slice`, etc.  If your class needs to be supported by these APIs, then use the dispatch decorators described above."
+        "**Note**: `BatchableExtensionType`s do *not* automatically define dispatchers for `tf.stack`, `tf.concat`, `tf.slice`, etc. If your class needs to be supported by these APIs, then use the dispatch decorators described above."
       ]
     },
     {
@@ -1291,7 +1291,7 @@
         "id": "xkOJ8ke8GH7s"
       },
       "source": [
-        "### BatchableExtensionType example: Network\n",
+        "### `BatchableExtensionType` example: `Network`\n",
         "As an example, consider a simple `Network` class used for load balancing, which tracks how much work is left to do at each node, and how much bandwidth is available to move work between nodes:"
       ]
     },
@@ -1317,7 +1317,7 @@
         "id": "PaOzUev6g3wT"
       },
       "source": [
-        "To make this type batchable, change the base type to `BatchableExtensionType`, and adjust the shape of each field to include optional batch dimensions.  The following example also adds a `shape` field to keept track of the batch shape.  This `shape` field is not required by `tf.data.Dataset` or `tf.map_fn`, but it *is* required by `tf.Keras`."
+        "To make this type batchable, change the base type to `BatchableExtensionType`, and adjust the shape of each field to include optional batch dimensions. The following example also adds a `shape` field to keep track of the batch shape. This `shape` field is not required by `tf.data.Dataset` or `tf.map_fn`, but it *is* required by `tf.Keras`."
       ]
     },
     {
@@ -1329,7 +1329,7 @@
       "outputs": [],
       "source": [
         "class Network(tf.experimental.BatchableExtensionType):\n",
-        "  shape: tf.TensorShape  # batch shape.  A single network has shape=[].\n",
+        "  shape: tf.TensorShape  # batch shape. A single network has shape=[].\n",
         "  work: tf.Tensor        # work[*shape, n] = work left to do at node n\n",
         "  bandwidth: tf.Tensor   # bandwidth[*shape, n1, n2] = bandwidth from n1->n2\n",
         "\n",
@@ -1426,7 +1426,7 @@
         "id": "f_HLsTT02Xul"
       },
       "source": [
-        "## TensorFlow APIs that support ExtensionTypes"
+        "## TensorFlow APIs that support `ExtensionType`s"
       ]
     },
     {
@@ -1437,7 +1437,7 @@
       "source": [
         "### @tf.function\n",
         "\n",
-        "[tf.function](https://www.tensorflow.org/guide/function) is a decorator that precomputes TensorFlow graphs for Python functions, which can substantially improve the performance of your TensorFlow code. Extension type values can be used transparently with `@tf.function`-decorated functions."
+        "[`tf.function`](https://www.tensorflow.org/guide/function) is a decorator that precomputes TensorFlow graphs for Python functions, which can substantially improve the performance of your TensorFlow code. Extension type values can be used transparently with `@tf.function`-decorated functions."
       ]
     },
     {
@@ -1532,7 +1532,7 @@
       },
       "outputs": [],
       "source": [
-        "# Example: using tf.cond to select between two MaskedTensors.  Note that the\n",
+        "# Example: using tf.cond to select between two MaskedTensors. Note that the\n",
         "# two MaskedTensors don't need to have the same shape.\n",
         "a = MaskedTensor([1., 2, 3], [True, False, True])\n",
         "b = MaskedTensor([22., 33, 108, 55], [True, True, True, False])\n",
@@ -1563,7 +1563,7 @@
       "source": [
         "### Autograph control flow\n",
         "\n",
-        "Extension types are also supported by control flow statements in tf.function (using autograph).  In the following example, the `if` statement and `for` statements are automatically converted to `tf.cond` and `tf.while_loop` operations, which support extension types."
+        "Extension types are also supported by control flow statements in `tf.function` (using autograph). In the following example, the `if` statement and `for` statements are automatically converted to `tf.cond` and `tf.while_loop` operations, which support extension types."
       ]
     },
     {
@@ -1596,10 +1596,10 @@
       "source": [
         "### Keras\n",
         "\n",
-        "[tf.keras](https://www.tensorflow.org/guide/keras) is TensorFlow's high-level API for building and training deep learning models. Extension types may be passed as inputs to a Keras model, passed between Keras layers, and returned by Keras models.  Keras currently puts two requirements on extension types:\n",
+        "[tf.keras](https://www.tensorflow.org/guide/keras) is TensorFlow's high-level API for building and training deep learning models. Extension types may be passed as inputs to a Keras model, passed between Keras layers, and returned by Keras models. Keras currently puts two requirements on extension types:\n",
         "\n",
-        "* They must be batchable (see \"Batchable ExtensionTypes\" above).\n",
-        "* The must have a field or property named `shape`. `shape[0]` is assumed to be the batch dimension.\n",
+        "* They must be batchable (go to \"Batchable `ExtensionType`s\" above).\n",
+        "* They must have a field or property named `shape`. `shape[0]` is assumed to be the batch dimension.\n",
         "\n",
         "The following two subsections give examples showing how extension types can be used with Keras.\n"
       ]
@@ -1612,7 +1612,7 @@
       "source": [
         "#### Keras example: `Network`\n",
         "\n",
-        "For the first example, consider the `Network` class defined in the \"Batchable ExtensionTypes\" section above, which can be used for load balancing work between nodes.  Its definition is repeated here:"
+        "For the first example, consider the `Network` class defined in the \"Batchable `ExtensionType`s\" section above, which can be used for load balancing work between nodes. Its definition is repeated here:"
       ]
     },
     {
@@ -1624,7 +1624,7 @@
       "outputs": [],
       "source": [
         "class Network(tf.experimental.BatchableExtensionType):\n",
-        "  shape: tf.TensorShape  # batch shape.  A single network has shape=[].\n",
+        "  shape: tf.TensorShape  # batch shape. A single network has shape=[].\n",
         "  work: tf.Tensor        # work[*shape, n] = work left to do at node n\n",
         "  bandwidth: tf.Tensor   # bandwidth[*shape, n1, n2] = bandwidth from n1->n2\n",
         "\n",
@@ -1647,7 +1647,7 @@
       },
       "outputs": [],
       "source": [
-        "single_network = Network(  # A single network w/ 4 nodes.\n",
+        "single_network = Network(  # A single network with 4 nodes.\n",
         "    work=[8.0, 5, 12, 2],\n",
         "    bandwidth=[[0.0, 1, 2, 2], [1, 0, 0, 2], [2, 0, 0, 1], [2, 2, 1, 0]])\n",
         "\n",
@@ -1679,7 +1679,7 @@
         "  Shifts work from more busy nodes to less busy nodes, constrained by bandwidth.\n",
         "  \"\"\"\n",
         "  def call(self, inputs):\n",
-        "    # This function is defined above, in \"Batchable ExtensionTypes\" section.\n",
+        "    # This function is defined above in the \"Batchable `ExtensionType`s\" section.\n",
         "    return balance_work_greedy(inputs)"
       ]
     },
@@ -1689,7 +1689,7 @@
         "id": "VWwFJNb1E03q"
       },
       "source": [
-        "You can then use this layers to create a simple model.  To feed an `ExtensionType` into a model, you can use a `tf.keras.layer.Input` layer with `type_spec` set to the extension type's `TypeSpec`.  If the Keras model will be used to process batches, then the `type_spec` must include the batch dimension."
+        "You can then use these layers to create a simple model. To feed an `ExtensionType` into a model, you can use a `tf.keras.layer.Input` layer with `type_spec` set to the extension type's `TypeSpec`. If the Keras model will be used to process batches, then the `type_spec` must include the batch dimension."
       ]
     },
     {
@@ -1748,7 +1748,7 @@
       "source": [
         "#### Keras example: MaskedTensor\n",
         "\n",
-        "In this example, `MaskedTensor` is extended to support `Keras`.  `shape` is defined as a property that is calculated from the `values` field.  Keras requires thatyou add this property to both the extension type and its `TypeSpec`.  `MaskedTensor` also defines a `__name__` variable, which will be required for `SavedModel` serialization (below)."
+        "In this example, `MaskedTensor` is extended to support `Keras`. `shape` is defined as a property that is calculated from the `values` field. Keras requires that you add this property to both the extension type and its `TypeSpec`. `MaskedTensor` also defines a `__name__` variable, which will be required for `SavedModel` serialization (below)."
       ]
     },
     {
@@ -1794,7 +1794,7 @@
         "id": "oer8BVc8H7_V"
       },
       "source": [
-        "Next, the dispatch decorators are used to override the default behavior of several TensorFlow APIs.  Since these APIs are used by standard Keras layers (such as the `Dense` layer), overriding these will allow us to use those layers with `MaskedTensor`.  For the purposes of this example, `matmul` for masked tensors is defined to treat the masked values as zeros (i.e., to not include them in the product)."
+        "Next, the dispatch decorators are used to override the default behavior of several TensorFlow APIs. Since these APIs are used by standard Keras layers (such as the `Dense` layer), overriding these will allow us to use those layers with `MaskedTensor`. For the purposes of this example, `matmul` for masked tensors is defined to treat the masked values as zeros (that is, to not include them in the product)."
       ]
     },
     {
@@ -1881,7 +1881,7 @@
         "\n",
         "A [SavedModel](https://www.tensorflow.org/guide/saved_model) is a serialized TensorFlow program, including both weights and computation. It can be built from a Keras model or from a custom model. In either case, extension types can be used transparently with the functions and methods defined by a SavedModel.\n",
         "\n",
-        "SavedModel can save models, layers, and functions that process extension types, as long as the extension types have a `__name__` field.  This name is used to register the extension type, so it can be located when the model is loaded."
+        "SavedModel can save models, layers, and functions that process extension types, as long as the extension types have a `__name__` field. This name is used to register the extension type, so it can be located when the model is loaded."
       ]
     },
     {
@@ -1954,9 +1954,9 @@
         "id": "o6beljh576ee"
       },
       "source": [
-        "#### Loading a SavedModel when the ExtensionType is unavailable\n",
+        "#### Loading a SavedModel when the `ExtensionType` is unavailable\n",
         "\n",
-        "If you load a `SavedModel` that uses an `ExtensionType`, but that `ExtensionType` is not available (i.e., has not been imported), then you will see a warning and TensorFlow will fall back to using an \"anonymous extension type\" object.  This object will have the same fields as the original type, but will lack any further customization you have added for the type, such as custom methods or properties."
+        "If you load a `SavedModel` that uses an `ExtensionType`, but that `ExtensionType` is not available (that is, it has not been imported), then you will get a warning and TensorFlow will fall back to using an \"anonymous extension type\" object. This object will have the same fields as the original type, but will lack any further customization you have added for the type, such as custom methods or properties."
       ]
     },
     {
@@ -1965,9 +1965,9 @@
         "id": "ec9PcUkJ9bFK"
       },
       "source": [
-        "#### Using ExtensionTypes with TensorFlow serving\n",
+        "#### Using `ExtensionType`s with TensorFlow Serving\n",
         "\n",
-        "Currently, [TensorFlow serving](https://www.tensorflow.org/tfx/guide/serving) (and other consumers of the SavedModel \"signatures\" dictionary) require that all inputs and outputs be raw tensors.  If you wish to use TensorFlow serving with a model that uses extension types, then you can add wrapper methods that compose or decompose extension type values from tensors.  E.g.:"
+        "Currently, [TensorFlow Serving](https://www.tensorflow.org/tfx/guide/serving) (and other consumers of the SavedModel \"signatures\" dictionary) require that all inputs and outputs be raw tensors. If you wish to use TensorFlow Serving with a model that uses extension types, then you can add wrapper methods that compose or decompose extension type values from tensors. For example:"
       ]
     },
     {
@@ -2012,9 +2012,9 @@
         "id": "4dwBadWQ5G9_"
       },
       "source": [
-        "### Datasets\n",
+        "### `Dataset`s\n",
         "\n",
-        "[tf.data](https://www.tensorflow.org/guide/data) is an API that enables you to build complex input pipelines from simple, reusable pieces.  Its core data structure is `tf.data.Dataset`, which represents a sequence of elements, in which each element consists of one or more components."
+        "[`tf.data`](https://www.tensorflow.org/guide/data) is an API that enables you to build complex input pipelines from simple, reusable pieces. Its core data structure is `tf.data.Dataset`, which represents a sequence of elements, in which each element consists of one or more components."
       ]
     },
     {
@@ -2023,7 +2023,7 @@
         "id": "GcIR19FuwRJV"
       },
       "source": [
-        "#### Building Datasets with extension types\n",
+        "#### Building `Dataset`s with extension types\n",
         "\n",
         "Datasets can be built from extension type values using `Dataset.from_tensors`, `Dataset.from_tensor_slices`, or `Dataset.from_generator`:"
       ]
@@ -2078,9 +2078,9 @@
         "id": "wfEm4NInyqtj"
       },
       "source": [
-        "#### Batching and unbatching Datasets with extension types\n",
+        "#### Batching and unbatching `Dataset`s with extension types\n",
         "\n",
-        "Datasets with extension types can be batchand and unbatched using `Dataset.batch` adn `Dataset.unbatch`."
+        "Datasets with extension types can be batchand and unbatched using `Dataset.batch` and `Dataset.unbatch`."
       ]
     },
     {

--- a/site/en/guide/extension_type.ipynb
+++ b/site/en/guide/extension_type.ipynb
@@ -407,9 +407,9 @@
       "source": [
         "### Validation method\n",
         "\n",
-        "`ExtensionType` adds a `__validate__` method, which can be overriden to perform validation checks on fields.  It is run after the constructor is called, and after fields have been type-checked and converted to their declared types, so it can assume that all fields have their declared types.\n",
+        "`ExtensionType` adds a `__validate__` method, which can be overridden to perform validation checks on fields.  It is run after the constructor is called, and after fields have been type-checked and converted to their declared types, so it can assume that all fields have their declared types.\n",
         "\n",
-        "he following example updates `MaskedTensor` to validate the `shape`s and `dtype`s of its fields:"
+        "The following example updates `MaskedTensor` to validate the `shape`s and `dtype`s of its fields:"
       ]
     },
     {


### PR DESCRIPTION
Typo fix `overriden` to `overridden` & `he` to `the`