### PR TITLE
Updated correct link for tf.keras API

### DIFF
--- a/site/en/tutorials/keras/save_and_load.ipynb
+++ b/site/en/tutorials/keras/save_and_load.ipynb
@@ -111,7 +111,7 @@
         "\n",
         "### Options\n",
         "\n",
-        "There are different ways to save TensorFlow models depending on the API you're using. This guide uses [tf.keras](https://www.tensorflow.org/guide/keras)—a high-level API to build and train models in TensorFlow. For other approaches, refer to the [Using the SavedModel format guide](../../guide/saved_model.ipynb) and the [Save and load Keras models guide](https://www.tensorflow.org/guide/keras/save_and_serialize)."
+        "There are different ways to save TensorFlow models depending on the API you're using. This guide uses [tf.keras](https://www.tensorflow.org/api_docs/python/tf/keras)—a high-level API to build and train models in TensorFlow. For other approaches, refer to the [Using the SavedModel format guide](../../guide/saved_model.ipynb) and the [Save and load Keras models guide](https://www.tensorflow.org/guide/keras/save_and_serialize)."
       ]
     },
     {


### PR DESCRIPTION
Updated correct link for tf.keras API from "https://www.tensorflow.org/guide/keras/sequential_model" to "https://www.tensorflow.org/api_docs/python/tf/keras"