### PR TITLE
Updated correct link for model subclassing API

### DIFF
--- a/site/en/tutorials/quickstart/advanced.ipynb
+++ b/site/en/tutorials/quickstart/advanced.ipynb
@@ -165,7 +165,7 @@
         "id": "BPZ68wASog_I"
       },
       "source": [
-        "Build the `tf.keras` model using the Keras [model subclassing API](https://www.tensorflow.org/guide/keras#model_subclassing):"
+        "Build the `tf.keras` model using the Keras [model subclassing API](https://www.tensorflow.org/guide/keras/custom_layers_and_models#the_model_class):"
       ]
     },
     {


### PR DESCRIPTION
The old link was routing to `the Sequential model` page which was not relevant, so updated the model subclassing API link with the exact page.