### PR TITLE
Added Activation Function and Increased Training Epochs in the CSV Tutorial

### DIFF
--- a/site/en/tutorials/load_data/csv.ipynb
+++ b/site/en/tutorials/load_data/csv.ipynb
@@ -226,7 +226,7 @@
       "outputs": [],
       "source": [
         "abalone_model = tf.keras.Sequential([\n",
-        "  layers.Dense(64),\n",
+        "  layers.Dense(64, activation='relu'),\n",
         "  layers.Dense(1)\n",
         "])\n",
         "\n",
@@ -251,7 +251,7 @@
       },
       "outputs": [],
       "source": [
-        "abalone_model.fit(abalone_features, abalone_labels, epochs=10)"
+        "abalone_model.fit(abalone_features, abalone_labels, epochs=30)"
       ]
     },
     {
@@ -337,14 +337,14 @@
       "source": [
         "norm_abalone_model = tf.keras.Sequential([\n",
         "  normalize,\n",
-        "  layers.Dense(64),\n",
+        "  layers.Dense(64, activation='relu'),\n",
         "  layers.Dense(1)\n",
         "])\n",
         "\n",
         "norm_abalone_model.compile(loss = tf.keras.losses.MeanSquaredError(),\n",
         "                           optimizer = tf.keras.optimizers.Adam())\n",
         "\n",
-        "norm_abalone_model.fit(abalone_features, abalone_labels, epochs=10)"
+        "norm_abalone_model.fit(abalone_features, abalone_labels, epochs=30)"
       ]
     },
     {
@@ -646,7 +646,7 @@
       "source": [
         "def titanic_model(preprocessing_head, inputs):\n",
         "  body = tf.keras.Sequential([\n",
-        "    layers.Dense(64),\n",
+        "    layers.Dense(64, activation='relu'),\n",
         "    layers.Dense(1)\n",
         "  ])\n",
         "\n",
@@ -678,7 +678,7 @@
       },
       "outputs": [],
       "source": [
-        "titanic_model.fit(x=titanic_features_dict, y=titanic_labels, epochs=10)"
+        "titanic_model.fit(x=titanic_features_dict, y=titanic_labels, epochs=30)"
       ]
     },
     {


### PR DESCRIPTION
This PR adds non-linear ReLU activation functions to the CSV tutorial in order to make the networks non-linear. I have noticed that the activation functions are missing as they are set to None when not explicitly passed and also, as to my knowledge, not added anywhere else. This makes the network linear which is probably not what we want in this context as we don't know whether the dataset is linear. Furthermore, stacking several layers does not make much sense in the linear case as it does not add any more capacity to the network.

Using a non-linear neural network also increases the training performance as shown in the evaluation below. However, the difference is only visible if trained for a little longer, this is why I increased the training epochs to 30.

Training on the abalone dataset for 30 epochs over $n=10$ runs **without** an activation function leads to the following loss (mean $\pm$ std):
$5.10\pm0.04$

Training with the same conditions but **with** ReLU as activation function:
$4.90\pm0.03$

The training examples later in the tutorial show a similar performance increase when ReLU is used.