### PR TITLE
Update time_series.ipynb

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -1376,7 +1376,7 @@
       "outputs": [],
       "source": [
         "print('Input shape:', wide_window.example[0].shape)\n",
-        "print('Output shape:', baseline(wide_window.example[0]).shape)"
+        "print('Output shape:', linear(wide_window.example[0]).shape)"
       ]
     },
     {


### PR DESCRIPTION
The description above the corrected code said that the `linear` model could be called with `wide_window`, but instead the `baseline` model was called. So I corrected the code to call the `linear` model. 

The outputs are unchanged and match the description.