### PR TITLE
Fixed documentation in Contribute to code page

### DIFF
--- a/site/en/community/contribute/code.md
+++ b/site/en/community/contribute/code.md
@@ -34,7 +34,8 @@ workflow, and for the core devs to become acquainted with the contributor.
 
 If you are interested in recruiting a team to help tackle a large-scale problem
 or a new feature, please email the
-[developers@tensorflow.org](https://groups.google.com/a/tensorflow.org/g/developers) group and review our current list of RFCs.
+[developers@ group](https://groups.google.com/a/tensorflow.org/g/developers)
+and review our current list of RFCs.
 
 ## Code review
 

--- a/site/en/community/contribute/code.md
+++ b/site/en/community/contribute/code.md
@@ -34,8 +34,7 @@ workflow, and for the core devs to become acquainted with the contributor.
 
 If you are interested in recruiting a team to help tackle a large-scale problem
 or a new feature, please email the
-[developers@ group](https://groups.google.com/a/tensorflow.org/forum/#!forum/developers)
-and review our current list of RFCs.
+[developers@tensorflow.org](https://groups.google.com/a/tensorflow.org/g/developers) group and review our current list of RFCs.
 
 ## Code review
 


### PR DESCRIPTION
Fixed group name and the corresponding hyperlink under [Issues for New Contributors](https://www.tensorflow.org/community/contribute/code#issues_for_new_contributors)