### PR TITLE
Fixed broken links

### DIFF
--- a/site/en/guide/distributed_training.ipynb
+++ b/site/en/guide/distributed_training.ipynb
@@ -503,14 +503,14 @@
       "source": [
         "## Use tf.distribute.Strategy with Keras Model.fit\n",
         "\n",
-        "`tf.distribute.Strategy` is integrated into `tf.keras`, which is TensorFlow's implementation of the [Keras API specification](https://keras.io/api/). `tf.keras` is a high-level API to build and train models. By integrating into the `tf.keras` backend, it's seamless for you to distribute your training written in the Keras training framework [using Model.fit](./keras/customizing_what_happens_in_fit.ipynb).\n",
+        "`tf.distribute.Strategy` is integrated into `tf.keras`, which is TensorFlow's implementation of the [Keras API specification](https://keras.io/api/). `tf.keras` is a high-level API to build and train models. By integrating into the `tf.keras` backend, it's seamless for you to distribute your training written in the Keras training framework [using Model.fit](https://www.tensorflow.org/guide/keras/customizing_what_happens_in_fit).\n",
         "\n",
         "Here's what you need to change in your code:\n",
         "\n",
         "1. Create an instance of the appropriate `tf.distribute.Strategy`.\n",
         "2. Move the creation of Keras model, optimizer and metrics inside `strategy.scope`.\n",
         "\n",
-        "TensorFlow distribution strategies support all types of Keras models—[Sequential](./keras/sequential_model.ipynb), [Functional](./keras/functional.ipynb), and [subclassed](./keras/custom_layers_and_models.ipynb)\n",
+        "TensorFlow distribution strategies support all types of Keras models—[Sequential](https://www.tensorflow.org/guide/keras/sequential_model), [Functional](https://www.tensorflow.org/guide/keras/functional), and [subclassed](https://www.tensorflow.org/guide/keras/custom_layers_and_models)\n",
         "\n",
         "Here is a snippet of code to do this for a very simple Keras model with one `Dense` layer:"
       ]
@@ -636,7 +636,7 @@
       "source": [
         "## Use tf.distribute.Strategy with custom training loops\n",
         "\n",
-        "As demonstrated above, using `tf.distribute.Strategy` with Keras `Model.fit` requires changing only a couple lines of your code. With a little more effort, you can also use `tf.distribute.Strategy` [with custom training loops](./keras/writing_a_training_loop_from_scratch.ipynb).\n",
+        "As demonstrated above, using `tf.distribute.Strategy` with Keras `Model.fit` requires changing only a couple lines of your code. With a little more effort, you can also use `tf.distribute.Strategy` [with custom training loops](https://www.tensorflow.org/guide/keras/writing_a_training_loop_from_scratch).\n",
         "\n",
         "If you need more flexibility and control over your training loops than is possible with Estimator or Keras, you can write custom training loops. For instance, when using a GAN, you may want to take a different number of generator or discriminator steps each round. Similarly, the high level frameworks are not very suitable for Reinforcement Learning training.\n",
         "\n",

--- a/site/en/guide/distributed_training.ipynb
+++ b/site/en/guide/distributed_training.ipynb
@@ -503,14 +503,14 @@
       "source": [
         "## Use tf.distribute.Strategy with Keras Model.fit\n",
         "\n",
-        "`tf.distribute.Strategy` is integrated into `tf.keras`, which is TensorFlow's implementation of the [Keras API specification](https://keras.io). `tf.keras` is a high-level API to build and train models. By integrating into the `tf.keras` backend, it's seamless for you to distribute your training written in the Keras training framework [using Model.fit](/keras/customizing_what_happens_in_fit.ipynb).\n",
+        "`tf.distribute.Strategy` is integrated into `tf.keras`, which is TensorFlow's implementation of the [Keras API specification](https://keras.io/api/). `tf.keras` is a high-level API to build and train models. By integrating into the `tf.keras` backend, it's seamless for you to distribute your training written in the Keras training framework [using Model.fit](keras-io/guides/ipynb/customizing_what_happens_in_fit.ipynb).\n",
         "\n",
         "Here's what you need to change in your code:\n",
         "\n",
         "1. Create an instance of the appropriate `tf.distribute.Strategy`.\n",
         "2. Move the creation of Keras model, optimizer and metrics inside `strategy.scope`.\n",
         "\n",
-        "TensorFlow distribution strategies support all types of Keras models—[Sequential](/keras/sequential_model.ipynb), [Functional](/keras/functional.ipynb), and [subclassed](/keras/custom_layers_and_models.ipynb).\n",
+        "TensorFlow distribution strategies support all types of Keras models—[Sequential](/keras-io/guides/ipynb/sequential_model.ipynb), [Functional](keras-io/guides/ipynb/functional_api.ipynb), and [subclassed](keras-io/guides/ipynb/making_new_layers_and_models_via_subclassing.ipynb).\n",
         "\n",
         "Here is a snippet of code to do this for a very simple Keras model with one `Dense` layer:"
       ]
@@ -636,7 +636,7 @@
       "source": [
         "## Use tf.distribute.Strategy with custom training loops\n",
         "\n",
-        "As demonstrated above, using `tf.distribute.Strategy` with Keras `Model.fit` requires changing only a couple lines of your code. With a little more effort, you can also use `tf.distribute.Strategy` [with custom training loops](/keras/writing_a_training_loop_from_scratch.ipynb).\n",
+        "As demonstrated above, using `tf.distribute.Strategy` with Keras `Model.fit` requires changing only a couple lines of your code. With a little more effort, you can also use `tf.distribute.Strategy` [with custom training loops](keras-io/guides/ipynb/writing_a_training_loop_from_scratch.ipynb).\n",
         "\n",
         "If you need more flexibility and control over your training loops than is possible with Estimator or Keras, you can write custom training loops. For instance, when using a GAN, you may want to take a different number of generator or discriminator steps each round. Similarly, the high level frameworks are not very suitable for Reinforcement Learning training.\n",
         "\n",

--- a/site/en/guide/distributed_training.ipynb
+++ b/site/en/guide/distributed_training.ipynb
@@ -503,14 +503,14 @@
       "source": [
         "## Use tf.distribute.Strategy with Keras Model.fit\n",
         "\n",
-        "`tf.distribute.Strategy` is integrated into `tf.keras`, which is TensorFlow's implementation of the [Keras API specification](https://keras.io/api/). `tf.keras` is a high-level API to build and train models. By integrating into the `tf.keras` backend, it's seamless for you to distribute your training written in the Keras training framework [using Model.fit](keras-io/guides/ipynb/customizing_what_happens_in_fit.ipynb).\n",
+        "`tf.distribute.Strategy` is integrated into `tf.keras`, which is TensorFlow's implementation of the [Keras API specification](https://keras.io/api/). `tf.keras` is a high-level API to build and train models. By integrating into the `tf.keras` backend, it's seamless for you to distribute your training written in the Keras training framework [using Model.fit](./keras/customizing_what_happens_in_fit.ipynb).\n",
         "\n",
         "Here's what you need to change in your code:\n",
         "\n",
         "1. Create an instance of the appropriate `tf.distribute.Strategy`.\n",
         "2. Move the creation of Keras model, optimizer and metrics inside `strategy.scope`.\n",
         "\n",
-        "TensorFlow distribution strategies support all types of Keras models—[Sequential](/keras-io/guides/ipynb/sequential_model.ipynb), [Functional](keras-io/guides/ipynb/functional_api.ipynb), and [subclassed](keras-io/guides/ipynb/making_new_layers_and_models_via_subclassing.ipynb).\n",
+        "TensorFlow distribution strategies support all types of Keras models—[Sequential](./keras/sequential_model.ipynb), [Functional](./keras/functional.ipynb), and [subclassed](./keras/custom_layers_and_models.ipynb)\n",
         "\n",
         "Here is a snippet of code to do this for a very simple Keras model with one `Dense` layer:"
       ]
@@ -636,7 +636,7 @@
       "source": [
         "## Use tf.distribute.Strategy with custom training loops\n",
         "\n",
-        "As demonstrated above, using `tf.distribute.Strategy` with Keras `Model.fit` requires changing only a couple lines of your code. With a little more effort, you can also use `tf.distribute.Strategy` [with custom training loops](keras-io/guides/ipynb/writing_a_training_loop_from_scratch.ipynb).\n",
+        "As demonstrated above, using `tf.distribute.Strategy` with Keras `Model.fit` requires changing only a couple lines of your code. With a little more effort, you can also use `tf.distribute.Strategy` [with custom training loops](./keras/writing_a_training_loop_from_scratch.ipynb).\n",
         "\n",
         "If you need more flexibility and control over your training loops than is possible with Estimator or Keras, you can write custom training loops. For instance, when using a GAN, you may want to take a different number of generator or discriminator steps each round. Similarly, the high level frameworks are not very suitable for Reinforcement Learning training.\n",
         "\n",


### PR DESCRIPTION
Fixed broken links for `Keras API specifications`, `Using Model.fit`, `Sequential`, `Functional` , `subclassed` links in section 'Use tf.distribute.Strategy with Keras Model.fit'  and  for `with custom training loops` link in section 'Use tf.distribute.Strategy with custom training loops'. I have provided the .ipynb file path as mentioned in the broken link.. Please suggest in case any changes are required.