### PR TITLE
Updated syntax to set memory limit on all gpus

### DIFF
--- a/site/en/guide/gpu.ipynb
+++ b/site/en/guide/gpu.ipynb
@@ -397,10 +397,10 @@
         "if gpus:\n",
         "  # Create 2 virtual GPUs with 1GB memory each\n",
         "  try:\n",
+        "   for i in range(len(gpus)):",
         "    tf.config.set_logical_device_configuration(\n",
-        "        gpus[0],\n",
-        "        [tf.config.LogicalDeviceConfiguration(memory_limit=1024),\n",
-        "         tf.config.LogicalDeviceConfiguration(memory_limit=1024)])\n",
+        "        gpus[i],\n",
+        "        [tf.config.LogicalDeviceConfiguration(memory_limit=1024)]\n"
         "    logical_gpus = tf.config.list_logical_devices('GPU')\n",
         "    print(len(gpus), \"Physical GPU,\", len(logical_gpus), \"Logical GPUs\")\n",
         "  except RuntimeError as e:\n",

--- a/site/en/guide/gpu.ipynb
+++ b/site/en/guide/gpu.ipynb
@@ -400,7 +400,7 @@
         "   for i in range(len(gpus)):",
         "    tf.config.set_logical_device_configuration(\n",
         "        gpus[i],\n",
-        "        [tf.config.LogicalDeviceConfiguration(memory_limit=1024)]\n"
+        "        [tf.config.LogicalDeviceConfiguration(memory_limit=1024)]\n",
         "    logical_gpus = tf.config.list_logical_devices('GPU')\n",
         "    print(len(gpus), \"Physical GPU,\", len(logical_gpus), \"Logical GPUs\")\n",
         "  except RuntimeError as e:\n",


### PR DESCRIPTION
Updated syntax to set memory limit on all found GPU's instead of setting only on GPU i.e gpu[0] .  
Attached [gist](https://colab.sandbox.google.com/gist/mohantym/04a7cd00f399f0a058eaca102dec17fe/gpu.ipynb#scrollTo=8EMGuGKbNkc6) as Proof of work.