### PR TITLE
Updated Bazel version for 2.11  Linux GPU build

### DIFF
--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -430,7 +430,7 @@ Success: TensorFlow is now installed.
 
 <table>
 <tr><th>Version</th><th>Python version</th><th>Compiler</th><th>Build tools</th><th>cuDNN</th><th>CUDA</th></tr>
-<tr><td>tensorflow-2.11.0</td><td>3.7-3.10</td><td>GCC 9.3.1</td><td>Bazel 5.1.1</td><td>8.1</td><td>11.2</td></tr>
+<tr><td>tensorflow-2.11.0</td><td>3.7-3.10</td><td>GCC 9.3.1</td><td>Bazel 5.3.1</td><td>8.1</td><td>11.2</td></tr>
 <tr><td>tensorflow-2.10.0</td><td>3.7-3.10</td><td>GCC 9.3.1</td><td>Bazel 5.1.1</td><td>8.1</td><td>11.2</td></tr>
 <tr><td>tensorflow-2.9.0</td><td>3.7-3.10</td><td>GCC 9.3.1</td><td>Bazel 5.0.0</td><td>8.1</td><td>11.2</td></tr>
 <tr><td>tensorflow-2.8.0</td><td>3.7-3.10</td><td>GCC 7.3.1</td><td>Bazel 4.2.1</td><td>8.1</td><td>11.2</td></tr>

--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -430,7 +430,7 @@ Success: TensorFlow is now installed.
 
 <table>
 <tr><th>Version</th><th>Python version</th><th>Compiler</th><th>Build tools</th><th>cuDNN</th><th>CUDA</th></tr>
-<tr><td>tensorflow-2.11.0</td><td>3.7-3.10</td><td>GCC 9.3.1</td><td>Bazel 5.3.1</td><td>8.1</td><td>11.2</td></tr>
+<tr><td>tensorflow-2.11.0</td><td>3.7-3.10</td><td>GCC 9.3.1</td><td>Bazel 5.3.0</td><td>8.1</td><td>11.2</td></tr>
 <tr><td>tensorflow-2.10.0</td><td>3.7-3.10</td><td>GCC 9.3.1</td><td>Bazel 5.1.1</td><td>8.1</td><td>11.2</td></tr>
 <tr><td>tensorflow-2.9.0</td><td>3.7-3.10</td><td>GCC 9.3.1</td><td>Bazel 5.0.0</td><td>8.1</td><td>11.2</td></tr>
 <tr><td>tensorflow-2.8.0</td><td>3.7-3.10</td><td>GCC 7.3.1</td><td>Bazel 4.2.1</td><td>8.1</td><td>11.2</td></tr>


### PR DESCRIPTION
Fixes - [#58694](https://github.com/tensorflow/tensorflow/issues/58694) .
Currently Build from source document mentions using Bazel 5.1.1 for Linux GPU build. But asks for Bazel 5.3.1 when we try to build the pip wheel.  Refactored build for source doc instead of  refactoring Bazel rc version . 

Attached [gist](https://colab.sandbox.google.com/gist/mohantym/d7479993bd95a7ad4f2bb028ca5d8d0d/tensorflow-ranking.ipynb#scrollTo=A3IQrnSBaqXx) for reference.