### PR TITLE
Replaced untar with extract in classification.ipynb

### DIFF
--- a/site/en/tutorials/images/classification.ipynb
+++ b/site/en/tutorials/images/classification.ipynb
@@ -153,7 +153,7 @@
         "import pathlib\n",
         "dataset_url = \"https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz\"\n",
         "data_dir = tf.keras.utils.get_file('flower_photos.tar', origin=dataset_url, extract=True)\n",
-        "data_dir = pathlib.Path(data_dir)"
+        "data_dir = pathlib.Path(data_dir).with_suffix('')"
       ]
     },
     {

--- a/site/en/tutorials/images/classification.ipynb
+++ b/site/en/tutorials/images/classification.ipynb
@@ -151,6 +151,7 @@
       "outputs": [],
       "source": [
         "import pathlib\n",
+        "\n",
         "dataset_url = \"https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz\"\n",
         "data_dir = tf.keras.utils.get_file('flower_photos.tar', origin=dataset_url, extract=True)\n",
         "data_dir = pathlib.Path(data_dir).with_suffix('')"

--- a/site/en/tutorials/images/classification.ipynb
+++ b/site/en/tutorials/images/classification.ipynb
@@ -152,7 +152,7 @@
       "source": [
         "import pathlib\n",
         "dataset_url = \"https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz\"\n",
-        "data_dir = tf.keras.utils.get_file('flower_photos', origin=dataset_url, untar=True)\n",
+        "data_dir = tf.keras.utils.get_file('flower_photos.tar', origin=dataset_url, extract=True)\n",
         "data_dir = pathlib.Path(data_dir)"
       ]
     },


### PR DESCRIPTION
As mentioned in the doc https://www.tensorflow.org/api_docs/python/tf/keras/utils/get_file **untar** argument was deprecated in favor of **extract**. Replaced `untar` with `extract`