### PR TITLE
Change the example for non-strict graph execution

### DIFF
--- a/site/en/guide/intro_to_graphs.ipynb
+++ b/site/en/guide/intro_to_graphs.ipynb
@@ -649,7 +649,7 @@
         "\n",
         "In particular, runtime error checking does not count as an observable effect. If an operation is skipped because it is unnecessary, it cannot raise any runtime errors.\n",
         "\n",
-        "In the following example, the \"unnecessary\" operation `tf.gather` is skipped during graph execution, so the runtime error `InvalidArgumentError` is not raised as it would be in eager execution. Do not rely on an error being raised while executing a graph."
+        "In the following example, the \"unnecessary\" operation `tf.slice` is skipped during graph execution, so the runtime error `InvalidArgumentError` is not raised as it would be in eager execution. Do not rely on an error being raised while executing a graph."
       ]
     },
     {
@@ -661,8 +661,8 @@
       "outputs": [],
       "source": [
         "def unused_return_eager(x):\n",
-        "  # Get index 1 will fail when `len(x) == 1`\n",
-        "  tf.gather(x, [1]) # unused \n",
+        "  # Slice with size 2 will fail when `len(x) == 1`\n",
+        "  tf.slice(x, [0], [2]) # unused \n",
         "  return x\n",
         "\n",
         "try:\n",
@@ -682,7 +682,7 @@
       "source": [
         "@tf.function\n",
         "def unused_return_graph(x):\n",
-        "  tf.gather(x, [1]) # unused\n",
+        "  tf.slice(x, [0], [2]) # unused\n",
         "  return x\n",
         "\n",
         "# Only needed operations are run during graph execution. The error is not raised.\n",


### PR DESCRIPTION
Resubmit https://github.com/tensorflow/docs/pull/2206, since I lost the branch and didn't pass the lint test.

Change the function from tf.gather to tf.slice, because tf.gather doesn't trigger InvalidArgumentError under GPU environment. Instead, "0 is stored in the corresponding output value" according to https://www.tensorflow.org/api_docs/python/tf/gather. Therefore there is no difference in the results of https://www.tensorflow.org/guide/intro_to_graphs#non-strict_execution.

After this change, as expected: tf.slice(x, [1], [1]) will trigger the error during eager execution under both CPU and GPU enviroments. It will not trigger the error for graph execution.