### PR TITLE
Format tf.data.dataset in music generation tutorial, lint the doc

### DIFF
--- a/site/en/tutorials/audio/music_generation.ipynb
+++ b/site/en/tutorials/audio/music_generation.ipynb
@@ -680,7 +680,7 @@
         "id": "xIBLvj-cODWS"
       },
       "source": [
-        "Next, create a [tf.data.Dataset](https://www.tensorflow.org/api_docs/python/tf/data/Dataset) from the parsed notes."
+        "Next, create a `tf.data.Dataset` from the parsed notes."
       ]
     },
     {

--- a/site/en/tutorials/audio/music_generation.ipynb
+++ b/site/en/tutorials/audio/music_generation.ipynb
@@ -68,9 +68,9 @@
         "id": "hr78EkAY-FFg"
       },
       "source": [
-        "This tutorial shows you how to generate musical notes using a simple RNN. You will train a model using a collection of piano MIDI files from the [MAESTRO dataset](https://magenta.tensorflow.org/datasets/maestro). Given a sequence of notes, your model will learn to predict the next note in the sequence. You can generate a longer sequences of notes by calling the model repeatedly.\n",
+        "This tutorial shows you how to generate musical notes using a simple recurrent neural network (RNN). You will train a model using a collection of piano MIDI files from the [MAESTRO dataset](https://magenta.tensorflow.org/datasets/maestro). Given a sequence of notes, your model will learn to predict the next note in the sequence. You can generate longer sequences of notes by calling the model repeatedly.\n",
         "\n",
-        "This tutorial contains complete code to parse and create MIDI files. You can learn more about how RNNs work by visiting [Text generation with an RNN](https://www.tensorflow.org/text/tutorials/text_generation)."
+        "This tutorial contains complete code to parse and create MIDI files. You can learn more about how RNNs work by visiting the [Text generation with an RNN](https://www.tensorflow.org/text/tutorials/text_generation) tutorial."
       ]
     },
     {
@@ -713,7 +713,7 @@
         "id": "Sj9SXRCjt3I7"
       },
       "source": [
-        "You will train the model on batches of sequences of notes. Each example will consist of a sequence of notes as the input features, and next note as the label. In this way, the model will be trained to predict the next note in a sequence. You can find a diagram explaining this process (and more details) in [Text classification with an RNN](https://www.tensorflow.org/text/tutorials/text_generation).\n",
+        "You will train the model on batches of sequences of notes. Each example will consist of a sequence of notes as the input features, and the next note as the label. In this way, the model will be trained to predict the next note in a sequence. You can find a diagram describing this process (and more details) in [Text classification with an RNN](https://www.tensorflow.org/text/tutorials/text_generation).\n",
         "\n",
         "You can use the handy [window](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#window) function with size `seq_length` to create the features and labels in this format."
       ]
@@ -1056,7 +1056,7 @@
       "source": [
         "To use the model to generate notes, you will first need to provide a starting sequence of notes. The function below generates one note from a sequence of notes. \n",
         "\n",
-        "For note pitch, it draws a sample from softmax distribution of notes produced by the model, and does not simply pick the note with the highest probability.\n",
+        "For note pitch, it draws a sample from the softmax distribution of notes produced by the model, and does not simply pick the note with the highest probability.\n",
         "Always picking the note with the highest probability would lead to repetitive sequences of notes being generated.\n",
         "\n",
         "The `temperature` parameter can be used to control the randomness of notes generated. You can find more details on temperature in [Text generation with an RNN](https://www.tensorflow.org/text/tutorials/text_generation)."
@@ -1229,7 +1229,7 @@
       "source": [
         "In the above plots, you will notice the change in distribution of the note variables.\n",
         "Since there is a feedback loop between the model's outputs and inputs, the model tends to generate similar sequences of outputs to reduce the loss. \n",
-        "This is particularly relevant for `step` and `duration`, which has uses MSE loss.\n",
+        "This is particularly relevant for `step` and `duration`, which uses the MSE loss.\n",
         "For `pitch`, you can increase the randomness by increasing the `temperature` in `predict_next_note`.\n"
       ]
     },
@@ -1243,7 +1243,7 @@
         "\n",
         "This tutorial demonstrated the mechanics of using an RNN to generate sequences of notes from a dataset of MIDI files. To learn more, you can visit the closely related [Text generation with an RNN](https://www.tensorflow.org/text/tutorials/text_generation) tutorial, which contains additional diagrams and explanations. \n",
         "\n",
-        "An alternative to using RNNs for music generation is using GANs. Rather than generating audio, a GAN-based approach can generate a entire sequence in parallel. The Magenta team has done impressive work on this approach with [GANSynth](https://magenta.tensorflow.org/gansynth). You can also find many wonderful music and art projects and open-source code on [Magenta project website](https://magenta.tensorflow.org/)."
+        "One of the alternatives to using RNNs for music generation is using GANs. Rather than generating audio, a GAN-based approach can generate an entire sequence in parallel. The Magenta team has done impressive work on this approach with [GANSynth](https://magenta.tensorflow.org/gansynth). You can also find many wonderful music and art projects and open-source code on [Magenta project website](https://magenta.tensorflow.org/)."
       ]
     }
   ],

--- a/site/en/tutorials/audio/music_generation.ipynb
+++ b/site/en/tutorials/audio/music_generation.ipynb
@@ -680,7 +680,7 @@
         "id": "xIBLvj-cODWS"
       },
       "source": [
-        "Next, create a [tf.data.Dataset](https://www.tensorflow.org/datasets) from the parsed notes."
+        "Next, create a [tf.data.Dataset](https://www.tensorflow.org/api_docs/python/tf/data/Dataset) from the parsed notes."
       ]
     },
     {


### PR DESCRIPTION
I have updated the tf.data.dataset link with the correct URL path(https://www.tensorflow.org/api_docs/python/tf/data/Dataset). Earlier this link was routing to tensorflow datasets page.