### PR TITLE
Fix typos in TensorFlow 1.x vs TensorFlow 2 - Behaviors and APIs guide

### DIFF
--- a/site/en/guide/migrate/tf1_vs_tf2.ipynb
+++ b/site/en/guide/migrate/tf1_vs_tf2.ipynb
@@ -131,7 +131,7 @@
         "\n",
         "### Other API changes\n",
         "\n",
-        "* TF2 features significant improvements to the device placement algorithms which renders the usage of `tf.colocate_with` unnecessary. If removing it causes a performance degrade [please file a bug](https://github.com/tensorflow/tensorflow/issues).\n",
+        "* TF2 features significant improvements to the device placement algorithms which renders the usage of `tf.colocate_with` unnecessary. If removing it causes a performance degradation, [please file a bug](https://github.com/tensorflow/tensorflow/issues).\n",
         "\n",
         "* Replace all usage of `tf.v1.ConfigProto` with equivalent functions from `tf.config`."
       ]
@@ -159,7 +159,7 @@
       "source": [
         "## No more globals\n",
         "\n",
-        "TF1.x relied heavily on implicit global namespaces and collections. When you called `tf.Variable`, it would be put into a collection in the default graph, and it would remain there, even if you lost track of the Python variable pointing to it. You could then recover that `tf.Variable`, but only if you knew the name that it had been created with. This was difficult to do if you were not in control of the variable's creation. As a result, all sorts of mechanisms proliferated to\n",
+        "TF1.x relied heavily on implicit global namespaces and collections. When you call `tf.Variable`, it would be put into a collection in the default graph, and it would remain there, even if you lost track of the Python variable pointing to it. You could then recover that `tf.Variable`, but only if you knew the name that it had been created with. This was difficult to do if you were not in control of the variable's creation. As a result, all sorts of mechanisms proliferated to\n",
         "attempt to help you find your variables again, and for frameworks to find\n",
         "user-created variables. Some of these include: variable scopes, global collections, helper methods like `tf.get_global_step` and `tf.global_variables_initializer`, optimizers implicitly\n",
         "computing gradients over all trainable variables, and so on. TF2 eliminates all of these mechanisms ([Variables 2.0 RFC](https://github.com/tensorflow/community/pull/11)) in favor of the default mechanism - you keep track of your variables. If you lose track of a `tf.Variable`, it gets garbage collected.\n",
@@ -340,7 +340,7 @@
         "  print(e) # <tf.Tensor ...> is out of scope and cannot be used here.\n",
         "```\n",
         "\n",
-        "The most straightfoward solution is ensuring that the variable creation and dataset creation are both outside of the `tf.function` call. For example:\n",
+        "The most straightforward solution is ensuring that the variable creation and dataset creation are both outside of the `tf.function` call. For example:\n",
         "\n",
         "```python\n",
         "class Model(tf.Module):\n",
@@ -681,7 +681,7 @@
       "source": [
         "### `ResourceVariables` instead of `ReferenceVariables`\n",
         "\n",
-        "`ResourceVariables` have stronger read-write consistency guarantees than `ReferenceVariables`. This leads to more predictable, easier-to-reason about semantics about whether or not you will observe the result of a previous write when using your variables. This change is extremely unlikely to cause existing code to raise errors or to break silently.\n",
+        "`ResourceVariables` have stronger read-write consistency guarantees than `ReferenceVariables`. This leads to more predictable, easier-to-reason semantics about whether or not you will observe the result of a previous write when using your variables. This change is extremely unlikely to cause existing code to raise errors or to break silently.\n",
         "\n",
         "However, it is ***possible though unlikely*** that these stronger consistency guarantees may increase the memory usage of your specific program. Please file an [issue](https://github.com/tensorflow/tensorflow/issues) if you find this to be the case. Additionally, if you have unit tests relying on exact string comparisons against the operator names in a graph corresponding to variable reads, be aware that enabling resource variables may slightly change the name of these operators.\n",
         "\n",

--- a/site/en/guide/migrate/tf1_vs_tf2.ipynb
+++ b/site/en/guide/migrate/tf1_vs_tf2.ipynb
@@ -1135,7 +1135,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "tf1_vs_tf2.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
Corrected the spelling of straightforward and made changes in lines 684,134 and 162.