### PR TITLE
Updates in Docker tutorial

### DIFF
--- a/site/en/install/docker.md
+++ b/site/en/install/docker.md
@@ -1,36 +1,37 @@
 # Docker
 
-[Docker](https://docs.docker.com/install/){:.external} uses *containers* to
+[Docker](https://docs.docker.com/install/) uses *containers* to
 create virtual environments that isolate a TensorFlow installation from the rest
 of the system. TensorFlow programs are run *within* this virtual environment that
 can share resources with its host machine (access directories, use the GPU,
 connect to the Internet, etc.). The
-[TensorFlow Docker images](https://hub.docker.com/r/tensorflow/tensorflow/){:.external}
+[TensorFlow Docker images](https://hub.docker.com/r/tensorflow/tensorflow/)
 are tested for each release.
 
-Docker is the easiest way to enable TensorFlow [GPU support](./pip.md) on Linux since only the
-[NVIDIA® GPU driver](https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#how-do-i-install-the-nvidia-driver){:.external}
+Docker is the easiest way to enable TensorFlow GPU support on Linux since only the
+[NVIDIA® GPU driver](https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#how-do-i-install-the-nvidia-driver)
 is required on the *host* machine (the *NVIDIA® CUDA® Toolkit* does not need to
-be installed).
+be installed). If you don't require the use of Docker, refer to
+[this installation guide](./pip.md).
 
 
 ## TensorFlow Docker requirements
 
-1. [Install Docker](https://docs.docker.com/install/){:.external} on
+1. [Install Docker](https://docs.docker.com/install/) on
    your local *host* machine.
-2. For GPU support on Linux, [install NVIDIA Docker support](https://github.com/NVIDIA/nvidia-docker){:.external}.
+2. For GPU support on Linux, [install NVIDIA Docker support](https://github.com/NVIDIA/nvidia-docker).
    * Take note of your Docker version with `docker -v`. Versions __earlier than__ 19.03 require nvidia-docker2 and the `--runtime=nvidia` flag. On versions __including and after__ 19.03, you will use the `nvidia-container-toolkit` package and the `--gpus all` flag. Both options are documented on the page linked above.
 
 Note: To run the `docker` command without `sudo`, create the `docker` group and
 add your user. For details, see the
-[post-installation steps for Linux](https://docs.docker.com/install/linux/linux-postinstall/){:.external}.
+[post-installation steps for Linux](https://docs.docker.com/install/linux/linux-postinstall/).
 
 
 ## Download a TensorFlow Docker image
 
 The official TensorFlow Docker images are located in the 
-[tensorflow/tensorflow](https://hub.docker.com/r/tensorflow/tensorflow/){:.external}
-Docker Hub repository. Image releases [are tagged](https://hub.docker.com/r/tensorflow/tensorflow/tags/){:.external}
+[tensorflow/tensorflow](https://hub.docker.com/r/tensorflow/tensorflow/)
+Docker Hub repository. Image releases [are tagged](https://hub.docker.com/r/tensorflow/tensorflow/tags/)
 using the following format:
 
 | Tag         | Description                                                                                                          |
@@ -66,7 +67,7 @@ To start a TensorFlow-configured container, use the following command form:
 docker run [-it] [--rm] [-p <em>hostPort</em>:<em>containerPort</em>] tensorflow/tensorflow[:<em>tag</em>] [<em>command</em>]
 </pre>
 
-For details, see the [docker run reference](https://docs.docker.com/engine/reference/run/){:.external}.
+For details, see the [docker run reference](https://docs.docker.com/engine/reference/run/).
 
 ### Examples using CPU-only images
 
@@ -100,7 +101,7 @@ docker run -it --rm -v $PWD:/tmp -w /tmp tensorflow/tensorflow python ./script.p
 Permission issues can arise when files created within a container are exposed to
 the host. It's usually best to edit files on the host system.
 
-Start a [Jupyter Notebook](https://jupyter.org/){:.external} server using
+Start a [Jupyter Notebook](https://jupyter.org/) server using
 TensorFlow's nightly build:
 
 <pre class="devsite-terminal devsite-click-to-copy">
@@ -114,13 +115,13 @@ Follow the instructions and open the URL in your host web browser:
 ## GPU support
 
 Docker is the easiest way to run TensorFlow on a GPU since the *host* machine
-only requires the [NVIDIA® driver](https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#how-do-i-install-the-nvidia-driver){:.external}
+only requires the [NVIDIA® driver](https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#how-do-i-install-the-nvidia-driver)
 (the *NVIDIA® CUDA® Toolkit* is not required).
 
-Install the [Nvidia Container Toolkit](https://github.com/NVIDIA/nvidia-docker/blob/master/README.md#quickstart){:.external} 
+Install the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker/blob/master/README.md#quickstart) 
 to add NVIDIA® GPU support to Docker. `nvidia-container-runtime` is only
 available for Linux. See the `nvidia-container-runtime` 
-[platform support FAQ](https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#platform-support){:.external}
+[platform support FAQ](https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#platform-support)
 for details.
 
 Check if a GPU is available:

--- a/site/en/install/docker.md
+++ b/site/en/install/docker.md
@@ -8,7 +8,7 @@ connect to the Internet, etc.). The
 [TensorFlow Docker images](https://hub.docker.com/r/tensorflow/tensorflow/){:.external}
 are tested for each release.
 
-Docker is the easiest way to enable TensorFlow [GPU support](./gpu.md) on Linux since only the
+Docker is the easiest way to enable TensorFlow [GPU support](https://www.tensorflow.org/install/pip) on Linux since only the
 [NVIDIA® GPU driver](https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#how-do-i-install-the-nvidia-driver){:.external}
 is required on the *host* machine (the *NVIDIA® CUDA® Toolkit* does not need to
 be installed).
@@ -37,7 +37,7 @@ using the following format:
 |-------------|----------------------------------------------------------------------------------------------------------------------|
 | `latest`    | The latest release of TensorFlow CPU binary image. Default.                                                          |
 | `nightly`   | Nightly builds of the TensorFlow image. (Unstable.)                                                                  |
-| *`version`* | Specify the *version* of the TensorFlow binary image, for example\: *2.1.0*                                          |
+| *`version`* | Specify the *version* of the TensorFlow binary image, for example\: *2.8.0*                                          |
 | `devel`     | Nightly builds of a TensorFlow `master` development environment. Includes TensorFlow source code.                    |
 | `custom-op` | Special experimental image for developing TF custom ops.  More info [here](https://github.com/tensorflow/custom-op). |
 

--- a/site/en/install/docker.md
+++ b/site/en/install/docker.md
@@ -8,7 +8,7 @@ connect to the Internet, etc.). The
 [TensorFlow Docker images](https://hub.docker.com/r/tensorflow/tensorflow/){:.external}
 are tested for each release.
 
-Docker is the easiest way to enable TensorFlow [GPU support](https://www.tensorflow.org/install/pip) on Linux since only the
+Docker is the easiest way to enable TensorFlow [GPU support](./pip.md) on Linux since only the
 [NVIDIA® GPU driver](https://github.com/NVIDIA/nvidia-docker/wiki/Frequently-Asked-Questions#how-do-i-install-the-nvidia-driver){:.external}
 is required on the *host* machine (the *NVIDIA® CUDA® Toolkit* does not need to
 be installed).

--- a/site/en/install/docker.md
+++ b/site/en/install/docker.md
@@ -37,7 +37,7 @@ using the following format:
 |-------------|----------------------------------------------------------------------------------------------------------------------|
 | `latest`    | The latest release of TensorFlow CPU binary image. Default.                                                          |
 | `nightly`   | Nightly builds of the TensorFlow image. (Unstable.)                                                                  |
-| *`version`* | Specify the *version* of the TensorFlow binary image, for example\: *2.8.0*                                          |
+| *`version`* | Specify the *version* of the TensorFlow binary image, for example\: *2.8.3*                                          |
 | `devel`     | Nightly builds of a TensorFlow `master` development environment. Includes TensorFlow source code.                    |
 | `custom-op` | Special experimental image for developing TF custom ops.  More info [here](https://github.com/tensorflow/custom-op). |
 

--- a/site/en/tutorials/load_data/video.ipynb
+++ b/site/en/tutorials/load_data/video.ipynb
@@ -1002,7 +1002,6 @@
         "id": "DdJm7ojgGxtT"
       },
       "source": [
-        "\n",
         "To learn more about working with video data in TensorFlow, check out the following tutorials:\n",
         "\n",
         "* [Build a 3D CNN model for video classification](https://www.tensorflow.org/tutorials/video/video_classification)\n",
@@ -1015,8 +1014,6 @@
     "accelerator": "GPU",
     "colab": {
       "name": "video.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
Fixed broken link in Docker tutorial  at text  "GPU support" and Update 2.1 to 2.8 version Replaced "./gpu.md"
with  
https://www.tensorflow.org/install/pip