### PR TITLE
Update link to Migrating model checkpoints in Use TF1.x models in TF2 workflows guide

### DIFF
--- a/site/en/guide/migrate/model_mapping.ipynb
+++ b/site/en/guide/migrate/model_mapping.ipynb
@@ -1253,7 +1253,7 @@
         "\n",
         "The above migration process to native TF2 APIs changed both the variable names (as Keras APIs produce very different weight names), and the object-oriented paths that point to different weights in the model. The impact of these changes is that they will have broken both any existing TF1-style name-based checkpoints or TF2-style object-oriented checkpoints.\n",
         "\n",
-        "However, in some cases, you might be able to take your original name-based checkpoint and find a mapping of the variables to their new names with approaches like the one detailed in the [Reusing TF1.x checkpoints guide](https://github.com/tensorflow/docs/blob/master/site/en/guide/migrate/migrating_checkpoints.ipynb).\n",
+        "However, in some cases, you might be able to take your original name-based checkpoint and find a mapping of the variables to their new names with approaches like the one detailed in the [Reusing TF1.x checkpoints guide](./migrating_checkpoints.ipynb).\n",
         "\n",
         "Some tips to making this feasible are as follows:\n",
         "- Variables still all have a `name` argument you can set.\n",

--- a/site/en/guide/migrate/model_mapping.ipynb
+++ b/site/en/guide/migrate/model_mapping.ipynb
@@ -1048,7 +1048,7 @@
       "source": [
         "random_tool = v1.keras.utils.DeterministicRandomTestTool(mode='num_random_ops')\n",
         "with random_tool.scope():\n",
-	"  tf.keras.utils.set_random_seed(42)\n",
+        "  tf.keras.utils.set_random_seed(42)\n",
         "  layer = CompatModel(10)\n",
         "\n",
         "  inputs = tf.random.normal(shape=(10, 5, 5, 5))\n",
@@ -1070,7 +1070,7 @@
       "source": [
         "random_tool = v1.keras.utils.DeterministicRandomTestTool(mode='num_random_ops')\n",
         "with random_tool.scope():\n",
-	"  tf.keras.utils.set_random_seed(42)\n",
+        "  tf.keras.utils.set_random_seed(42)\n",
         "  layer = PartiallyMigratedModel(10)\n",
         "\n",
         "  inputs = tf.random.normal(shape=(10, 5, 5, 5))\n",
@@ -1144,7 +1144,7 @@
       "source": [
         "random_tool = v1.keras.utils.DeterministicRandomTestTool(mode='num_random_ops')\n",
         "with random_tool.scope():\n",
-	"  tf.keras.utils.set_random_seed(42)\n",
+        "  tf.keras.utils.set_random_seed(42)\n",
         "  layer = NearlyFullyNativeModel(10)\n",
         "\n",
         "  inputs = tf.random.normal(shape=(10, 5, 5, 5))\n",
@@ -1218,7 +1218,7 @@
       "source": [
         "random_tool = v1.keras.utils.DeterministicRandomTestTool(mode='num_random_ops')\n",
         "with random_tool.scope():\n",
-	"  tf.keras.utils.set_random_seed(42)\n",
+        "  tf.keras.utils.set_random_seed(42)\n",
         "  layer = FullyNativeModel(10)\n",
         "\n",
         "  inputs = tf.random.normal(shape=(10, 5, 5, 5))\n",

--- a/site/en/guide/migrate/model_mapping.ipynb
+++ b/site/en/guide/migrate/model_mapping.ipynb
@@ -1253,7 +1253,7 @@
         "\n",
         "The above migration process to native TF2 APIs changed both the variable names (as Keras APIs produce very different weight names), and the object-oriented paths that point to different weights in the model. The impact of these changes is that they will have broken both any existing TF1-style name-based checkpoints or TF2-style object-oriented checkpoints.\n",
         "\n",
-        "However, in some cases, you might be able to take your original name-based checkpoint and find a mapping of the variables to their new names with approaches like the one detailed in the [Reusing TF1.x checkpoints guide](./reusing_checkpoints.ipynb).\n",
+        "However, in some cases, you might be able to take your original name-based checkpoint and find a mapping of the variables to their new names with approaches like the one detailed in the [Reusing TF1.x checkpoints guide](https://github.com/tensorflow/docs/blob/master/site/en/guide/migrate/migrating_checkpoints.ipynb).\n",
         "\n",
         "Some tips to making this feasible are as follows:\n",
         "- Variables still all have a `name` argument you can set.\n",


### PR DESCRIPTION
Fixed a broken link at line 1256