### PR TITLE
Fixed broken link

### DIFF
--- a/site/en/tutorials/structured_data/preprocessing_layers.ipynb
+++ b/site/en/tutorials/structured_data/preprocessing_layers.ipynb
@@ -363,7 +363,7 @@
         "In this tutorial, you will use the following four preprocessing layers to demonstrate how to perform preprocessing, structured data encoding, and feature engineering:\n",
         "\n",
         "- `tf.keras.layers.Normalization`: Performs feature-wise normalization of input features.\n",
-        "- `tf.keras.layers.CategoryEncoding`: Turns integer categorical features into one-hot, multi-hot, or <a href=\"https://en.wikipedia.org/wiki/Tf%E2%80%93idf/\" class=\"external\">tf-idf</a>\n",
+        "- `tf.keras.layers.CategoryEncoding`: Turns integer categorical features into one-hot, multi-hot, or <a href=\"https://en.wikipedia.org/wiki/Tf%E2%80%93idf\" class=\"external\">tf-idf</a>\n",
         "dense representations.\n",
         "- `tf.keras.layers.StringLookup`: Turns string categorical values into integer indices.\n",
         "- `tf.keras.layers.IntegerLookup`: Turns integer categorical values into integer indices.\n",


### PR DESCRIPTION
Fixed broken link for tf-idf. Changed "https://en.wikipedia.org/wiki/Tf%E2%80%93idf/" to "https://en.wikipedia.org/wiki/Tf%E2%80%93idf"