### PR TITLE
Fixed typo in generate_training_data

### DIFF
--- a/site/en/tutorials/text/word2vec.ipynb
+++ b/site/en/tutorials/text/word2vec.ipynb
@@ -1,1441 +1,1454 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "hX4n9TsbGw-f"
-      },
-      "source": [
-        "##### Copyright 2020 The TensorFlow Authors."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "id": "0nbI5DtDGw-i"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "AOpGoE2T-YXS"
-      },
-      "source": [
-        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/text/word2vec\">\n",
-        "    <img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />\n",
-        "    View on TensorFlow.org</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/text/word2vec.ipynb\">\n",
-        "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />\n",
-        "    Run in Google Colab</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/text/word2vec.ipynb\">\n",
-        "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
-        "    View source on GitHub</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/text/word2vec.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
-        "  </td>\n",
-        "</table>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "haJUNjSB60Kh"
-      },
-      "source": [
-        "# word2vec"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "99d4ky2lWFvn"
-      },
-      "source": [
-        "word2vec is not a singular algorithm, rather, it is a family of model architectures and optimizations that can be used to learn word embeddings from large datasets. Embeddings learned through word2vec have proven to be successful on a variety of downstream natural language processing tasks.\n",
-        "\n",
-        "Note: This tutorial is based on [Efficient estimation of word representations in vector space](https://arxiv.org/pdf/1301.3781.pdf) and [Distributed representations of words and phrases and their compositionality](https://papers.nips.cc/paper/5021-distributed-representations-of-words-and-phrases-and-their-compositionality.pdf). It is not an exact implementation of the papers. Rather, it is intended to illustrate the key ideas.\n",
-        "\n",
-        "These papers proposed two methods for learning representations of words:\n",
-        "\n",
-        "*   **Continuous bag-of-words model**: predicts the middle word based on surrounding context words. The context consists of a few words before and after the current (middle) word. This architecture is called a bag-of-words model as the order of words in the context is not important.\n",
-        "*   **Continuous skip-gram model**: predicts words within a certain range before and after the current word in the same sentence. A worked example of this is given below.\n",
-        "\n",
-        "You'll use the skip-gram approach in this tutorial. First, you'll explore skip-grams and other concepts using a single sentence for illustration. Next, you'll train your own word2vec model on a small dataset. This tutorial also contains code to export the trained embeddings and visualize them in the [TensorFlow Embedding Projector](http://projector.tensorflow.org/).\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xP00WlaMWBZC"
-      },
-      "source": [
-        "## Skip-gram and negative sampling "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Zr2wjv0bW236"
-      },
-      "source": [
-        "While a bag-of-words model predicts a word given the neighboring context, a skip-gram model predicts the context (or neighbors) of a word, given the word itself. The model is trained on skip-grams, which are n-grams that allow tokens to be skipped (see the diagram below for an example). The context of a word can be represented through a set of skip-gram pairs of `(target_word, context_word)` where `context_word` appears in the neighboring context of `target_word`. "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ICjc-McbaVTd"
-      },
-      "source": [
-        "Consider the following sentence of eight words:\n",
-        "\n",
-        "> The wide road shimmered in the hot sun.\n",
-        "\n",
-        "The context words for each of the 8 words of this sentence are defined by a window size. The window size determines the span of words on either side of a `target_word` that can be considered a `context word`. Below is a table of skip-grams for target words based on different window sizes."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YKE87IKT_YT8"
-      },
-      "source": [
-        "Note: For this tutorial, a window size of `n` implies n words on each side with a total window span of 2*n+1 words across a word."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "RsCwQ07E8mqU"
-      },
-      "source": [
-        "![word2vec_skipgrams](https://tensorflow.org/tutorials/text/images/word2vec_skipgram.png)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gK1gN1jwkMpU"
-      },
-      "source": [
-        "The training objective of the skip-gram model is to maximize the probability of predicting context words given the target word. For a sequence of words *w<sub>1</sub>, w<sub>2</sub>, ... w<sub>T</sub>*, the objective can be written as the average log probability"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pILO_iAc84e-"
-      },
-      "source": [
-        "![word2vec_skipgram_objective](https://tensorflow.org/tutorials/text/images/word2vec_skipgram_objective.png)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Gsy6TUbtnz_K"
-      },
-      "source": [
-        "where `c` is the size of the training context. The basic skip-gram formulation defines this probability using the softmax function."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "P81Qavbb9APd"
-      },
-      "source": [
-        "![word2vec_full_softmax](https://tensorflow.org/tutorials/text/images/word2vec_full_softmax.png)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "axZvd-hhotVB"
-      },
-      "source": [
-        "where *v* and *v<sup>'<sup>* are target and context vector representations of words and *W* is vocabulary size. "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "SoLzxbqSpT6_"
-      },
-      "source": [
-        "Computing the denominator of this formulation involves performing a full softmax over the entire vocabulary words, which are often large (10<sup>5</sup>-10<sup>7</sup>) terms."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Y5VWYtmFzHkU"
-      },
-      "source": [
-        "The [noise contrastive estimation](https://www.tensorflow.org/api_docs/python/tf/nn/nce_loss) (NCE) loss function is an efficient approximation for a full softmax. With an objective to learn word embeddings instead of modeling the word distribution, the NCE loss can be [simplified](https://papers.nips.cc/paper/5021-distributed-representations-of-words-and-phrases-and-their-compositionality.pdf) to use negative sampling. "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WTZBPf1RsOsg"
-      },
-      "source": [
-        "The simplified negative sampling objective for a target word is to distinguish  the context word from `num_ns` negative samples drawn from noise distribution *P<sub>n</sub>(w)* of words. More precisely, an efficient approximation of full softmax over the vocabulary is, for a skip-gram pair, to pose the loss for a target word as a classification problem between the context word and `num_ns` negative samples. "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Cl0rSfHjt6Mf"
-      },
-      "source": [
-        "A negative sample is defined as a `(target_word, context_word)` pair such that the `context_word` does not appear in the `window_size` neighborhood of the `target_word`. For the example sentence, these are a few potential negative samples (when `window_size` is `2`).\n",
-        "\n",
-        "```\n",
-        "(hot, shimmered)\n",
-        "(wide, hot)\n",
-        "(wide, sun)\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "kq0q2uqbucFg"
-      },
-      "source": [
-        "In the next section, you'll generate skip-grams and negative samples for a single sentence. You'll also learn about subsampling techniques and train a classification model for positive and negative training examples later in the tutorial."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mk4-Hpe1CH16"
-      },
-      "source": [
-        "## Setup"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "RutaI-Tpev3T"
-      },
-      "outputs": [],
-      "source": [
-        "import io\n",
-        "import re\n",
-        "import string\n",
-        "import tqdm\n",
-        "\n",
-        "import numpy as np\n",
-        "\n",
-        "import tensorflow as tf\n",
-        "from tensorflow.keras import layers"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "10pyUMFkGKVQ"
-      },
-      "outputs": [],
-      "source": [
-        "# Load the TensorBoard notebook extension\n",
-        "%load_ext tensorboard"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "XkJ5299Tek6B"
-      },
-      "outputs": [],
-      "source": [
-        "SEED = 42\n",
-        "AUTOTUNE = tf.data.AUTOTUNE"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "RW-g5buCHwh3"
-      },
-      "source": [
-        "### Vectorize an example sentence"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "y8TfZIgoQrcP"
-      },
-      "source": [
-        "Consider the following sentence:\n",
-        "\n",
-        "> The wide road shimmered in the hot sun.\n",
-        "\n",
-        "Tokenize the sentence:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "bsl7jBzV6_KK"
-      },
-      "outputs": [],
-      "source": [
-        "sentence = \"The wide road shimmered in the hot sun\"\n",
-        "tokens = list(sentence.lower().split())\n",
-        "print(len(tokens))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "PU-bs1XtThEw"
-      },
-      "source": [
-        "Create a vocabulary to save mappings from tokens to integer indices:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "UdYv1HJUQ8XA"
-      },
-      "outputs": [],
-      "source": [
-        "vocab, index = {}, 1  # start indexing from 1\n",
-        "vocab['<pad>'] = 0  # add a padding token\n",
-        "for token in tokens:\n",
-        "  if token not in vocab:\n",
-        "    vocab[token] = index\n",
-        "    index += 1\n",
-        "vocab_size = len(vocab)\n",
-        "print(vocab)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ZpuP43Dddasr"
-      },
-      "source": [
-        "Create an inverse vocabulary to save mappings from integer indices to tokens:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "o9ULAJYtEvKl"
-      },
-      "outputs": [],
-      "source": [
-        "inverse_vocab = {index: token for token, index in vocab.items()}\n",
-        "print(inverse_vocab)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "n3qtuyxIRyii"
-      },
-      "source": [
-        "Vectorize your sentence:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "CsB3-9uQQYyl"
-      },
-      "outputs": [],
-      "source": [
-        "example_sequence = [vocab[word] for word in tokens]\n",
-        "print(example_sequence)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ox1I28JRIOdM"
-      },
-      "source": [
-        "### Generate skip-grams from one sentence"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "t7NNKAmSiHvy"
-      },
-      "source": [
-        "The `tf.keras.preprocessing.sequence` module provides useful functions that simplify data preparation for word2vec. You can use the `tf.keras.preprocessing.sequence.skipgrams` to generate skip-gram pairs from the `example_sequence` with a given `window_size` from tokens in the range `[0, vocab_size)`.\n",
-        "\n",
-        "Note: `negative_samples` is set to `0` here, as batching negative samples generated by this function requires a bit of code. You will use another function to perform negative sampling in the next section."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "USAJxW4RD7pn"
-      },
-      "outputs": [],
-      "source": [
-        "window_size = 2\n",
-        "positive_skip_grams, _ = tf.keras.preprocessing.sequence.skipgrams(\n",
-        "      example_sequence,\n",
-        "      vocabulary_size=vocab_size,\n",
-        "      window_size=window_size,\n",
-        "      negative_samples=0)\n",
-        "print(len(positive_skip_grams))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "uc9uhiMwY-AQ"
-      },
-      "source": [
-        "Print a few positive skip-grams:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "SCnqEukIE9pt"
-      },
-      "outputs": [],
-      "source": [
-        "for target, context in positive_skip_grams[:5]:\n",
-        "  print(f\"({target}, {context}): ({inverse_vocab[target]}, {inverse_vocab[context]})\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_ua9PkMTISF0"
-      },
-      "source": [
-        "### Negative sampling for one skip-gram "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Esqn8WBfZnEK"
-      },
-      "source": [
-        "The `skipgrams` function returns all positive skip-gram pairs by sliding over a given window span. To produce additional skip-gram pairs that would serve as negative samples for training, you need to sample random words from the vocabulary. Use the `tf.random.log_uniform_candidate_sampler` function to sample `num_ns` number of negative samples for a given target word in a window. You can call the function on one skip-grams's target word and pass the context word as true class to exclude it from being sampled.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "AgH3aSvw3xTD"
-      },
-      "source": [
-        "Key point: `num_ns` (the number of negative samples per a positive context word) in the `[5, 20]` range is [shown to work](https://papers.nips.cc/paper/5021-distributed-representations-of-words-and-phrases-and-their-compositionality.pdf) best for smaller datasets, while `num_ns` in the `[2, 5]` range suffices for larger datasets."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "m_LmdzqIGr5L"
-      },
-      "outputs": [],
-      "source": [
-        "# Get target and context words for one positive skip-gram.\n",
-        "target_word, context_word = positive_skip_grams[0]\n",
-        "\n",
-        "# Set the number of negative samples per positive context.\n",
-        "num_ns = 4\n",
-        "\n",
-        "context_class = tf.reshape(tf.constant(context_word, dtype=\"int64\"), (1, 1))\n",
-        "negative_sampling_candidates, _, _ = tf.random.log_uniform_candidate_sampler(\n",
-        "    true_classes=context_class,  # class that should be sampled as 'positive'\n",
-        "    num_true=1,  # each positive skip-gram has 1 positive context class\n",
-        "    num_sampled=num_ns,  # number of negative context words to sample\n",
-        "    unique=True,  # all the negative samples should be unique\n",
-        "    range_max=vocab_size,  # pick index of the samples from [0, vocab_size]\n",
-        "    seed=SEED,  # seed for reproducibility\n",
-        "    name=\"negative_sampling\"  # name of this operation\n",
-        ")\n",
-        "print(negative_sampling_candidates)\n",
-        "print([inverse_vocab[index.numpy()] for index in negative_sampling_candidates])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8MSxWCrLIalp"
-      },
-      "source": [
-        "### Construct one training example"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Q6uEWdj8vKKv"
-      },
-      "source": [
-        "For a given positive `(target_word, context_word)` skip-gram, you now also have `num_ns` negative sampled context words that do not appear in the window size neighborhood of `target_word`. Batch the `1` positive `context_word` and `num_ns` negative context words into one tensor. This produces a set of positive skip-grams (labeled as `1`) and negative samples (labeled as `0`) for each target word."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "zSiZwifuLvHf"
-      },
-      "outputs": [],
-      "source": [
-        "# Add a dimension so you can use concatenation (in the next step).\n",
-        "negative_sampling_candidates = tf.expand_dims(negative_sampling_candidates, 1)\n",
-        "\n",
-        "# Concatenate a positive context word with negative sampled words.\n",
-        "context = tf.concat([context_class, negative_sampling_candidates], 0)\n",
-        "\n",
-        "# Label the first context word as `1` (positive) followed by `num_ns` `0`s (negative).\n",
-        "label = tf.constant([1] + [0]*num_ns, dtype=\"int64\")\n",
-        "\n",
-        "# Reshape the target to shape `(1,)` and context and label to `(num_ns+1,)`.\n",
-        "target = tf.squeeze(target_word)\n",
-        "context = tf.squeeze(context)\n",
-        "label = tf.squeeze(label)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "OIJeoFCAwtXJ"
-      },
-      "source": [
-        "Check out the context and the corresponding labels for the target word from the skip-gram example above:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "tzyCPCuZwmdL"
-      },
-      "outputs": [],
-      "source": [
-        "print(f\"target_index    : {target}\")\n",
-        "print(f\"target_word     : {inverse_vocab[target_word]}\")\n",
-        "print(f\"context_indices : {context}\")\n",
-        "print(f\"context_words   : {[inverse_vocab[c.numpy()] for c in context]}\")\n",
-        "print(f\"label           : {label}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gBtTcUVQr8EO"
-      },
-      "source": [
-        "A tuple of `(target, context, label)` tensors constitutes one training example for training your skip-gram negative sampling word2vec model. Notice that the target is of shape `(1,)` while the context and label are of shape `(1+num_ns,)`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "x-FwkR8jx9-Z"
-      },
-      "outputs": [],
-      "source": [
-        "print(\"target  :\", target)\n",
-        "print(\"context :\", context)\n",
-        "print(\"label   :\", label)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4bRJIlow4Dlv"
-      },
-      "source": [
-        "### Summary"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pWkuha0oykG5"
-      },
-      "source": [
-        "This diagram summarizes the procedure of generating a training example from a sentence:\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_KlwdiAa9crJ"
-      },
-      "source": [
-        "![word2vec_negative_sampling](https://tensorflow.org/tutorials/text/images/word2vec_negative_sampling.png)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "37e53f07f67c"
-      },
-      "source": [
-        "Notice that the words `temperature` and `code` are not part of the input sentence. They belong to the vocabulary like certain other indices used in the diagram above."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9wmdO_MEIpaM"
-      },
-      "source": [
-        "## Compile all steps into one function\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "iLKwNAczHsKg"
-      },
-      "source": [
-        "### Skip-gram sampling table "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TUUK3uDtFNFE"
-      },
-      "source": [
-        "A large dataset means larger vocabulary with higher number of more frequent words such as stopwords. Training examples obtained from sampling commonly occurring words (such as `the`, `is`, `on`) don't add much useful information  for the model to learn from. [Mikolov et al.](https://papers.nips.cc/paper/5021-distributed-representations-of-words-and-phrases-and-their-compositionality.pdf) suggest subsampling of frequent words as a helpful practice to improve embedding quality. "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bPtbv7zNP7Dx"
-      },
-      "source": [
-        "The `tf.keras.preprocessing.sequence.skipgrams` function accepts a sampling table argument to encode probabilities of sampling any token. You can use the `tf.keras.preprocessing.sequence.make_sampling_table` to  generate a word-frequency rank based probabilistic sampling table and pass it to the `skipgrams` function. Inspect the sampling probabilities for a `vocab_size` of 10."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Rn9zAnDccyRg"
-      },
-      "outputs": [],
-      "source": [
-        "sampling_table = tf.keras.preprocessing.sequence.make_sampling_table(size=10)\n",
-        "print(sampling_table)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EHvSptcPk5fp"
-      },
-      "source": [
-        "`sampling_table[i]` denotes the probability of sampling the i-th most common word in a dataset. The function assumes a [Zipf's distribution](https://en.wikipedia.org/wiki/Zipf%27s_law) of the word frequencies for sampling."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mRHMssMmHgH-"
-      },
-      "source": [
-        "Key point: The `tf.random.log_uniform_candidate_sampler` already assumes that the vocabulary frequency follows a log-uniform (Zipf's) distribution. Using these distribution weighted sampling also helps approximate the Noise Contrastive Estimation (NCE) loss with simpler loss functions for training a negative sampling objective."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aj--8RFK6fgW"
-      },
-      "source": [
-        "### Generate training data"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dy5hl4lQ0B2M"
-      },
-      "source": [
-        "Compile all the steps described above into a function that can be called on a list of vectorized sentences obtained from any text dataset. Notice that the sampling table is built before sampling skip-gram word pairs. You will use this function in the later sections."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "63INISDEX1Hu"
-      },
-      "outputs": [],
-      "source": [
-        "# Generates skip-gram pairs with negative sampling for a list of sequences\n",
-        "# (int-encoded sentences) based on window size, number of negative samples\n",
-        "# and vocabulary size.\n",
-        "def generate_training_data(sequences, window_size, num_ns, vocab_size, seed):\n",
-        "  # Elements of each training example are appended to these lists.\n",
-        "  targets, contexts, labels = [], [], []\n",
-        "\n",
-        "  # Build the sampling table for `vocab_size` tokens.\n",
-        "  sampling_table = tf.keras.preprocessing.sequence.make_sampling_table(vocab_size)\n",
-        "\n",
-        "  # Iterate over all sequences (sentences) in the dataset.\n",
-        "  for sequence in tqdm.tqdm(sequences):\n",
-        "\n",
-        "    # Generate positive skip-gram pairs for a sequence (sentence).\n",
-        "    positive_skip_grams, _ = tf.keras.preprocessing.sequence.skipgrams(\n",
-        "          sequence,\n",
-        "          vocabulary_size=vocab_size,\n",
-        "          sampling_table=sampling_table,\n",
-        "          window_size=window_size,\n",
-        "          negative_samples=0)\n",
-        "\n",
-        "    # Iterate over each positive skip-gram pair to produce training examples\n",
-        "    # with a positive context word and negative samples.\n",
-        "    for target_word, context_word in positive_skip_grams:\n",
-        "      context_class = tf.expand_dims(\n",
-        "          tf.constant([context_word], dtype=\"int64\"), 1)\n",
-        "      negative_sampling_candidates, _, _ = tf.random.log_uniform_candidate_sampler(\n",
-        "          true_classes=context_class,\n",
-        "          num_true=1,\n",
-        "          num_sampled=num_ns,\n",
-        "          unique=True,\n",
-        "          range_max=vocab_size,\n",
-        "          seed=SEED,\n",
-        "          name=\"negative_sampling\")\n",
-        "\n",
-        "      # Build context and label vectors (for one target word)\n",
-        "      negative_sampling_candidates = tf.expand_dims(\n",
-        "          negative_sampling_candidates, 1)\n",
-        "\n",
-        "      context = tf.concat([context_class, negative_sampling_candidates], 0)\n",
-        "      label = tf.constant([1] + [0]*num_ns, dtype=\"int64\")\n",
-        "\n",
-        "      # Append each element from the training example to global lists.\n",
-        "      targets.append(target_word)\n",
-        "      contexts.append(context)\n",
-        "      labels.append(label)\n",
-        "\n",
-        "  return targets, contexts, labels"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "shvPC8Ji2cMK"
-      },
-      "source": [
-        "## Prepare training data for word2vec"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "j5mbZsZu6uKg"
-      },
-      "source": [
-        "With an understanding of how to work with one sentence for a skip-gram negative sampling based word2vec model, you can proceed to generate training examples from a larger list of sentences!"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "OFlikI6L26nh"
-      },
-      "source": [
-        "### Download text corpus\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rEFavOgN98al"
-      },
-      "source": [
-        "You will use a text file of Shakespeare's writing for this tutorial. Change the following line to run this code on your own data."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "QFkitxzVVaAi"
-      },
-      "outputs": [],
-      "source": [
-        "path_to_file = tf.keras.utils.get_file('shakespeare.txt', 'https://storage.googleapis.com/download.tensorflow.org/data/shakespeare.txt')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sOsbLq8a37dr"
-      },
-      "source": [
-        "Read the text from the file and print the first few lines: "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "lfgnsUw3ofMD"
-      },
-      "outputs": [],
-      "source": [
-        "with open(path_to_file) as f:\n",
-        "  lines = f.read().splitlines()\n",
-        "for line in lines[:20]:\n",
-        "  print(line)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gTNZYqUs5C2V"
-      },
-      "source": [
-        "Use the non empty lines to construct a `tf.data.TextLineDataset` object for the next steps:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ViDrwy-HjAs9"
-      },
-      "outputs": [],
-      "source": [
-        "text_ds = tf.data.TextLineDataset(path_to_file).filter(lambda x: tf.cast(tf.strings.length(x), bool))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vfsc88zE9upk"
-      },
-      "source": [
-        "### Vectorize sentences from the corpus"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XfgZo8zR94KK"
-      },
-      "source": [
-        "You can use the `TextVectorization` layer to vectorize sentences from the corpus. Learn more about using this layer in this [Text classification](https://www.tensorflow.org/tutorials/keras/text_classification) tutorial. Notice from the first few sentences above that the text needs to be in one case and punctuation needs to be removed. To do this, define a `custom_standardization function` that can be used in the TextVectorization layer."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2MlsXzo-ZlfK"
-      },
-      "outputs": [],
-      "source": [
-        "# Now, create a custom standardization function to lowercase the text and\n",
-        "# remove punctuation.\n",
-        "def custom_standardization(input_data):\n",
-        "  lowercase = tf.strings.lower(input_data)\n",
-        "  return tf.strings.regex_replace(lowercase,\n",
-        "                                  '[%s]' % re.escape(string.punctuation), '')\n",
-        "\n",
-        "\n",
-        "# Define the vocabulary size and the number of words in a sequence.\n",
-        "vocab_size = 4096\n",
-        "sequence_length = 10\n",
-        "\n",
-        "# Use the `TextVectorization` layer to normalize, split, and map strings to\n",
-        "# integers. Set the `output_sequence_length` length to pad all samples to the\n",
-        "# same length.\n",
-        "vectorize_layer = layers.TextVectorization(\n",
-        "    standardize=custom_standardization,\n",
-        "    max_tokens=vocab_size,\n",
-        "    output_mode='int',\n",
-        "    output_sequence_length=sequence_length)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "g92LuvnyBmz1"
-      },
-      "source": [
-        "Call `TextVectorization.adapt` on the text dataset to create vocabulary.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "seZau_iYMPFT"
-      },
-      "outputs": [],
-      "source": [
-        "vectorize_layer.adapt(text_ds.batch(1024))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jg2z7eeHMnH-"
-      },
-      "source": [
-        "Once the state of the layer has been adapted to represent the text corpus, the vocabulary can be accessed with `TextVectorization.get_vocabulary`. This function returns a list of all vocabulary tokens sorted (descending) by their frequency."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "jgw9pTA7MRaU"
-      },
-      "outputs": [],
-      "source": [
-        "# Save the created vocabulary for reference.\n",
-        "inverse_vocab = vectorize_layer.get_vocabulary()\n",
-        "print(inverse_vocab[:20])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "DOQ30Tx6KA2G"
-      },
-      "source": [
-        "The `vectorize_layer` can now be used to generate vectors for each element in the `text_ds` (a `tf.data.Dataset`). Apply `Dataset.batch`, `Dataset.prefetch`, `Dataset.map`, and `Dataset.unbatch`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "yUVYrDp0araQ"
-      },
-      "outputs": [],
-      "source": [
-        "# Vectorize the data in text_ds.\n",
-        "text_vector_ds = text_ds.batch(1024).prefetch(AUTOTUNE).map(vectorize_layer).unbatch()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7YyH_SYzB72p"
-      },
-      "source": [
-        "### Obtain sequences from the dataset"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NFUQLX0_KaRC"
-      },
-      "source": [
-        "You now have a `tf.data.Dataset` of integer encoded sentences. To prepare the dataset for training a word2vec model, flatten the dataset into a list of sentence vector sequences. This step is required as you would iterate over each sentence in the dataset to produce positive and negative examples.\n",
-        "\n",
-        "Note: Since the `generate_training_data()` defined earlier uses non-TensorFlow Python/NumPy functions, you could also use a `tf.py_function` or `tf.numpy_function` with `tf.data.Dataset.map`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "sGXoOh9y11pM"
-      },
-      "outputs": [],
-      "source": [
-        "sequences = list(text_vector_ds.as_numpy_iterator())\n",
-        "print(len(sequences))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tDc4riukLTqg"
-      },
-      "source": [
-        "Inspect a few examples from `sequences`:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "WZf1RIbB2Dfb"
-      },
-      "outputs": [],
-      "source": [
-        "for seq in sequences[:5]:\n",
-        "  print(f\"{seq} => {[inverse_vocab[i] for i in seq]}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "yDzSOjNwCWNh"
-      },
-      "source": [
-        "### Generate training examples from sequences"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BehvYr-nEKyY"
-      },
-      "source": [
-        "`sequences` is now a list of int encoded sentences. Just call the `generate_training_data` function defined earlier to generate training examples for the word2vec model. To recap, the function iterates over each word from each sequence to collect positive and negative context words. Length of target, contexts and labels should be the same, representing the total number of training examples."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "44DJ22M6nX5o"
-      },
-      "outputs": [],
-      "source": [
-        "targets, contexts, labels = generate_training_data(\n",
-        "    sequences=sequences,\n",
-        "    window_size=2,\n",
-        "    num_ns=4,\n",
-        "    vocab_size=vocab_size,\n",
-        "    seed=SEED)\n",
-        "\n",
-        "targets = np.array(targets)\n",
-        "contexts = np.array(contexts)[:,:,0]\n",
-        "labels = np.array(labels)\n",
-        "\n",
-        "print('\\n')\n",
-        "print(f\"targets.shape: {targets.shape}\")\n",
-        "print(f\"contexts.shape: {contexts.shape}\")\n",
-        "print(f\"labels.shape: {labels.shape}\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "97PqsusOFEpc"
-      },
-      "source": [
-        "### Configure the dataset for performance"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7jnFVySViQTj"
-      },
-      "source": [
-        "To perform efficient batching for the potentially large number of training examples, use the `tf.data.Dataset` API. After this step, you would have a `tf.data.Dataset` object of `(target_word, context_word), (label)` elements to train your word2vec model!"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "nbu8PxPSnVY2"
-      },
-      "outputs": [],
-      "source": [
-        "BATCH_SIZE = 1024\n",
-        "BUFFER_SIZE = 10000\n",
-        "dataset = tf.data.Dataset.from_tensor_slices(((targets, contexts), labels))\n",
-        "dataset = dataset.shuffle(BUFFER_SIZE).batch(BATCH_SIZE, drop_remainder=True)\n",
-        "print(dataset)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tyrNX6Fs6K3F"
-      },
-      "source": [
-        "Apply `Dataset.cache` and `Dataset.prefetch` to improve performance:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Y5Ueg6bcFPVL"
-      },
-      "outputs": [],
-      "source": [
-        "dataset = dataset.cache().prefetch(buffer_size=AUTOTUNE)\n",
-        "print(dataset)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "1S-CmUMszyEf"
-      },
-      "source": [
-        "## Model and training"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sQFqaBMPwBqC"
-      },
-      "source": [
-        "The word2vec model can be implemented as a classifier to distinguish between true context words from skip-grams and false context words obtained through negative sampling. You can perform a dot product multiplication between the embeddings of target and context words to obtain predictions for labels and compute the loss function against true labels in the dataset."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oc7kTbiwD9sy"
-      },
-      "source": [
-        "### Subclassed word2vec model"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Jvr9pM1G1sQN"
-      },
-      "source": [
-        "Use the [Keras Subclassing API](https://www.tensorflow.org/guide/keras/custom_layers_and_models) to define your word2vec model with the following layers:\n",
-        "\n",
-        "* `target_embedding`: A `tf.keras.layers.Embedding` layer, which looks up the embedding of a word when it appears as a target word. The number of parameters in this layer are `(vocab_size * embedding_dim)`.\n",
-        "* `context_embedding`: Another `tf.keras.layers.Embedding` layer, which looks up the embedding of a word when it appears as a context word. The number of parameters in this layer are the same as those in `target_embedding`, i.e. `(vocab_size * embedding_dim)`.\n",
-        "* `dots`: A `tf.keras.layers.Dot` layer that computes the dot product of target and context embeddings from a training pair.\n",
-        "* `flatten`: A `tf.keras.layers.Flatten` layer to flatten the results of `dots` layer into logits.\n",
-        "\n",
-        "With the subclassed model, you can define the `call()` function that accepts `(target, context)` pairs which can then be passed into their corresponding embedding layer. Reshape the `context_embedding` to perform a dot product with `target_embedding` and return the flattened result."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "KiAwuIqqw7-7"
-      },
-      "source": [
-        "Key point: The `target_embedding` and `context_embedding` layers can be shared as well. You could also use a concatenation of both embeddings as the final word2vec embedding."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "i9ec-sS6xd8Z"
-      },
-      "outputs": [],
-      "source": [
-        "class Word2Vec(tf.keras.Model):\n",
-        "  def __init__(self, vocab_size, embedding_dim):\n",
-        "    super(Word2Vec, self).__init__()\n",
-        "    self.target_embedding = layers.Embedding(vocab_size,\n",
-        "                                      embedding_dim,\n",
-        "                                      input_length=1,\n",
-        "                                      name=\"w2v_embedding\")\n",
-        "    self.context_embedding = layers.Embedding(vocab_size,\n",
-        "                                       embedding_dim,\n",
-        "                                       input_length=num_ns+1)\n",
-        "\n",
-        "  def call(self, pair):\n",
-        "    target, context = pair\n",
-        "    # target: (batch, dummy?)  # The dummy axis doesn't exist in TF2.7+\n",
-        "    # context: (batch, context)\n",
-        "    if len(target.shape) == 2:\n",
-        "      target = tf.squeeze(target, axis=1)\n",
-        "    # target: (batch,)\n",
-        "    word_emb = self.target_embedding(target)\n",
-        "    # word_emb: (batch, embed)\n",
-        "    context_emb = self.context_embedding(context)\n",
-        "    # context_emb: (batch, context, embed)\n",
-        "    dots = tf.einsum('be,bce->bc', word_emb, context_emb)\n",
-        "    # dots: (batch, context)\n",
-        "    return dots"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-RLKz9LFECXu"
-      },
-      "source": [
-        "### Define loss function and compile model\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "I3Md-9QanqBM"
-      },
-      "source": [
-        "For simplicity, you can use `tf.keras.losses.CategoricalCrossEntropy` as an alternative to the negative sampling loss. If you would like to write your own custom loss function, you can also do so as follows:\n",
-        "\n",
-        "``` python\n",
-        "def custom_loss(x_logit, y_true):\n",
-        "      return tf.nn.sigmoid_cross_entropy_with_logits(logits=x_logit, labels=y_true)\n",
-        "```\n",
-        "\n",
-        "It's time to build your model! Instantiate your word2vec class with an embedding dimension of 128 (you could experiment with different values). Compile the model with the `tf.keras.optimizers.Adam` optimizer. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ekQg_KbWnnmQ"
-      },
-      "outputs": [],
-      "source": [
-        "embedding_dim = 128\n",
-        "word2vec = Word2Vec(vocab_size, embedding_dim)\n",
-        "word2vec.compile(optimizer='adam',\n",
-        "                 loss=tf.keras.losses.CategoricalCrossentropy(from_logits=True),\n",
-        "                 metrics=['accuracy'])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "P3MUMrluqNX2"
-      },
-      "source": [
-        "Also define a callback to log training statistics for TensorBoard:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "9d-ftBCeEZIR"
-      },
-      "outputs": [],
-      "source": [
-        "tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=\"logs\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "h5wEBotlGZ7B"
-      },
-      "source": [
-        "Train the model on the `dataset` for some number of epochs:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "gmC1BJalEZIY"
-      },
-      "outputs": [],
-      "source": [
-        "word2vec.fit(dataset, epochs=20, callbacks=[tensorboard_callback])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wze38jG57XvZ"
-      },
-      "source": [
-        "TensorBoard now shows the word2vec model's accuracy and loss:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "22E9eqS55rgz"
-      },
-      "outputs": [],
-      "source": [
-        "#docs_infra: no_execute\n",
-        "%tensorboard --logdir logs"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "awF3iRQCZOLj"
-      },
-      "source": [
-        "<!-- <img class=\"tfo-display-only-on-site\" src=\"images/word2vec_tensorboard.png\"/> -->"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TaDW2tIIz8fL"
-      },
-      "source": [
-        "## Embedding lookup and analysis"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Zp5rv01WG2YA"
-      },
-      "source": [
-        "Obtain the weights from the model using `Model.get_layer` and `Layer.get_weights`. The `TextVectorization.get_vocabulary` function provides the vocabulary to build a metadata file with one token per line."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "_Uamp1YH8RzU"
-      },
-      "outputs": [],
-      "source": [
-        "weights = word2vec.get_layer('w2v_embedding').get_weights()[0]\n",
-        "vocab = vectorize_layer.get_vocabulary()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gWzdmUzS8Sl4"
-      },
-      "source": [
-        "Create and save the vectors and metadata files:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "VLIahl9s53XT"
-      },
-      "outputs": [],
-      "source": [
-        "out_v = io.open('vectors.tsv', 'w', encoding='utf-8')\n",
-        "out_m = io.open('metadata.tsv', 'w', encoding='utf-8')\n",
-        "\n",
-        "for index, word in enumerate(vocab):\n",
-        "  if index == 0:\n",
-        "    continue  # skip 0, it's padding.\n",
-        "  vec = weights[index]\n",
-        "  out_v.write('\\t'.join([str(x) for x in vec]) + \"\\n\")\n",
-        "  out_m.write(word + \"\\n\")\n",
-        "out_v.close()\n",
-        "out_m.close()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "1T8KcThhIU8-"
-      },
-      "source": [
-        "Download the `vectors.tsv` and `metadata.tsv` to analyze the obtained embeddings in the [Embedding Projector](https://projector.tensorflow.org/):"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "lUsjQOKMIV2z"
-      },
-      "outputs": [],
-      "source": [
-        "try:\n",
-        "  from google.colab import files\n",
-        "  files.download('vectors.tsv')\n",
-        "  files.download('metadata.tsv')\n",
-        "except Exception:\n",
-        "  pass"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "iS_uMeMw3Xpj"
-      },
-      "source": [
-        "## Next steps\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BSgAZpwF5xF_"
-      },
-      "source": [
-        "This tutorial has shown you how to implement a skip-gram word2vec model with negative sampling from scratch and visualize the obtained word embeddings.\n",
-        "\n",
-        "* To learn more about word vectors and their mathematical representations, refer to these [notes](https://web.stanford.edu/class/cs224n/readings/cs224n-2019-notes01-wordvecs1.pdf).\n",
-        "\n",
-        "* To learn more about advanced text processing, read the [Transformer model for language understanding](https://www.tensorflow.org/tutorials/text/transformer) tutorial.\n",
-        "\n",
-        "* If you’re interested in pre-trained embedding models, you may also be interested in [Exploring the TF-Hub CORD-19 Swivel Embeddings](https://www.tensorflow.org/hub/tutorials/cord_19_embeddings_keras), or the [Multilingual Universal Sentence Encoder](https://www.tensorflow.org/hub/tutorials/cross_lingual_similarity_with_tf_hub_multilingual_universal_encoder).\n",
-        "\n",
-        "* You may also like to train the model on a new dataset (there are many available in [TensorFlow Datasets](https://www.tensorflow.org/datasets)).\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [],
-      "name": "word2vec.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hX4n9TsbGw-f"
+   },
+   "source": [
+    "##### Copyright 2020 The TensorFlow Authors."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "id": "0nbI5DtDGw-i"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AOpGoE2T-YXS"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tutorials/text/word2vec\">\n",
+    "    <img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />\n",
+    "    View on TensorFlow.org</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/text/word2vec.ipynb\">\n",
+    "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />\n",
+    "    Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/text/word2vec.ipynb\">\n",
+    "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
+    "    View source on GitHub</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs/site/en/tutorials/text/word2vec.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "haJUNjSB60Kh"
+   },
+   "source": [
+    "# word2vec"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "99d4ky2lWFvn"
+   },
+   "source": [
+    "word2vec is not a singular algorithm, rather, it is a family of model architectures and optimizations that can be used to learn word embeddings from large datasets. Embeddings learned through word2vec have proven to be successful on a variety of downstream natural language processing tasks.\n",
+    "\n",
+    "Note: This tutorial is based on [Efficient estimation of word representations in vector space](https://arxiv.org/pdf/1301.3781.pdf) and [Distributed representations of words and phrases and their compositionality](https://papers.nips.cc/paper/5021-distributed-representations-of-words-and-phrases-and-their-compositionality.pdf). It is not an exact implementation of the papers. Rather, it is intended to illustrate the key ideas.\n",
+    "\n",
+    "These papers proposed two methods for learning representations of words:\n",
+    "\n",
+    "*   **Continuous bag-of-words model**: predicts the middle word based on surrounding context words. The context consists of a few words before and after the current (middle) word. This architecture is called a bag-of-words model as the order of words in the context is not important.\n",
+    "*   **Continuous skip-gram model**: predicts words within a certain range before and after the current word in the same sentence. A worked example of this is given below.\n",
+    "\n",
+    "You'll use the skip-gram approach in this tutorial. First, you'll explore skip-grams and other concepts using a single sentence for illustration. Next, you'll train your own word2vec model on a small dataset. This tutorial also contains code to export the trained embeddings and visualize them in the [TensorFlow Embedding Projector](http://projector.tensorflow.org/).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "xP00WlaMWBZC"
+   },
+   "source": [
+    "## Skip-gram and negative sampling "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Zr2wjv0bW236"
+   },
+   "source": [
+    "While a bag-of-words model predicts a word given the neighboring context, a skip-gram model predicts the context (or neighbors) of a word, given the word itself. The model is trained on skip-grams, which are n-grams that allow tokens to be skipped (see the diagram below for an example). The context of a word can be represented through a set of skip-gram pairs of `(target_word, context_word)` where `context_word` appears in the neighboring context of `target_word`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ICjc-McbaVTd"
+   },
+   "source": [
+    "Consider the following sentence of eight words:\n",
+    "\n",
+    "> The wide road shimmered in the hot sun.\n",
+    "\n",
+    "The context words for each of the 8 words of this sentence are defined by a window size. The window size determines the span of words on either side of a `target_word` that can be considered a `context word`. Below is a table of skip-grams for target words based on different window sizes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "YKE87IKT_YT8"
+   },
+   "source": [
+    "Note: For this tutorial, a window size of `n` implies n words on each side with a total window span of 2*n+1 words across a word."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RsCwQ07E8mqU"
+   },
+   "source": [
+    "![word2vec_skipgrams](https://tensorflow.org/tutorials/text/images/word2vec_skipgram.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gK1gN1jwkMpU"
+   },
+   "source": [
+    "The training objective of the skip-gram model is to maximize the probability of predicting context words given the target word. For a sequence of words *w<sub>1</sub>, w<sub>2</sub>, ... w<sub>T</sub>*, the objective can be written as the average log probability"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pILO_iAc84e-"
+   },
+   "source": [
+    "![word2vec_skipgram_objective](https://tensorflow.org/tutorials/text/images/word2vec_skipgram_objective.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Gsy6TUbtnz_K"
+   },
+   "source": [
+    "where `c` is the size of the training context. The basic skip-gram formulation defines this probability using the softmax function."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "P81Qavbb9APd"
+   },
+   "source": [
+    "![word2vec_full_softmax](https://tensorflow.org/tutorials/text/images/word2vec_full_softmax.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "axZvd-hhotVB"
+   },
+   "source": [
+    "where *v* and *v<sup>'<sup>* are target and context vector representations of words and *W* is vocabulary size. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "SoLzxbqSpT6_"
+   },
+   "source": [
+    "Computing the denominator of this formulation involves performing a full softmax over the entire vocabulary words, which are often large (10<sup>5</sup>-10<sup>7</sup>) terms."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Y5VWYtmFzHkU"
+   },
+   "source": [
+    "The [noise contrastive estimation](https://www.tensorflow.org/api_docs/python/tf/nn/nce_loss) (NCE) loss function is an efficient approximation for a full softmax. With an objective to learn word embeddings instead of modeling the word distribution, the NCE loss can be [simplified](https://papers.nips.cc/paper/5021-distributed-representations-of-words-and-phrases-and-their-compositionality.pdf) to use negative sampling. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WTZBPf1RsOsg"
+   },
+   "source": [
+    "The simplified negative sampling objective for a target word is to distinguish  the context word from `num_ns` negative samples drawn from noise distribution *P<sub>n</sub>(w)* of words. More precisely, an efficient approximation of full softmax over the vocabulary is, for a skip-gram pair, to pose the loss for a target word as a classification problem between the context word and `num_ns` negative samples. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Cl0rSfHjt6Mf"
+   },
+   "source": [
+    "A negative sample is defined as a `(target_word, context_word)` pair such that the `context_word` does not appear in the `window_size` neighborhood of the `target_word`. For the example sentence, these are a few potential negative samples (when `window_size` is `2`).\n",
+    "\n",
+    "```\n",
+    "(hot, shimmered)\n",
+    "(wide, hot)\n",
+    "(wide, sun)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "kq0q2uqbucFg"
+   },
+   "source": [
+    "In the next section, you'll generate skip-grams and negative samples for a single sentence. You'll also learn about subsampling techniques and train a classification model for positive and negative training examples later in the tutorial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mk4-Hpe1CH16"
+   },
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "RutaI-Tpev3T"
+   },
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import re\n",
+    "import string\n",
+    "import tqdm\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "import tensorflow as tf\n",
+    "from tensorflow.keras import layers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "10pyUMFkGKVQ"
+   },
+   "outputs": [],
+   "source": [
+    "# Load the TensorBoard notebook extension\n",
+    "%load_ext tensorboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "XkJ5299Tek6B"
+   },
+   "outputs": [],
+   "source": [
+    "SEED = 42\n",
+    "AUTOTUNE = tf.data.AUTOTUNE"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RW-g5buCHwh3"
+   },
+   "source": [
+    "### Vectorize an example sentence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "y8TfZIgoQrcP"
+   },
+   "source": [
+    "Consider the following sentence:\n",
+    "\n",
+    "> The wide road shimmered in the hot sun.\n",
+    "\n",
+    "Tokenize the sentence:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bsl7jBzV6_KK"
+   },
+   "outputs": [],
+   "source": [
+    "sentence = \"The wide road shimmered in the hot sun\"\n",
+    "tokens = list(sentence.lower().split())\n",
+    "print(len(tokens))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "PU-bs1XtThEw"
+   },
+   "source": [
+    "Create a vocabulary to save mappings from tokens to integer indices:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "UdYv1HJUQ8XA"
+   },
+   "outputs": [],
+   "source": [
+    "vocab, index = {}, 1  # start indexing from 1\n",
+    "vocab['<pad>'] = 0  # add a padding token\n",
+    "for token in tokens:\n",
+    "  if token not in vocab:\n",
+    "    vocab[token] = index\n",
+    "    index += 1\n",
+    "vocab_size = len(vocab)\n",
+    "print(vocab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ZpuP43Dddasr"
+   },
+   "source": [
+    "Create an inverse vocabulary to save mappings from integer indices to tokens:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "o9ULAJYtEvKl"
+   },
+   "outputs": [],
+   "source": [
+    "inverse_vocab = {index: token for token, index in vocab.items()}\n",
+    "print(inverse_vocab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "n3qtuyxIRyii"
+   },
+   "source": [
+    "Vectorize your sentence:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "CsB3-9uQQYyl"
+   },
+   "outputs": [],
+   "source": [
+    "example_sequence = [vocab[word] for word in tokens]\n",
+    "print(example_sequence)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ox1I28JRIOdM"
+   },
+   "source": [
+    "### Generate skip-grams from one sentence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "t7NNKAmSiHvy"
+   },
+   "source": [
+    "The `tf.keras.preprocessing.sequence` module provides useful functions that simplify data preparation for word2vec. You can use the `tf.keras.preprocessing.sequence.skipgrams` to generate skip-gram pairs from the `example_sequence` with a given `window_size` from tokens in the range `[0, vocab_size)`.\n",
+    "\n",
+    "Note: `negative_samples` is set to `0` here, as batching negative samples generated by this function requires a bit of code. You will use another function to perform negative sampling in the next section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "USAJxW4RD7pn"
+   },
+   "outputs": [],
+   "source": [
+    "window_size = 2\n",
+    "positive_skip_grams, _ = tf.keras.preprocessing.sequence.skipgrams(\n",
+    "      example_sequence,\n",
+    "      vocabulary_size=vocab_size,\n",
+    "      window_size=window_size,\n",
+    "      negative_samples=0)\n",
+    "print(len(positive_skip_grams))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "uc9uhiMwY-AQ"
+   },
+   "source": [
+    "Print a few positive skip-grams:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "SCnqEukIE9pt"
+   },
+   "outputs": [],
+   "source": [
+    "for target, context in positive_skip_grams[:5]:\n",
+    "  print(f\"({target}, {context}): ({inverse_vocab[target]}, {inverse_vocab[context]})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_ua9PkMTISF0"
+   },
+   "source": [
+    "### Negative sampling for one skip-gram "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Esqn8WBfZnEK"
+   },
+   "source": [
+    "The `skipgrams` function returns all positive skip-gram pairs by sliding over a given window span. To produce additional skip-gram pairs that would serve as negative samples for training, you need to sample random words from the vocabulary. Use the `tf.random.log_uniform_candidate_sampler` function to sample `num_ns` number of negative samples for a given target word in a window. You can call the function on one skip-grams's target word and pass the context word as true class to exclude it from being sampled.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AgH3aSvw3xTD"
+   },
+   "source": [
+    "Key point: `num_ns` (the number of negative samples per a positive context word) in the `[5, 20]` range is [shown to work](https://papers.nips.cc/paper/5021-distributed-representations-of-words-and-phrases-and-their-compositionality.pdf) best for smaller datasets, while `num_ns` in the `[2, 5]` range suffices for larger datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "m_LmdzqIGr5L"
+   },
+   "outputs": [],
+   "source": [
+    "# Get target and context words for one positive skip-gram.\n",
+    "target_word, context_word = positive_skip_grams[0]\n",
+    "\n",
+    "# Set the number of negative samples per positive context.\n",
+    "num_ns = 4\n",
+    "\n",
+    "context_class = tf.reshape(tf.constant(context_word, dtype=\"int64\"), (1, 1))\n",
+    "negative_sampling_candidates, _, _ = tf.random.log_uniform_candidate_sampler(\n",
+    "    true_classes=context_class,  # class that should be sampled as 'positive'\n",
+    "    num_true=1,  # each positive skip-gram has 1 positive context class\n",
+    "    num_sampled=num_ns,  # number of negative context words to sample\n",
+    "    unique=True,  # all the negative samples should be unique\n",
+    "    range_max=vocab_size,  # pick index of the samples from [0, vocab_size]\n",
+    "    seed=SEED,  # seed for reproducibility\n",
+    "    name=\"negative_sampling\"  # name of this operation\n",
+    ")\n",
+    "print(negative_sampling_candidates)\n",
+    "print([inverse_vocab[index.numpy()] for index in negative_sampling_candidates])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8MSxWCrLIalp"
+   },
+   "source": [
+    "### Construct one training example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Q6uEWdj8vKKv"
+   },
+   "source": [
+    "For a given positive `(target_word, context_word)` skip-gram, you now also have `num_ns` negative sampled context words that do not appear in the window size neighborhood of `target_word`. Batch the `1` positive `context_word` and `num_ns` negative context words into one tensor. This produces a set of positive skip-grams (labeled as `1`) and negative samples (labeled as `0`) for each target word."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zSiZwifuLvHf"
+   },
+   "outputs": [],
+   "source": [
+    "# Add a dimension so you can use concatenation (in the next step).\n",
+    "negative_sampling_candidates = tf.expand_dims(negative_sampling_candidates, 1)\n",
+    "\n",
+    "# Concatenate a positive context word with negative sampled words.\n",
+    "context = tf.concat([context_class, negative_sampling_candidates], 0)\n",
+    "\n",
+    "# Label the first context word as `1` (positive) followed by `num_ns` `0`s (negative).\n",
+    "label = tf.constant([1] + [0]*num_ns, dtype=\"int64\")\n",
+    "\n",
+    "# Reshape the target to shape `(1,)` and context and label to `(num_ns+1,)`.\n",
+    "target = tf.squeeze(target_word)\n",
+    "context = tf.squeeze(context)\n",
+    "label = tf.squeeze(label)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "OIJeoFCAwtXJ"
+   },
+   "source": [
+    "Check out the context and the corresponding labels for the target word from the skip-gram example above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "tzyCPCuZwmdL"
+   },
+   "outputs": [],
+   "source": [
+    "print(f\"target_index    : {target}\")\n",
+    "print(f\"target_word     : {inverse_vocab[target_word]}\")\n",
+    "print(f\"context_indices : {context}\")\n",
+    "print(f\"context_words   : {[inverse_vocab[c.numpy()] for c in context]}\")\n",
+    "print(f\"label           : {label}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gBtTcUVQr8EO"
+   },
+   "source": [
+    "A tuple of `(target, context, label)` tensors constitutes one training example for training your skip-gram negative sampling word2vec model. Notice that the target is of shape `(1,)` while the context and label are of shape `(1+num_ns,)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "x-FwkR8jx9-Z"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"target  :\", target)\n",
+    "print(\"context :\", context)\n",
+    "print(\"label   :\", label)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4bRJIlow4Dlv"
+   },
+   "source": [
+    "### Summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pWkuha0oykG5"
+   },
+   "source": [
+    "This diagram summarizes the procedure of generating a training example from a sentence:\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_KlwdiAa9crJ"
+   },
+   "source": [
+    "![word2vec_negative_sampling](https://tensorflow.org/tutorials/text/images/word2vec_negative_sampling.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "37e53f07f67c"
+   },
+   "source": [
+    "Notice that the words `temperature` and `code` are not part of the input sentence. They belong to the vocabulary like certain other indices used in the diagram above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9wmdO_MEIpaM"
+   },
+   "source": [
+    "## Compile all steps into one function\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "iLKwNAczHsKg"
+   },
+   "source": [
+    "### Skip-gram sampling table "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TUUK3uDtFNFE"
+   },
+   "source": [
+    "A large dataset means larger vocabulary with higher number of more frequent words such as stopwords. Training examples obtained from sampling commonly occurring words (such as `the`, `is`, `on`) don't add much useful information  for the model to learn from. [Mikolov et al.](https://papers.nips.cc/paper/5021-distributed-representations-of-words-and-phrases-and-their-compositionality.pdf) suggest subsampling of frequent words as a helpful practice to improve embedding quality. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bPtbv7zNP7Dx"
+   },
+   "source": [
+    "The `tf.keras.preprocessing.sequence.skipgrams` function accepts a sampling table argument to encode probabilities of sampling any token. You can use the `tf.keras.preprocessing.sequence.make_sampling_table` to  generate a word-frequency rank based probabilistic sampling table and pass it to the `skipgrams` function. Inspect the sampling probabilities for a `vocab_size` of 10."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Rn9zAnDccyRg"
+   },
+   "outputs": [],
+   "source": [
+    "sampling_table = tf.keras.preprocessing.sequence.make_sampling_table(size=10)\n",
+    "print(sampling_table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EHvSptcPk5fp"
+   },
+   "source": [
+    "`sampling_table[i]` denotes the probability of sampling the i-th most common word in a dataset. The function assumes a [Zipf's distribution](https://en.wikipedia.org/wiki/Zipf%27s_law) of the word frequencies for sampling."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mRHMssMmHgH-"
+   },
+   "source": [
+    "Key point: The `tf.random.log_uniform_candidate_sampler` already assumes that the vocabulary frequency follows a log-uniform (Zipf's) distribution. Using these distribution weighted sampling also helps approximate the Noise Contrastive Estimation (NCE) loss with simpler loss functions for training a negative sampling objective."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aj--8RFK6fgW"
+   },
+   "source": [
+    "### Generate training data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dy5hl4lQ0B2M"
+   },
+   "source": [
+    "Compile all the steps described above into a function that can be called on a list of vectorized sentences obtained from any text dataset. Notice that the sampling table is built before sampling skip-gram word pairs. You will use this function in the later sections."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "63INISDEX1Hu"
+   },
+   "outputs": [],
+   "source": [
+    "# Generates skip-gram pairs with negative sampling for a list of sequences\n",
+    "# (int-encoded sentences) based on window size, number of negative samples\n",
+    "# and vocabulary size.\n",
+    "def generate_training_data(sequences, window_size, num_ns, vocab_size, seed):\n",
+    "  # Elements of each training example are appended to these lists.\n",
+    "  targets, contexts, labels = [], [], []\n",
+    "\n",
+    "  # Build the sampling table for `vocab_size` tokens.\n",
+    "  sampling_table = tf.keras.preprocessing.sequence.make_sampling_table(vocab_size)\n",
+    "\n",
+    "  # Iterate over all sequences (sentences) in the dataset.\n",
+    "  for sequence in tqdm.tqdm(sequences):\n",
+    "\n",
+    "    # Generate positive skip-gram pairs for a sequence (sentence).\n",
+    "    positive_skip_grams, _ = tf.keras.preprocessing.sequence.skipgrams(\n",
+    "          sequence,\n",
+    "          vocabulary_size=vocab_size,\n",
+    "          sampling_table=sampling_table,\n",
+    "          window_size=window_size,\n",
+    "          negative_samples=0)\n",
+    "\n",
+    "    # Iterate over each positive skip-gram pair to produce training examples\n",
+    "    # with a positive context word and negative samples.\n",
+    "    for target_word, context_word in positive_skip_grams:\n",
+    "      context_class = tf.expand_dims(\n",
+    "          tf.constant([context_word], dtype=\"int64\"), 1)\n",
+    "      negative_sampling_candidates, _, _ = tf.random.log_uniform_candidate_sampler(\n",
+    "          true_classes=context_class,\n",
+    "          num_true=1,\n",
+    "          num_sampled=num_ns,\n",
+    "          unique=True,\n",
+    "          range_max=vocab_size,\n",
+    "          seed=seed,\n",
+    "          name=\"negative_sampling\")\n",
+    "\n",
+    "      # Build context and label vectors (for one target word)\n",
+    "      negative_sampling_candidates = tf.expand_dims(\n",
+    "          negative_sampling_candidates, 1)\n",
+    "\n",
+    "      context = tf.concat([context_class, negative_sampling_candidates], 0)\n",
+    "      label = tf.constant([1] + [0]*num_ns, dtype=\"int64\")\n",
+    "\n",
+    "      # Append each element from the training example to global lists.\n",
+    "      targets.append(target_word)\n",
+    "      contexts.append(context)\n",
+    "      labels.append(label)\n",
+    "\n",
+    "  return targets, contexts, labels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "shvPC8Ji2cMK"
+   },
+   "source": [
+    "## Prepare training data for word2vec"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "j5mbZsZu6uKg"
+   },
+   "source": [
+    "With an understanding of how to work with one sentence for a skip-gram negative sampling based word2vec model, you can proceed to generate training examples from a larger list of sentences!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "OFlikI6L26nh"
+   },
+   "source": [
+    "### Download text corpus\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rEFavOgN98al"
+   },
+   "source": [
+    "You will use a text file of Shakespeare's writing for this tutorial. Change the following line to run this code on your own data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "QFkitxzVVaAi"
+   },
+   "outputs": [],
+   "source": [
+    "path_to_file = tf.keras.utils.get_file('shakespeare.txt', 'https://storage.googleapis.com/download.tensorflow.org/data/shakespeare.txt')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sOsbLq8a37dr"
+   },
+   "source": [
+    "Read the text from the file and print the first few lines: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "lfgnsUw3ofMD"
+   },
+   "outputs": [],
+   "source": [
+    "with open(path_to_file) as f:\n",
+    "  lines = f.read().splitlines()\n",
+    "for line in lines[:20]:\n",
+    "  print(line)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gTNZYqUs5C2V"
+   },
+   "source": [
+    "Use the non empty lines to construct a `tf.data.TextLineDataset` object for the next steps:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ViDrwy-HjAs9"
+   },
+   "outputs": [],
+   "source": [
+    "text_ds = tf.data.TextLineDataset(path_to_file).filter(lambda x: tf.cast(tf.strings.length(x), bool))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vfsc88zE9upk"
+   },
+   "source": [
+    "### Vectorize sentences from the corpus"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XfgZo8zR94KK"
+   },
+   "source": [
+    "You can use the `TextVectorization` layer to vectorize sentences from the corpus. Learn more about using this layer in this [Text classification](https://www.tensorflow.org/tutorials/keras/text_classification) tutorial. Notice from the first few sentences above that the text needs to be in one case and punctuation needs to be removed. To do this, define a `custom_standardization function` that can be used in the TextVectorization layer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2MlsXzo-ZlfK"
+   },
+   "outputs": [],
+   "source": [
+    "# Now, create a custom standardization function to lowercase the text and\n",
+    "# remove punctuation.\n",
+    "def custom_standardization(input_data):\n",
+    "  lowercase = tf.strings.lower(input_data)\n",
+    "  return tf.strings.regex_replace(lowercase,\n",
+    "                                  '[%s]' % re.escape(string.punctuation), '')\n",
+    "\n",
+    "\n",
+    "# Define the vocabulary size and the number of words in a sequence.\n",
+    "vocab_size = 4096\n",
+    "sequence_length = 10\n",
+    "\n",
+    "# Use the `TextVectorization` layer to normalize, split, and map strings to\n",
+    "# integers. Set the `output_sequence_length` length to pad all samples to the\n",
+    "# same length.\n",
+    "vectorize_layer = layers.TextVectorization(\n",
+    "    standardize=custom_standardization,\n",
+    "    max_tokens=vocab_size,\n",
+    "    output_mode='int',\n",
+    "    output_sequence_length=sequence_length)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g92LuvnyBmz1"
+   },
+   "source": [
+    "Call `TextVectorization.adapt` on the text dataset to create vocabulary.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "seZau_iYMPFT"
+   },
+   "outputs": [],
+   "source": [
+    "vectorize_layer.adapt(text_ds.batch(1024))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jg2z7eeHMnH-"
+   },
+   "source": [
+    "Once the state of the layer has been adapted to represent the text corpus, the vocabulary can be accessed with `TextVectorization.get_vocabulary`. This function returns a list of all vocabulary tokens sorted (descending) by their frequency."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "jgw9pTA7MRaU"
+   },
+   "outputs": [],
+   "source": [
+    "# Save the created vocabulary for reference.\n",
+    "inverse_vocab = vectorize_layer.get_vocabulary()\n",
+    "print(inverse_vocab[:20])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "DOQ30Tx6KA2G"
+   },
+   "source": [
+    "The `vectorize_layer` can now be used to generate vectors for each element in the `text_ds` (a `tf.data.Dataset`). Apply `Dataset.batch`, `Dataset.prefetch`, `Dataset.map`, and `Dataset.unbatch`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "yUVYrDp0araQ"
+   },
+   "outputs": [],
+   "source": [
+    "# Vectorize the data in text_ds.\n",
+    "text_vector_ds = text_ds.batch(1024).prefetch(AUTOTUNE).map(vectorize_layer).unbatch()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7YyH_SYzB72p"
+   },
+   "source": [
+    "### Obtain sequences from the dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NFUQLX0_KaRC"
+   },
+   "source": [
+    "You now have a `tf.data.Dataset` of integer encoded sentences. To prepare the dataset for training a word2vec model, flatten the dataset into a list of sentence vector sequences. This step is required as you would iterate over each sentence in the dataset to produce positive and negative examples.\n",
+    "\n",
+    "Note: Since the `generate_training_data()` defined earlier uses non-TensorFlow Python/NumPy functions, you could also use a `tf.py_function` or `tf.numpy_function` with `tf.data.Dataset.map`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "sGXoOh9y11pM"
+   },
+   "outputs": [],
+   "source": [
+    "sequences = list(text_vector_ds.as_numpy_iterator())\n",
+    "print(len(sequences))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tDc4riukLTqg"
+   },
+   "source": [
+    "Inspect a few examples from `sequences`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "WZf1RIbB2Dfb"
+   },
+   "outputs": [],
+   "source": [
+    "for seq in sequences[:5]:\n",
+    "  print(f\"{seq} => {[inverse_vocab[i] for i in seq]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yDzSOjNwCWNh"
+   },
+   "source": [
+    "### Generate training examples from sequences"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BehvYr-nEKyY"
+   },
+   "source": [
+    "`sequences` is now a list of int encoded sentences. Just call the `generate_training_data` function defined earlier to generate training examples for the word2vec model. To recap, the function iterates over each word from each sequence to collect positive and negative context words. Length of target, contexts and labels should be the same, representing the total number of training examples."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "44DJ22M6nX5o"
+   },
+   "outputs": [],
+   "source": [
+    "targets, contexts, labels = generate_training_data(\n",
+    "    sequences=sequences,\n",
+    "    window_size=2,\n",
+    "    num_ns=4,\n",
+    "    vocab_size=vocab_size,\n",
+    "    seed=SEED)\n",
+    "\n",
+    "targets = np.array(targets)\n",
+    "contexts = np.array(contexts)[:,:,0]\n",
+    "labels = np.array(labels)\n",
+    "\n",
+    "print('\\n')\n",
+    "print(f\"targets.shape: {targets.shape}\")\n",
+    "print(f\"contexts.shape: {contexts.shape}\")\n",
+    "print(f\"labels.shape: {labels.shape}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "97PqsusOFEpc"
+   },
+   "source": [
+    "### Configure the dataset for performance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7jnFVySViQTj"
+   },
+   "source": [
+    "To perform efficient batching for the potentially large number of training examples, use the `tf.data.Dataset` API. After this step, you would have a `tf.data.Dataset` object of `(target_word, context_word), (label)` elements to train your word2vec model!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "nbu8PxPSnVY2"
+   },
+   "outputs": [],
+   "source": [
+    "BATCH_SIZE = 1024\n",
+    "BUFFER_SIZE = 10000\n",
+    "dataset = tf.data.Dataset.from_tensor_slices(((targets, contexts), labels))\n",
+    "dataset = dataset.shuffle(BUFFER_SIZE).batch(BATCH_SIZE, drop_remainder=True)\n",
+    "print(dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tyrNX6Fs6K3F"
+   },
+   "source": [
+    "Apply `Dataset.cache` and `Dataset.prefetch` to improve performance:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Y5Ueg6bcFPVL"
+   },
+   "outputs": [],
+   "source": [
+    "dataset = dataset.cache().prefetch(buffer_size=AUTOTUNE)\n",
+    "print(dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1S-CmUMszyEf"
+   },
+   "source": [
+    "## Model and training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sQFqaBMPwBqC"
+   },
+   "source": [
+    "The word2vec model can be implemented as a classifier to distinguish between true context words from skip-grams and false context words obtained through negative sampling. You can perform a dot product multiplication between the embeddings of target and context words to obtain predictions for labels and compute the loss function against true labels in the dataset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "oc7kTbiwD9sy"
+   },
+   "source": [
+    "### Subclassed word2vec model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Jvr9pM1G1sQN"
+   },
+   "source": [
+    "Use the [Keras Subclassing API](https://www.tensorflow.org/guide/keras/custom_layers_and_models) to define your word2vec model with the following layers:\n",
+    "\n",
+    "* `target_embedding`: A `tf.keras.layers.Embedding` layer, which looks up the embedding of a word when it appears as a target word. The number of parameters in this layer are `(vocab_size * embedding_dim)`.\n",
+    "* `context_embedding`: Another `tf.keras.layers.Embedding` layer, which looks up the embedding of a word when it appears as a context word. The number of parameters in this layer are the same as those in `target_embedding`, i.e. `(vocab_size * embedding_dim)`.\n",
+    "* `dots`: A `tf.keras.layers.Dot` layer that computes the dot product of target and context embeddings from a training pair.\n",
+    "* `flatten`: A `tf.keras.layers.Flatten` layer to flatten the results of `dots` layer into logits.\n",
+    "\n",
+    "With the subclassed model, you can define the `call()` function that accepts `(target, context)` pairs which can then be passed into their corresponding embedding layer. Reshape the `context_embedding` to perform a dot product with `target_embedding` and return the flattened result."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "KiAwuIqqw7-7"
+   },
+   "source": [
+    "Key point: The `target_embedding` and `context_embedding` layers can be shared as well. You could also use a concatenation of both embeddings as the final word2vec embedding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "i9ec-sS6xd8Z"
+   },
+   "outputs": [],
+   "source": [
+    "class Word2Vec(tf.keras.Model):\n",
+    "  def __init__(self, vocab_size, embedding_dim):\n",
+    "    super(Word2Vec, self).__init__()\n",
+    "    self.target_embedding = layers.Embedding(vocab_size,\n",
+    "                                      embedding_dim,\n",
+    "                                      input_length=1,\n",
+    "                                      name=\"w2v_embedding\")\n",
+    "    self.context_embedding = layers.Embedding(vocab_size,\n",
+    "                                       embedding_dim,\n",
+    "                                       input_length=num_ns+1)\n",
+    "\n",
+    "  def call(self, pair):\n",
+    "    target, context = pair\n",
+    "    # target: (batch, dummy?)  # The dummy axis doesn't exist in TF2.7+\n",
+    "    # context: (batch, context)\n",
+    "    if len(target.shape) == 2:\n",
+    "      target = tf.squeeze(target, axis=1)\n",
+    "    # target: (batch,)\n",
+    "    word_emb = self.target_embedding(target)\n",
+    "    # word_emb: (batch, embed)\n",
+    "    context_emb = self.context_embedding(context)\n",
+    "    # context_emb: (batch, context, embed)\n",
+    "    dots = tf.einsum('be,bce->bc', word_emb, context_emb)\n",
+    "    # dots: (batch, context)\n",
+    "    return dots"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-RLKz9LFECXu"
+   },
+   "source": [
+    "### Define loss function and compile model\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "I3Md-9QanqBM"
+   },
+   "source": [
+    "For simplicity, you can use `tf.keras.losses.CategoricalCrossEntropy` as an alternative to the negative sampling loss. If you would like to write your own custom loss function, you can also do so as follows:\n",
+    "\n",
+    "``` python\n",
+    "def custom_loss(x_logit, y_true):\n",
+    "      return tf.nn.sigmoid_cross_entropy_with_logits(logits=x_logit, labels=y_true)\n",
+    "```\n",
+    "\n",
+    "It's time to build your model! Instantiate your word2vec class with an embedding dimension of 128 (you could experiment with different values). Compile the model with the `tf.keras.optimizers.Adam` optimizer. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ekQg_KbWnnmQ"
+   },
+   "outputs": [],
+   "source": [
+    "embedding_dim = 128\n",
+    "word2vec = Word2Vec(vocab_size, embedding_dim)\n",
+    "word2vec.compile(optimizer='adam',\n",
+    "                 loss=tf.keras.losses.CategoricalCrossentropy(from_logits=True),\n",
+    "                 metrics=['accuracy'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "P3MUMrluqNX2"
+   },
+   "source": [
+    "Also define a callback to log training statistics for TensorBoard:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "9d-ftBCeEZIR"
+   },
+   "outputs": [],
+   "source": [
+    "tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=\"logs\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "h5wEBotlGZ7B"
+   },
+   "source": [
+    "Train the model on the `dataset` for some number of epochs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "gmC1BJalEZIY"
+   },
+   "outputs": [],
+   "source": [
+    "word2vec.fit(dataset, epochs=20, callbacks=[tensorboard_callback])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wze38jG57XvZ"
+   },
+   "source": [
+    "TensorBoard now shows the word2vec model's accuracy and loss:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "22E9eqS55rgz"
+   },
+   "outputs": [],
+   "source": [
+    "#docs_infra: no_execute\n",
+    "%tensorboard --logdir logs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "awF3iRQCZOLj"
+   },
+   "source": [
+    "<!-- <img class=\"tfo-display-only-on-site\" src=\"images/word2vec_tensorboard.png\"/> -->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TaDW2tIIz8fL"
+   },
+   "source": [
+    "## Embedding lookup and analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Zp5rv01WG2YA"
+   },
+   "source": [
+    "Obtain the weights from the model using `Model.get_layer` and `Layer.get_weights`. The `TextVectorization.get_vocabulary` function provides the vocabulary to build a metadata file with one token per line."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "_Uamp1YH8RzU"
+   },
+   "outputs": [],
+   "source": [
+    "weights = word2vec.get_layer('w2v_embedding').get_weights()[0]\n",
+    "vocab = vectorize_layer.get_vocabulary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gWzdmUzS8Sl4"
+   },
+   "source": [
+    "Create and save the vectors and metadata files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VLIahl9s53XT"
+   },
+   "outputs": [],
+   "source": [
+    "out_v = io.open('vectors.tsv', 'w', encoding='utf-8')\n",
+    "out_m = io.open('metadata.tsv', 'w', encoding='utf-8')\n",
+    "\n",
+    "for index, word in enumerate(vocab):\n",
+    "  if index == 0:\n",
+    "    continue  # skip 0, it's padding.\n",
+    "  vec = weights[index]\n",
+    "  out_v.write('\\t'.join([str(x) for x in vec]) + \"\\n\")\n",
+    "  out_m.write(word + \"\\n\")\n",
+    "out_v.close()\n",
+    "out_m.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1T8KcThhIU8-"
+   },
+   "source": [
+    "Download the `vectors.tsv` and `metadata.tsv` to analyze the obtained embeddings in the [Embedding Projector](https://projector.tensorflow.org/):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "lUsjQOKMIV2z"
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "  from google.colab import files\n",
+    "  files.download('vectors.tsv')\n",
+    "  files.download('metadata.tsv')\n",
+    "except Exception:\n",
+    "  pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "iS_uMeMw3Xpj"
+   },
+   "source": [
+    "## Next steps\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BSgAZpwF5xF_"
+   },
+   "source": [
+    "This tutorial has shown you how to implement a skip-gram word2vec model with negative sampling from scratch and visualize the obtained word embeddings.\n",
+    "\n",
+    "* To learn more about word vectors and their mathematical representations, refer to these [notes](https://web.stanford.edu/class/cs224n/readings/cs224n-2019-notes01-wordvecs1.pdf).\n",
+    "\n",
+    "* To learn more about advanced text processing, read the [Transformer model for language understanding](https://www.tensorflow.org/tutorials/text/transformer) tutorial.\n",
+    "\n",
+    "* If you’re interested in pre-trained embedding models, you may also be interested in [Exploring the TF-Hub CORD-19 Swivel Embeddings](https://www.tensorflow.org/hub/tutorials/cord_19_embeddings_keras), or the [Multilingual Universal Sentence Encoder](https://www.tensorflow.org/hub/tutorials/cross_lingual_similarity_with_tf_hub_multilingual_universal_encoder).\n",
+    "\n",
+    "* You may also like to train the model on a new dataset (there are many available in [TensorFlow Datasets](https://www.tensorflow.org/datasets)).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "word2vec.ipynb",
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
The function "generate_training_data" used the global variable "SEED" even though it takes a variable "seed" as its argument (which is also used later in the notebook). This is the code section I am talking about:

```
    for target_word, context_word in positive_skip_grams:
      context_class = tf.expand_dims(
          tf.constant([context_word], dtype="int64"), 1)
      negative_sampling_candidates, _, _ = tf.random.log_uniform_candidate_sampler(
          true_classes=context_class,
          num_true=1,
          num_sampled=num_ns,
          unique=True,
          range_max=vocab_size,
          seed=SEED,
          name="negative_sampling")
```

I changed "SEED" to "seed" to fix the typo. No other changes were made to the notebook.