### PR TITLE
Update Windows GPU libtensorflow C package to 2.10

### DIFF
--- a/site/en/install/lang_c.ipynb
+++ b/site/en/install/lang_c.ipynb
@@ -148,7 +148,7 @@
         "  </tr>\n",
         "  <tr>\n",
         "    <td>Windows GPU only</td>\n",
-        "    <td class=\"devsite-click-to-copy\"><a href=\"https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-windows-x86_64-2.11.0.zip\">https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-windows-x86_64-2.11.0.zip</a></td>\n",
+        "    <td class=\"devsite-click-to-copy\"><a href=\"https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-windows-x86_64-2.10.0.zip\">https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-windows-x86_64-2.10.0.zip</a></td>\n",
         "  </tr>\n",
         "</table>"
       ]

--- a/site/en/install/lang_c.ipynb
+++ b/site/en/install/lang_c.ipynb
@@ -150,7 +150,10 @@
         "    <td>Windows GPU only</td>\n",
         "    <td class=\"devsite-click-to-copy\"><a href=\"https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-windows-x86_64-2.10.0.zip\">https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-windows-x86_64-2.10.0.zip</a></td>\n",
         "  </tr>\n",
-        "</table>"
+        "</table><br>\n",
+        "<aside class=\"caution\">\n",
+        "  <p><b>Note:</b> TensorFlow 2.10 was the last TensorFlow release that supported GPU on native-Windows.</p>\n",
+        "</aside>"
       ]
     },
     {


### PR DESCRIPTION
Windows GPU libtensorflow C packages are not available in the 2.11 release. To support the community update the same to 2.10.

#Fixes https://discuss.tensorflow.org/t/windows-gpu-only-c-tensorflow-download-failure/13744/