### PR TITLE
Fixed typo in generate_training_data

### DIFF
--- a/site/en/tutorials/text/word2vec.ipynb
+++ b/site/en/tutorials/text/word2vec.ipynb
@@ -747,7 +747,7 @@
         "          num_sampled=num_ns,\n",
         "          unique=True,\n",
         "          range_max=vocab_size,\n",
-        "          seed=SEED,\n",
+        "          seed=seed,\n",
         "          name=\"negative_sampling\")\n",
         "\n",
         "      # Build context and label vectors (for one target word)\n",


### PR DESCRIPTION


The function "generate_training_data" used the global variable "SEED" even though it takes a variable "seed" as its argument (which is also used later in the notebook). This is the code section I am talking about:

```
for target_word, context_word in positive_skip_grams:
      context_class = tf.expand_dims(
          tf.constant([context_word], dtype="int64"), 1)
      negative_sampling_candidates, _, _ = tf.random.log_uniform_candidate_sampler(
          true_classes=context_class,
          num_true=1,
          num_sampled=num_ns,
          unique=True,
          range_max=vocab_size,
          seed=SEED,
          name="negative_sampling")
```

I changed "SEED" to "seed" to fix the typo. No other changes were made to the notebook.
