### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/bot-label-lgtm.yaml
+++ b/.github/workflows/bot-label-lgtm.yaml
@@ -10,6 +10,9 @@ on:
     # From: issue_comment, pull_request_review
     types: [created, edited, submitted]
 
+permissions:
+  pull-requests: write  #  to add labels to pull-requests
+
 jobs:
   lgtm-comment:
     # Check the comment. contains() is case-insensitive.

--- a/.github/workflows/bot-nightly.yaml
+++ b/.github/workflows/bot-nightly.yaml
@@ -4,8 +4,12 @@ on:
   repository_dispatch:
     types: [nightly]
 
+permissions: {}
 jobs:
   snapshot-source:
+    permissions:
+      contents: write  #  for git push
+
     name: Update Keras guides
     if : ${{ github.actor == 'tfdocsbot' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/bot-pr-fix.yaml
+++ b/.github/workflows/bot-pr-fix.yaml
@@ -6,9 +6,15 @@ on:
   repository_dispatch:
     types: [opened, synchronize]
 
+permissions: {}
+
 jobs:
   nbfmt:
     # Check for opt-out label.
+    permissions:
+      contents: write
+      pull-requests: write
+
     if: >-
       ${{ github.actor == 'tfdocsbot' &&
           !contains(github.event.client_payload.pull_request.labels.*.name, 'nbfmt-disable') }}

--- a/.github/workflows/bot-pr-new.yaml
+++ b/.github/workflows/bot-pr-new.yaml
@@ -6,8 +6,15 @@ on:
   repository_dispatch:
     types: [opened, reopened]
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   comment-welcome:
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
+      pull-requests: write  #  to comment on pull-request
+
     if: ${{ github.actor == 'tfdocsbot' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.