### PR TITLE
fix minor typo on the image segmentation tutorial

### DIFF
--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -710,7 +710,7 @@
         "id": "Gbwo3DZ-9TxM"
       },
       "source": [
-        "So, to make sample weights for this tutorial, you need a function that takes a `(data, label)` pair and returns a `(data, label, sample_weight)` triple. Where the `sample_weight` is a 1-channel image containing the class weight for each pixel.\n",
+        "So, to make sample weights for this tutorial, you need a function that takes a `(data, label)` pair and returns a `(data, label, sample_weight)` triple where the `sample_weight` is a 1-channel image containing the class weight for each pixel.\n",
         "\n",
         "The simplest possible implementation is to use the label as an index into a `class_weight` list:"
       ]
@@ -804,7 +804,7 @@
         "\n",
         "Now that you have an understanding of what image segmentation is and how it works, you can try this tutorial out with different intermediate layer outputs, or even different pretrained models. You may also challenge yourself by trying out the [Carvana](https://www.kaggle.com/c/carvana-image-masking-challenge/overview) image masking challenge hosted on Kaggle.\n",
         "\n",
-        "You may also want to see the [Tensorflow Object Detection API](https://github.com/tensorflow/models/blob/master/research/object_detection/README.md) for another model you can retrain on your own data. Pretrained models are available on [TensorFlow Hub](https://www.tensorflow.org/hub/tutorials/tf2_object_detection#optional)"
+        "You may also want to see the [Tensorflow Object Detection API](https://github.com/tensorflow/models/blob/master/research/object_detection/README.md) for another model you can retrain on your own data. Pretrained models are available on [TensorFlow Hub](https://www.tensorflow.org/hub/tutorials/tf2_object_detection#optional)."
       ]
     }
   ],

--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -452,7 +452,7 @@
         "\n",
         "Now, all that is left to do is to compile and train the model. \n",
         "\n",
-        "Since this is a multiclass classification problem, use the `tf.keras.losses.CategoricalCrossentropy` loss function with the `from_logits` argument set to `True`, since the labels are scalar integers instead of vectors of scores for each pixel of every class.\n",
+        "Since this is a multiclass classification problem, use the `tf.keras.losses.SparseCategoricalCrossentropy` loss function with the `from_logits` argument set to `True`, since the labels are scalar integers instead of vectors of scores for each pixel of every class.\n",
         "\n",
         "When running inference, the label assigned to the pixel is the channel with the highest value. This is what the `create_mask` function is doing."
       ]


### PR DESCRIPTION
tf.keras.losses.CategoricalCrossentropy should be changed to tf.keras.losses.SparseCategoricalCrossentropy since the pixel classes (labels) are integers, not one-hot encoded. Code is written correct, but the markdown should fix to prevent potential confusion to readers.