### PR TITLE
Updated old NumPy API Link to New one

### DIFF
--- a/site/en/guide/tf_numpy.ipynb
+++ b/site/en/guide/tf_numpy.ipynb
@@ -70,7 +70,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "TensorFlow implements a subset of the [NumPy API](https://numpy.org/doc/stable/reference/index.html), available as `tf.experimental.numpy`. This allows running NumPy code, accelerated by TensorFlow, while also allowing access to all of TensorFlow's APIs."
+        "TensorFlow implements a subset of the [NumPy API](https://numpy.org/doc/stable/index.html), available as `tf.experimental.numpy`. This allows running NumPy code, accelerated by TensorFlow, while also allowing access to all of TensorFlow's APIs."
       ]
     },
     {

--- a/site/en/guide/tf_numpy.ipynb
+++ b/site/en/guide/tf_numpy.ipynb
@@ -70,7 +70,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "TensorFlow implements a subset of the [NumPy API](https://numpy.org/doc/1.16), available as `tf.experimental.numpy`. This allows running NumPy code, accelerated by TensorFlow, while also allowing access to all of TensorFlow's APIs."
+        "TensorFlow implements a subset of the [NumPy API](https://numpy.org/doc/stable/reference/index.html), available as `tf.experimental.numpy`. This allows running NumPy code, accelerated by TensorFlow, while also allowing access to all of TensorFlow's APIs."
       ]
     },
     {


### PR DESCRIPTION
I have updated old NumPy API link (https://numpy.org/doc/1.16) to Latest and New stable NumPy API Link (https://numpy.org/doc/stable/reference/index.html) so please do the needful. Thank you!