### PR TITLE
Quickstart advanced tutorial: simplify super().__init__() call

### DIFF
--- a/site/en/tutorials/quickstart/advanced.ipynb
+++ b/site/en/tutorials/quickstart/advanced.ipynb
@@ -178,7 +178,7 @@
       "source": [
         "class MyModel(Model):\n",
         "  def __init__(self):\n",
-        "    super(MyModel, self).__init__()\n",
+        "    super().__init__()\n",
         "    self.conv1 = Conv2D(32, 3, activation='relu')\n",
         "    self.flatten = Flatten()\n",
         "    self.d1 = Dense(128, activation='relu')\n",


### PR DESCRIPTION
In the Quickstart for experts tutorial there is the following code:
```python
class MyModel(Model):
  def __init__(self):
    super(MyModel, self).__init__()
    # ...
```
I suggest to use `super().__init__()` instead as described everywhere else.