### PR TITLE
Correct a bullet point, lint Custom training with tf.distribute.Strategy

### DIFF
--- a/site/en/tutorials/distribute/custom_training.ipynb
+++ b/site/en/tutorials/distribute/custom_training.ipynb
@@ -277,12 +277,12 @@
       "source": [
         "## Define the loss function\n",
         "\n",
-        "Normally, on a single machine with single GPU/CPU, loss is divided by the number of examples in the batch of input.\n",
+        "Normally, on a single machine with a single GPU/CPU, the loss function is divided by the number of examples in the batch of input.\n",
         "\n",
         "*So, how should the loss be calculated when using a `tf.distribute.Strategy`?*\n",
         "\n",
-        "* For an example, let's say you have 4 GPU's and a batch size of 64. One batch of input is distributed\n",
-        "across the replicas (4 GPUs), each replica getting an input of size 16.\n",
+        "* For an example, let's say you have 4 GPUs and a batch size of 64. One batch of input is distributed\n",
+        "across the replicas (4 GPUs), and each replica gets an input of size 16.\n",
         "\n",
         "* The model on each replica does a forward pass with its respective input and calculates the loss. Now, instead of dividing the loss by the number of examples in its respective input (`BATCH_SIZE_PER_REPLICA` = 16), the loss should be divided by the `GLOBAL_BATCH_SIZE` (64)."
       ]

--- a/site/en/tutorials/distribute/custom_training.ipynb
+++ b/site/en/tutorials/distribute/custom_training.ipynb
@@ -495,7 +495,7 @@
         "* Iterate over the `train_dist_dataset` and `test_dist_dataset` using  a `for x in ...` construct.\n",
         "* The scaled loss is the return value of the `distributed_train_step`. This value is aggregated across replicas using the `tf.distribute.Strategy.reduce` call and then across batches by summing the return value of the `tf.distribute.Strategy.reduce` calls.\n",
         "* `tf.keras.Metrics` should be updated inside `train_step` and `test_step` that gets executed by `tf.distribute.Strategy.run`.\n",
-        "*`tf.distribute.Strategy.run` returns results from each local replica in the strategy, and there are multiple ways to consume this result. You can do `tf.distribute.Strategy.reduce` to get an aggregated value. You can also do `tf.distribute.Strategy.experimental_local_results` to get the list of values contained in the result, one per local replica.\n"
+        "* `tf.distribute.Strategy.run` returns results from each local replica in the strategy, and there are multiple ways to consume this result. You can do `tf.distribute.Strategy.reduce` to get an aggregated value. You can also do `tf.distribute.Strategy.experimental_local_results` to get the list of values contained in the result, one per local replica.\n"
       ]
     },
     {


### PR DESCRIPTION
A bullet point appeared as an asterisk in the resulting notebook due to a missing 'space' character.