### PR TITLE
Update GPU Support For Windows Native

### DIFF
--- a/site/en/install/pip.md
+++ b/site/en/install/pip.md
@@ -53,7 +53,8 @@ step-by-step instructions.
 
     ```bash
     conda install -c conda-forge cudatoolkit=11.2 cudnn=8.1.0
-    python3 -m pip install tensorflow=2.10 # Anything above 2.10 is not supported on the GPU on Windows Native
+    # Anything above 2.10 is not supported on the GPU on Windows Native
+    python3 -m pip install "tensorflow<2.11"
     # Verify install:
     python3 -c "import tensorflow as tf; print(tf.config.list_physical_devices('GPU'))"
     ```
@@ -486,7 +487,8 @@ The following NVIDIA® software are only required for GPU support.
     PyPI.
 
     ```bash
-    pip install tensorflow=2.10 # Anything above 2.10 is not supported on the GPU on Windows Native
+    # Anything above 2.10 is not supported on the GPU on Windows Native
+    pip install "tensorflow<2.11" 
     ```
 
     ### 7. Verify install

--- a/site/en/install/pip.md
+++ b/site/en/install/pip.md
@@ -53,7 +53,7 @@ step-by-step instructions.
 
     ```bash
     conda install -c conda-forge cudatoolkit=11.2 cudnn=8.1.0
-    python3 -m pip install tensorflow
+    python3 -m pip install tensorflow=2.10 # Anything above 2.10 is not supported on the GPU on Windows Native
     # Verify install:
     python3 -c "import tensorflow as tf; print(tf.config.list_physical_devices('GPU'))"
     ```
@@ -486,7 +486,7 @@ The following NVIDIA® software are only required for GPU support.
     PyPI.
 
     ```bash
-    pip install tensorflow
+    pip install tensorflow=2.10 # Anything above 2.10 is not supported on the GPU on Windows Native
     ```
 
     ### 7. Verify install


### PR DESCRIPTION
Since TF 2.11 does't support GPU on Windows native,  updated `python3 -m pip install tensorflow` to `python3 -m pip install tensorflow=2.10` else it will always install latest release and it doesn't recognize the GPU.