### PR TITLE
fix: inconsistent single host multi-device distributed guide

### DIFF
--- a/site/en/guide/distributed_training.ipynb
+++ b/site/en/guide/distributed_training.ipynb
@@ -527,8 +527,7 @@
         "\n",
         "with mirrored_strategy.scope():\n",
         "  model = tf.keras.Sequential([tf.keras.layers.Dense(1, input_shape=(1,))])\n",
-        "\n",
-        "model.compile(loss='mse', optimizer='sgd')"
+        "  model.compile(loss='mse', optimizer='sgd')"
       ]
     },
     {


### PR DESCRIPTION
In reference to the Keras [documentation](https://keras.io/guides/distributed_training/#singlehost-multidevice-synchronous-training) regarding single-host multi-device training, both model creation and compilation are advised to be executed within the `strategy.scope`. However, the official TensorFlow [guide](https://www.tensorflow.org/guide/distributed_training#use_tfdistributestrategy_with_keras_modelfit) shows `model.compile(...)` outside of `strategy.scope`. Possible inconsistency? Appreciate any clarification on this matter and I've opened this PR just in case. Thank you.