### PR TITLE
To fix `nbformat` pre-commit instructions...

### DIFF
--- a/tools/tensorflow_docs/tools/README.md
+++ b/tools/tensorflow_docs/tools/README.md
@@ -58,14 +58,16 @@ this, use a standard Git hook or use the
 [https://pre-commit.com/](https://pre-commit.com/) framework to create the hook
 for you.
 
-If you want to use pre-commit to handle the hook installation for you, include
-the [.pre-commit-hooks.yaml](./.pre-commit-hooks.yaml) file in your repo with
-the following contents:
+If you want to use pre-commit to handle the hook installation for you, create a
+`.pre-commit-config.yaml` file with the contents below to include the `nbformat`
+hook from the [.pre-commit-hooks.yaml](./.pre-commit-hooks.yaml) plugin.
 
 ```
 repos:
 - repo: https://github.com/tensorflow/docs
-  rev: pre-commit
+  rev: 2023.5.24.56664
+  hooks:
+  - id: nbformat
 ```
 
 Someone who clones that repo for development would then install the hook with:


### PR DESCRIPTION
The current instructions did not work from me and didn't seem to match the usage in the [pre-commit docs](https://pre-commit.com/). I believe that these changes will address the issue by

1. specifying that the given YAML contents go in a *.pre-commit-config.yaml* file;
2. clarifying that *.pre-commit-hooks.yaml* is a pre-commit plugin;
3. fixing the `rev` (there's no `pre-commit` rev so I used the only [release tag](https://github.com/tensorflow/docs/blob/2023.5.24.56664/tools/tensorflow_docs/tools/.pre-commit-hooks.yaml) I found); and
4. completing the config by specifying which `hooks` to run (from the plugin).

However, it still won't work as-is because `.pre-commit-hooks.yaml` is not located at the root of the repo (as indicated in https://pre-commit.com/#new-hooks). Am I missing something? E.g. is *tools/tensorflow_docs/tools* intended as some sort of subrepo?