### PR TITLE
Removing deprecated argument

### DIFF
--- a/site/en/tutorials/images/transfer_learning_with_hub.ipynb
+++ b/site/en/tutorials/images/transfer_learning_with_hub.ipynb
@@ -324,7 +324,7 @@
         "data_root = tf.keras.utils.get_file(\n",
         "  'flower_photos',\n",
         "  'https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz',\n",
-        "   untar=True)"
+        "   extract=True)"
       ]
     },
     {


### PR DESCRIPTION
The untar argument is now deprecated in favor of extract according to the information at https://www.tensorflow.org/api_docs/python/tf/keras/utils/get_file. This PR replaces the untar argument used in this tutorial's keras.utils.get_file method with extract.