### PR TITLE
Fix pip install docs on linux and wsl2

### DIFF
--- a/site/en/install/pip.md
+++ b/site/en/install/pip.md
@@ -260,8 +260,8 @@ The following NVIDIA® software are only required for GPU support.
 
     ```bash
     mkdir -p $CONDA_PREFIX/etc/conda/activate.d
-    CUDNN_PATH=$(dirname $(python -c "import nvidia.cudnn;print(nvidia.cudnn.__file__)"))
-    echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CONDA_PREFIX/lib/:$CUDNN_PATH/lib' > $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+    echo 'CUDNN_PATH=$(dirname $(python -c "import nvidia.cudnn;print(nvidia.cudnn.__file__)"))' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+    echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CONDA_PREFIX/lib/:$CUDNN_PATH/lib' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
     ```
 
     ### 5. Install TensorFlow
@@ -628,8 +628,8 @@ The following NVIDIA® software are only required for GPU support.
 
     ```bash
     mkdir -p $CONDA_PREFIX/etc/conda/activate.d
-    CUDNN_PATH=$(dirname $(python -c "import nvidia.cudnn;print(nvidia.cudnn.__file__)"))
-    echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CONDA_PREFIX/lib/:$CUDNN_PATH/lib' > $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+    echo 'CUDNN_PATH=$(dirname $(python -c "import nvidia.cudnn;print(nvidia.cudnn.__file__)"))' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+    echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CONDA_PREFIX/lib/:$CUDNN_PATH/lib' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
     ```
 
     ### 5. Install TensorFlow


### PR DESCRIPTION
The install on linux still failes if the extended docs are used, because the CUDNN_PATH variable is not set when executing the activate script

An alternative would be to use:

`echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:'"$CONDA_PREFIX/lib/:$CUDNN_PATH/lib" > $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh`

which would also be idempotent. Yet I did stick to the current suggested way of appending to the existing file.