### PR TITLE
Fixes depreciated API in gpu_performance_analysis

### DIFF
--- a/site/en/guide/gpu_performance_analysis.md
+++ b/site/en/guide/gpu_performance_analysis.md
@@ -170,7 +170,7 @@ disabling callbacks/metrics improves performance. Some details of these ops are
 also on the trace viewer (both device and host side).The recommendation in this
 scenario is to amortize the overhead of these ops by executing them after a
 fixed number of steps instead of every step. When using the `compile` method in
-the `tf.keras` API, setting the `experimental_steps_per_execution` flag does
+the `tf.keras` API, setting the `steps_per_execution` flag does
 this automatically. For custom training loops, use `tf.while_loop`.
 
 #### 2. Achieve higher device utilization

--- a/site/en/guide/gpu_performance_analysis.md
+++ b/site/en/guide/gpu_performance_analysis.md
@@ -169,7 +169,7 @@ the trace viewer, you should look at the model code between steps and check if
 disabling callbacks/metrics improves performance. Some details of these ops are
 also on the trace viewer (both device and host side).The recommendation in this
 scenario is to amortize the overhead of these ops by executing them after a
-fixed number of steps instead of every step. When using the `compile` method in
+fixed number of steps instead of every step. When using the `Model.compile` method in
 the `tf.keras` API, setting the `steps_per_execution` flag does
 this automatically. For custom training loops, use `tf.while_loop`.
 

--- a/site/en/guide/migrate/canned_estimators.ipynb
+++ b/site/en/guide/migrate/canned_estimators.ipynb
@@ -742,7 +742,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "canned_estimators.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
Fixes depreciated API in gpu_performance_analysis at line 173 . From  experimental_steps_per_execution to steps_per_execution