### PR TITLE
Update segmentation.ipynb

### DIFF
--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -652,7 +652,7 @@
       "source": [
         "Semantic segmentation datasets can be highly imbalanced meaning that particular class pixels can be present more inside images than that of other classes. Since segmentation problems can be treated as per-pixel classification problems, you can deal with the imbalance problem by weighing the loss function to account for this. It's a simple and elegant way to deal with this problem. Refer to the [Classification on imbalanced data](../structured_data/imbalanced_data.ipynb) tutorial to learn more.\n",
         "\n",
-        "To [avoid ambiguity](https://github.com/keras-team/keras/issues/3653#issuecomment-243939748), `Model.fit` does not support the `class_weight` argument for inputs with 3+ dimensions."
+        "To [avoid ambiguity](https://github.com/keras-team/keras/issues/3653#issuecomment-243939748), `Model.fit` does not support the `class_weight` argument for targets with 3+ dimensions."
       ]
     },
     {


### PR DESCRIPTION
`class_weight` is still supported for 3+ dimensional inputs with a binary target (e.g. binary classification of images). The problem is when the target is 3+ dimensional. Saying "`Model.fit` does not support the`class_weight` argument for inputs with 3+ dimensions" may generate confusion for the use case I mentioned.