### PR TITLE
Fixed "NameError" in regression.ipynb.

### DIFF
--- a/site/en/tutorials/keras/regression.ipynb
+++ b/site/en/tutorials/keras/regression.ipynb
@@ -547,7 +547,7 @@
       "source": [
         "horsepower = np.array(train_features['Horsepower'])\n",
         "\n",
-        "horsepower_normalizer = layers.Normalization(input_shape=[1,], axis=None)\n",
+        "horsepower_normalizer = tf.keras.layers.Normalization(input_shape=[1,], axis=None)\n",
         "horsepower_normalizer.adapt(horsepower)"
       ]
     },


### PR DESCRIPTION
In **regression.ipynb** file at **docs/site/en/tutorials/keras**, `horsepower_normalizer = layers.Normalization(input_shape=[1,],axis=None)` was used, throwing the `NameError: name 'layers' is not defined`. 
Replaced it with `tf.keras.layers.Normalization(input_shape=[1,],axis=None)` and now it is working fine :)

----

+ You can also find this missing on the [website](https://www.tensorflow.org/tutorials/keras/regression#linear_regression_with_one_variable)

![image](https://user-images.githubusercontent.com/93156825/202843313-d5d03a16-aa78-4eab-bdc6-75de6d021ef5.png)
