### PR TITLE
Fix UFC to UCF errors

### DIFF
--- a/site/en/tutorials/load_data/video.ipynb
+++ b/site/en/tutorials/load_data/video.ipynb
@@ -444,7 +444,7 @@
         "id": "LlEQ_I0TLd1X"
       },
       "source": [
-        "The following `download_ufc_101_subset` function allows you to download a subset of the UCF101 dataset and split it into the training, validation, and test sets. You can specify the number of classes that you would like to use. The `splits` argument allows you to pass in a dictionary in which the key values are the name of subset (example: \"train\") and the number of videos you would like to have per class."
+        "The following `download_ucf_101_subset` function allows you to download a subset of the UCF101 dataset and split it into the training, validation, and test sets. You can specify the number of classes that you would like to use. The `splits` argument allows you to pass in a dictionary in which the key values are the name of subset (example: \"train\") and the number of videos you would like to have per class."
       ]
     },
     {
@@ -455,8 +455,8 @@
       },
       "outputs": [],
       "source": [
-        "def download_ufc_101_subset(zip_url, num_classes, splits, download_dir):\n",
-        "  \"\"\" Download a subset of the UFC101 dataset and split them into various parts, such as\n",
+        "def download_ucf_101_subset(zip_url, num_classes, splits, download_dir):\n",
+        "  \"\"\" Download a subset of the UCF101 dataset and split them into various parts, such as\n",
         "    training, validation, and test.\n",
         "\n",
         "    Args:\n",
@@ -506,7 +506,7 @@
       "outputs": [],
       "source": [
         "download_dir = pathlib.Path('./UCF101_subset/')\n",
-        "subset_paths = download_ufc_101_subset(URL,\n",
+        "subset_paths = download_ucf_101_subset(URL,\n",
         "                                       num_classes = NUM_CLASSES,\n",
         "                                       splits = {\"train\": 30, \"val\": 10, \"test\": 10},\n",
         "                                       download_dir = download_dir)"

--- a/site/en/tutorials/load_data/video.ipynb
+++ b/site/en/tutorials/load_data/video.ipynb
@@ -1002,7 +1002,6 @@
         "id": "DdJm7ojgGxtT"
       },
       "source": [
-        "\n",
         "To learn more about working with video data in TensorFlow, check out the following tutorials:\n",
         "\n",
         "* [Build a 3D CNN model for video classification](https://www.tensorflow.org/tutorials/video/video_classification)\n",
@@ -1015,8 +1014,6 @@
     "accelerator": "GPU",
     "colab": {
       "name": "video.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
There were a few cases where the dataset was referred to as UFC rather than UCF.