### PR TITLE
Fixed broken link in XLA documentation

### DIFF
--- a/site/en/tutorials/_index.yaml
+++ b/site/en/tutorials/_index.yaml
@@ -221,7 +221,7 @@ landing_page:
           <a href="/xla"><h3 class="tfo-landing-page-heading no-link">XLA</h3></a>
           <ul class="tfo-landing-page-resources-ul">
           <li><a href="/xla/tutorials/autoclustering_xla">Classifying CIFAR-10 with XLA</a></li>
-          <li><a href="/xla/tutorials/compile">Use XLA with tf.function</a></li>
+          <li><a href="/xla/tutorials/jit_compile">Use XLA with tf.function</a></li>
           </ul>
         path: /xla
         icon:


### PR DESCRIPTION
Fixed broken link in XLA documentation for "Use XLA with tf.function" at line 224