### PR TITLE
Minor scope typo fix in music gen tutorial

### DIFF
--- a/site/en/tutorials/audio/music_generation.ipynb
+++ b/site/en/tutorials/audio/music_generation.ipynb
@@ -1081,7 +1081,7 @@
         "  # Add batch dimension\n",
         "  inputs = tf.expand_dims(notes, 0)\n",
         "\n",
-        "  predictions = model.predict(inputs)\n",
+        "  predictions = keras_model.predict(inputs)\n",
         "  pitch_logits = predictions['pitch']\n",
         "  step = predictions['step']\n",
         "  duration = predictions['duration']\n",


### PR DESCRIPTION
_predict_next_note()_ function required _keras_model_ argument, but was using _model_ variable from parent scope.