### PR TITLE
pandas df loading tutorial: Fix incorrect super().__init__() call

### DIFF
--- a/site/en/tutorials/load_data/pandas_dataframe.ipynb
+++ b/site/en/tutorials/load_data/pandas_dataframe.ipynb
@@ -533,7 +533,7 @@
         "class MyModel(tf.keras.Model):\n",
         "  def __init__(self):\n",
         "    # Create all the internal layers in init.\n",
-        "    super().__init__(self)\n",
+        "    super().__init__()\n",
         "\n",
         "    self.normalizer = tf.keras.layers.Normalization(axis=-1)\n",
         "\n",


### PR DESCRIPTION
In the beginner's tutorials > load and process data > pandas.DataFrame there is the following code:
```python
class MyModel(tf.keras.Model):
  def __init__(self):
    # Create all the internal layers in init.
    super().__init__(self)

    self.normalizer = tf.keras.layers.Normalization(axis=-1)
    # ...
```
It seems like `super().__init__(self)` is incorrect here, sending `self` as one of the args to the base class `tf.keras.Model`. The documentation of `tf.keras.Model` uses `super().__init__()`, so I suggest to align it.