### PR TITLE
Keras basic text classification tutorial: removed +1 from embeddings …

### DIFF
--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -631,7 +631,7 @@
       "outputs": [],
       "source": [
         "model = tf.keras.Sequential([\n",
-        "  layers.Embedding(max_features + 1, embedding_dim),\n",
+        "  layers.Embedding(max_features, embedding_dim),\n",
         "  layers.Dropout(0.2),\n",
         "  layers.GlobalAveragePooling1D(),\n",
         "  layers.Dropout(0.2),\n",


### PR DESCRIPTION
…input dimensions

In the Tutorials > Beginner > ML basics with Keras > Basic text classification, there is the following code:
```python
max_features = 10000
sequence_length = 250

vectorize_layer = layers.TextVectorization(
    standardize=custom_standardization,
    max_tokens=max_features,
    output_mode='int',
    output_sequence_length=sequence_length)

# ...

model = tf.keras.Sequential([
  layers.Embedding(max_features + 1, embedding_dim),
  layers.Dropout(0.2),
  layers.GlobalAveragePooling1D(),
  layers.Dropout(0.2),
  layers.Dense(1)])
```

I believe the +1 in `max_features + 1` is unnecessary, as the vocabulary of `TextVectorization` layers already includes the padding and OOV tokens. 