### PR TITLE
refactor: removing deprecated argument

### DIFF
--- a/site/en/tutorials/load_data/images.ipynb
+++ b/site/en/tutorials/load_data/images.ipynb
@@ -151,8 +151,8 @@
         "import pathlib\n",
         "dataset_url = \"https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz\"\n",
         "data_dir = tf.keras.utils.get_file(origin=dataset_url,\n",
-        "                                   fname='flower_photos',\n",
-        "                                   untar=True)\n",
+        "                                   fname='flower_photos.tar',\n",
+        "                                   extract=True)\n",
         "data_dir = pathlib.Path(data_dir)"
       ]
     },


### PR DESCRIPTION
The `untar` argument is now deprecated in favor of `extract` according to the information at https://www.tensorflow.org/api_docs/python/tf/keras/utils/get_file. This PR replaces the `untar` argument used in this tutorial's `keras.utils.get_file` method with `extract`.