### PR TITLE
Fix inequality for best validation loss

### DIFF
--- a/site/en/guide/migrate/early_stopping.ipynb
+++ b/site/en/guide/migrate/early_stopping.ipynb
@@ -486,7 +486,7 @@
         "    # The early stopping strategy: stop the training if `val_loss` does not\n",
         "    # decrease over a certain number of epochs.\n",
         "    wait += 1\n",
-        "    if val_loss > best:\n",
+        "    if val_loss < best:\n",
         "      best = val_loss\n",
         "      wait = 0\n",
         "    if wait >= patience:\n",

--- a/site/en/guide/migrate/early_stopping.ipynb
+++ b/site/en/guide/migrate/early_stopping.ipynb
@@ -457,7 +457,7 @@
         "epochs = 100\n",
         "patience = 5\n",
         "wait = 0\n",
-        "best = float("inf")\n",
+        "best = float('inf')\n",
         "\n",
         "for epoch in range(epochs):\n",
         "    print(\"\\nStart of epoch %d\" % (epoch,))\n",

--- a/site/en/guide/migrate/early_stopping.ipynb
+++ b/site/en/guide/migrate/early_stopping.ipynb
@@ -457,7 +457,7 @@
         "epochs = 100\n",
         "patience = 5\n",
         "wait = 0\n",
-        "best = 0\n",
+        "best = float("inf")\n",
         "\n",
         "for epoch in range(epochs):\n",
         "    print(\"\\nStart of epoch %d\" % (epoch,))\n",


### PR DESCRIPTION
Fixing a minor mistake in the documentation for early stopping with custom training loop.  The tutorial shows the best validation loss starting at 0 and being updated if the current validation loss is greater than, as opposed to less than, the best.