### PR TITLE
Update bazel version for Linux_CPU in source.md

### DIFF
--- a/site/en/install/source.md
+++ b/site/en/install/source.md
@@ -397,7 +397,7 @@ Success: TensorFlow is now installed.
 <table>
 <tr><th>Version</th><th>Python version</th><th>Compiler</th><th>Build tools</th></tr>
 <tr><td>tensorflow-2.11.0</td><td>3.7-3.10</td><td>GCC 9.3.1</td><td>Bazel 5.3.0</td></tr>
-<tr><td>tensorflow-2.10.0</td><td>3.7-3.10</td><td>GCC 9.3.1</td><td>Bazel 5.0.0</td></tr>
+<tr><td>tensorflow-2.10.0</td><td>3.7-3.10</td><td>GCC 9.3.1</td><td>Bazel 5.1.1</td></tr>
 <tr><td>tensorflow-2.9.0</td><td>3.7-3.10</td><td>GCC 9.3.1</td><td>Bazel 5.0.0</td></tr>
 <tr><td>tensorflow-2.8.0</td><td>3.7-3.10</td><td>GCC 7.3.1</td><td>Bazel 4.2.1</td></tr>
 <tr><td>tensorflow-2.7.0</td><td>3.7-3.9</td><td>GCC 7.3.1</td><td>Bazel 3.7.2</td></tr>


### PR DESCRIPTION
As per source file from r2.10 branch the tested Bazel version for Bazel builds for TF2.10v is 5.1.1. Please refer to source [file](https://github.com/tensorflow/tensorflow/blob/r2.10/.bazelversion).  

But as per documentation still Bazel version is mentioning as 5.0.0 for Linux-CPU build configuration as per [source](https://www.tensorflow.org/install/source#cpu). 

This needs to be updated to 5.1.1 as to eliminate unwanted confusion to users.