### PR TITLE
Remove semi-colon symbol when plotting metrics in Classification on imbalanced data tutorial

### DIFF
--- a/site/en/tutorials/structured_data/imbalanced_data.ipynb
+++ b/site/en/tutorials/structured_data/imbalanced_data.ipynb
@@ -814,7 +814,7 @@
         "    else:\n",
         "      plt.ylim([0,1])\n",
         "\n",
-        "    plt.legend();"
+        "    plt.legend()"
       ]
     },
     {


### PR DESCRIPTION
remove unneeded symbol