### PR TITLE
Updated the old link to new link in validate_correctness.ipynb

### DIFF
--- a/site/en/guide/migrate/validate_correctness.ipynb
+++ b/site/en/guide/migrate/validate_correctness.ipynb
@@ -1254,7 +1254,7 @@
       "source": [
         "## Step 3b or 4b (optional): Testing with pre-existing checkpoints\n",
         "\n",
-        "After step 3 or step 4 above, it can be useful to run your numerical equivalence tests when starting from pre-existing name-based checkpoints if you have some. This can test both that your legacy checkpoint loading is working correctly and that the model itself is working right. The [Reusing TF1.x checkpoints guide](./reuse_checkpoints.ipynb) covers how to reuse your pre-existing TF1.x checkpoints and transfer them over to TF2 checkpoints.\n"
+        "After step 3 or step 4 above, it can be useful to run your numerical equivalence tests when starting from pre-existing name-based checkpoints if you have some. This can test both that your legacy checkpoint loading is working correctly and that the model itself is working right. The [Reusing TF1.x checkpoints guide](https://github.com/tensorflow/docs/blob/master/site/en/guide/migrate/migrating_checkpoints.ipynb) covers how to reuse your pre-existing TF1.x checkpoints and transfer them over to TF2 checkpoints.\n"
       ]
     },
     {

--- a/site/en/guide/migrate/validate_correctness.ipynb
+++ b/site/en/guide/migrate/validate_correctness.ipynb
@@ -1254,7 +1254,7 @@
       "source": [
         "## Step 3b or 4b (optional): Testing with pre-existing checkpoints\n",
         "\n",
-        "After step 3 or step 4 above, it can be useful to run your numerical equivalence tests when starting from pre-existing name-based checkpoints if you have some. This can test both that your legacy checkpoint loading is working correctly and that the model itself is working right. The [Reusing TF1.x checkpoints guide](https://github.com/tensorflow/docs/blob/master/site/en/guide/migrate/migrating_checkpoints.ipynb) covers how to reuse your pre-existing TF1.x checkpoints and transfer them over to TF2 checkpoints.\n"
+        "After step 3 or step 4 above, it can be useful to run your numerical equivalence tests when starting from pre-existing name-based checkpoints if you have some. This can test both that your legacy checkpoint loading is working correctly and that the model itself is working right. The [Reusing TF1.x checkpoints guide](./migrating_checkpoints.ipynb) covers how to reuse your pre-existing TF1.x checkpoints and transfer them over to TF2 checkpoints.\n"
       ]
     },
     {


### PR DESCRIPTION
Updated the broken link for Reusing TF1.x checkpoints guide with correct link