### PR TITLE
Include print function in predictions

### DIFF
--- a/site/en/tutorials/quickstart/beginner.ipynb
+++ b/site/en/tutorials/quickstart/beginner.ipynb
@@ -189,7 +189,7 @@
       "outputs": [],
       "source": [
         "predictions = model(x_train[:1]).numpy()\n",
-        "predictions"
+        "print(predictions)"
       ]
     },
     {


### PR DESCRIPTION
Adds a print function to the predictions section in case the reader wants to verify the functionality of the model using their own environment. 

Seeing is believing. I just found it odd the docs show what seems to be the expected return array, but don't provide the user by default a way to confirm this for themselves using a local environment. Optionally could extend this to the other examples on the page as well.