### PR TITLE
Use NEAREST NEIGHBOR method when resizing image mask

### DIFF
--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -182,7 +182,11 @@
       "source": [
         "def load_image(datapoint):\n",
         "  input_image = tf.image.resize(datapoint['image'], (128, 128))\n",
-        "  input_mask = tf.image.resize(datapoint['segmentation_mask'], (128, 128))\n",
+        "  input_mask = tf.image.resize(\n",
+        "    datapoint['segmentation_mask'],\n",
+        "    (128, 128),\n",
+        "    method = tf.image.ResizeMethod.NEAREST_NEIGHBOR,\n",
+        "  )\n",
         "\n",
         "  input_image, input_mask = normalize(input_image, input_mask)\n",
         "\n",


### PR DESCRIPTION
IIUC, when resizing the mask, the NEAREST NEIGHBOR interpolation method should be used to prevent the introduction of values of labels that are not present in the original mask.

Currently, if we print the values of sample mask we get:

```
>>> import numpy as np
>>> mask = iter(train_batches).next()[1]))
>>> print(np.unique(mask))

[0.0000000e+00 1.2207031e-04 3.6621094e-04 ... 1.9995728e+00 1.9999390e+00
 2.0000000e+00]
```

After the change:

```
>>> import numpy as np
>>> mask = iter(train_batches).next()[1]))
>>> print(np.unique(mask))

[0. 1. 2.]
```