### PR TITLE
Update note in transfer_learning.ipynb related to Model.fit

### DIFF
--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -1077,7 +1077,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "transfer_learning.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -337,7 +337,7 @@
         "id": "s9SlcbhrarOO"
       },
       "source": [
-        "Note: These layers are active only during training, when you call `Model.fit`. They are inactive when the model is used in inference mode in `Model.evaluate` or `Model.call`."
+        "Note: These layers are active only during training, when you call `Model.fit`. They are inactive when the model is used in inference mode in `Model.evaluate`, `Model.predict`, or `Model.call`."
       ]
     },
     {

--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -337,7 +337,7 @@
         "id": "s9SlcbhrarOO"
       },
       "source": [
-        "Note: These layers are active only during training, when you call `Model.fit`. They are inactive when the model is used in inference mode in `Model.evaluate` or `Model.fit`."
+        "Note: These layers are active only during training, when you call `Model.fit`. They are inactive when the model is used in inference mode in `Model.evaluate` or `Model.call`."
       ]
     },
     {


### PR DESCRIPTION
**Typo**
Note: These layers are active only during training, when you call [Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit). They are inactive when the model is used in inference mode in [Model.evaluate](https://www.tensorflow.org/api_docs/python/tf/keras/Model#evaluate) or **[Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit)**.

The second reference to `Model.fit` is not intended or correct and should be changed to `Model.call` as follows:

**Correction**
Note: These layers are active only during training, when you call [Model.fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit). They are inactive when the model is used in inference mode in [Model.evaluate](https://www.tensorflow.org/api_docs/python/tf/keras/Model#evaluate) or **[Model.call](https://www.tensorflow.org/api_docs/python/tf/keras/Model#call)**.

[Issue #60907 ](https://github.com/tensorflow/tensorflow/issues/60907)