### PR TITLE
Load text tutorial: Remove unnecessary +1 from VOCAB_SIZE+1

### DIFF
--- a/site/en/tutorials/load_data/text.ipynb
+++ b/site/en/tutorials/load_data/text.ipynb
@@ -689,8 +689,7 @@
       },
       "outputs": [],
       "source": [
-        "# `vocab_size` is `VOCAB_SIZE + 1` since `0` is used additionally for padding.\n",
-        "int_model = create_model(vocab_size=VOCAB_SIZE + 1, num_labels=4)\n",
+        "int_model = create_model(vocab_size=VOCAB_SIZE, num_labels=4)\n",
         "int_model.compile(\n",
         "    loss=losses.SparseCategoricalCrossentropy(from_logits=True),\n",
         "    optimizer='adam',\n",


### PR DESCRIPTION
In the Beginners tutorials > Load and preprocess data > Text, there is the following code:
```python
# `vocab_size` is `VOCAB_SIZE + 1` since `0` is used additionally for padding.
int_model = create_model(vocab_size=VOCAB_SIZE + 1, num_labels=4)
```
I believe that the +1 in `VOCAB_SIZE + 1` is unnecessary, as the `TextVectorization` layer already includes a padding token (as well as an OOV token) when its `output_mode` is `int`. Per the layer's documentation:
```
      output_mode: Optional specification for the output of the layer. Values
        can be `"int"`, `"multi_hot"`, `"count"` or `"tf_idf"`, configuring the
        layer as follows:
          - `"int"`: Outputs integer indices, one integer index per split string
            token. When `output_mode == "int"`, 0 is reserved for masked
            locations; this reduces the vocab size to
            `max_tokens - 2` instead of `max_tokens - 1`.
```