### PR TITLE
Simple audio tutorial: macOS fix, typo, do not mix label variables

### DIFF
--- a/site/en/tutorials/audio/simple_audio.ipynb
+++ b/site/en/tutorials/audio/simple_audio.ipynb
@@ -178,7 +178,7 @@
       "outputs": [],
       "source": [
         "commands = np.array(tf.io.gfile.listdir(str(data_dir)))\n",
-        "commands = commands[commands != 'README.md']\n",
+        "commands = commands[(commands != 'README.md') & (commands != '.DS_Store')]\n",
         "print('Commands:', commands)"
       ]
     },
@@ -266,7 +266,7 @@
       },
       "source": [
         "The `utils.audio_dataset_from_directory` function only returns up to two splits. It's a good idea to keep a test set separate from your validation set.\n",
-        "Ideally you'd keep it in a separate directory, but in this case you can use `Dataset.shard` to split the validation set into two halves. Note that iterating over **any** shard will load **all** the data, and only keep it's fraction. "
+        "Ideally you'd keep it in a separate directory, but in this case you can use `Dataset.shard` to split the validation set into two halves. Note that iterating over **any** shard will load **all** the data, and only keep its fraction. "
       ]
     },
     {
@@ -547,7 +547,7 @@
         "    c = i % cols\n",
         "    ax = axes[r][c]\n",
         "    plot_spectrogram(example_spectrograms[i].numpy(), ax)\n",
-        "    ax.set_title(commands[example_spect_labels[i].numpy()])\n",
+        "    ax.set_title(label_names[example_spect_labels[i].numpy()])\n",
         "\n",
         "plt.show()"
       ]
@@ -609,7 +609,7 @@
       "source": [
         "input_shape = example_spectrograms.shape[1:]\n",
         "print('Input shape:', input_shape)\n",
-        "num_labels = len(commands)\n",
+        "num_labels = len(label_names)\n",
         "\n",
         "# Instantiate the `tf.keras.layers.Normalization` layer.\n",
         "norm_layer = layers.Normalization()\n",
@@ -797,8 +797,8 @@
         "confusion_mtx = tf.math.confusion_matrix(y_true, y_pred)\n",
         "plt.figure(figsize=(10, 8))\n",
         "sns.heatmap(confusion_mtx,\n",
-        "            xticklabels=commands,\n",
-        "            yticklabels=commands,\n",
+        "            xticklabels=label_names,\n",
+        "            yticklabels=label_names,\n",
         "            annot=True, fmt='g')\n",
         "plt.xlabel('Prediction')\n",
         "plt.ylabel('Label')\n",


### PR DESCRIPTION
The [tutorial outcome](https://www.tensorflow.org/tutorials/audio/simple_audio#run_inference_on_an_audio_file) is currently confusing since the plot shows a totally different prediction than the speech file. In the graph, "go" is allegedly predicted:

<img width="771" alt="Tutorial before" src="https://user-images.githubusercontent.com/1376043/209804139-02c6f389-72af-4ac2-aab5-cdf86354ef14.png">

This fixes the bug by using the correct variable for plot labels.

Plus minor fixes (see commit message).

Not sure 