### PR TITLE
Fixing the broken link in tf_records.ipynb

### DIFF
--- a/site/en/r1/tutorials/load_data/tf_records.ipynb
+++ b/site/en/r1/tutorials/load_data/tf_records.ipynb
@@ -632,7 +632,7 @@
       "source": [
         "We can also read the TFRecord file using the `tf.data.TFRecordDataset` class.\n",
         "\n",
-        "More information on consuming TFRecord files using `tf.data` can be found [here](https://www.tensorflow.org/r1/guide/datasets#consuming_tfrecord_data).\n",
+        "More information on consuming TFRecord files using `tf.data` can be found [here](https://www.tensorflow.org/guide/data#consuming_tfrecord_data).\n",
         "\n",
         "Using `TFRecordDataset`s can be useful for standardizing input data and optimizing performance."
       ]


### PR DESCRIPTION
Replaced the broken link in **tf_records.ipynb** with the right link