### PR TITLE
minor typo fix function return type

### DIFF
--- a/site/en/tutorials/audio/music_generation.ipynb
+++ b/site/en/tutorials/audio/music_generation.ipynb
@@ -1073,7 +1073,7 @@
         "def predict_next_note(\n",
         "    notes: np.ndarray, \n",
         "    keras_model: tf.keras.Model, \n",
-        "    temperature: float = 1.0) -> int:\n",
+        "    temperature: float = 1.0) -> Tuple:\n",
         "  \"\"\"Generates a note IDs using a trained sequence model.\"\"\"\n",
         "\n",
         "  assert temperature > 0\n",


### PR DESCRIPTION
*predict_next_note* returns a tuple of 3 values, but it currently shows int as the return type