### PR TITLE
Wrong x-axis label order

### DIFF
--- a/site/en/tutorials/audio/simple_audio.ipynb
+++ b/site/en/tutorials/audio/simple_audio.ipynb
@@ -826,7 +826,7 @@
         "x = x[tf.newaxis,...]\n",
         "\n",
         "prediction = model(x)\n",
-        "x_labels = ['up', 'no', 'stop', 'right', 'down', 'left', 'yes', 'go']\n",
+        "x_labels = ['down', 'go', 'left', 'no', 'right', 'stop', 'up', 'yes']\n",
         "plt.bar(x_labels, tf.nn.softmax(prediction[0]))\n",
         "plt.title('No')\n",
         "plt.show()\n",


### PR DESCRIPTION

Just take a look at this chapter's graph
[www.tensorflow.org/tutorials/audio/simple_audio#run_inference_on_an_audio_file](http://www.tensorflow.org/tutorials/audio/simple_audio)
You may find It is wrong actually. Result is not campatible with the words.
It seems you posted the wrong order of x-axis labels.
The correct order is followed by initial characters by alphabet order.
So I propose it should be ['down', 'go', 'left', 'no', 'right', 'stop', 'up', 'yes']
I am not so sure whether there are any hidden possible order I did not notice from this.
If have, please tell me and then take the correction order.
