### PR TITLE
Please add missing folders for TF C library for Windows CPU only

### DIFF
--- a/site/en/install/lang_c.ipynb
+++ b/site/en/install/lang_c.ipynb
@@ -147,6 +147,7 @@
         "    </aside>\n",
         "  </td></tr>\n",
         "  <tr>\n",
+        "  Below setup file is missing some folders so please do the needful, I just added this line to highlight changes
         "    <td>Windows CPU only</td>\n",
         "    <td class=\"devsite-click-to-copy\"><a href=\"https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-windows-x86_64-2.11.0.zip\">https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-windows-x86_64-2.11.0.zip</a></td>\n",
         "  </tr>\n",


### PR DESCRIPTION
I found some folders are missing in the `include` folder for `Windows CPU only(2.11)` set up file (https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-windows-x86_64-2.11.0.zip) and after extracting setup file, `include` folder  is having structure like, `include-->tensorflow-->core-->c` but actual folder should have folder structure like, `include-->tensorflow-->tsl-->python_tensorflow-->core-->c` so `tsl` and `python_tensorflow `folders are missing and user also reported this issue [#59762](https://github.com/tensorflow/tensorflow/issues/59762). Please do the needful. Thank you!