### PR TITLE
Fix metrics in `compile_and_fit`

### DIFF
--- a/site/en/tutorials/keras/overfit_and_underfit.ipynb
+++ b/site/en/tutorials/keras/overfit_and_underfit.ipynb
@@ -536,7 +536,7 @@
         "  model.compile(optimizer=optimizer,\n",
         "                loss=tf.keras.losses.BinaryCrossentropy(from_logits=True),\n",
         "                metrics=[\n",
-        "                  tf.keras.losses.BinaryCrossentropy(\n",
+        "                  tf.keras.metrics.BinaryCrossentropy(\n",
         "                      from_logits=True, name='binary_crossentropy'),\n",
         "                  'accuracy'])\n",
         "\n",


### PR DESCRIPTION
Passing a `loss` model into the `metrics` argument causes an error while trying to save and load the model:  
```
TypeError: __init__() got an unexpected keyword argument 'reduction' while trying to load keras model
```

Reproduce:  
1. Follow the guide and build a model
2. Save the model using `model.save(path)`
3. Load the model using `tf.keras.models.load_model(path)`