### PR TITLE
Loading text tutorial: fixed OOV handling

### DIFF
--- a/site/en/tutorials/load_data/text.ipynb
+++ b/site/en/tutorials/load_data/text.ipynb
@@ -1140,8 +1140,9 @@
       },
       "outputs": [],
       "source": [
-        "keys = vocab\n",
-        "values = range(2, len(vocab) + 2)  # Reserve `0` for padding, `1` for OOV tokens.\n",
+        "# Reserve `0` for padding, `1` for OOV tokens.\n",
+        "keys = ['', '[UNK]'] + vocab\n",
+        "values = range(len(keys))\n",
         "\n",
         "init = tf.lookup.KeyValueTensorInitializer(\n",
         "    keys, values, key_dtype=tf.string, value_dtype=tf.int64)\n",
@@ -1171,6 +1172,8 @@
         "  standardized = tf_text.case_fold_utf8(text)\n",
         "  tokenized = tokenizer.tokenize(standardized)\n",
         "  vectorized = vocab_table.lookup(tokenized)\n",
+        "  # StaticVocabularyTable returns the OOV token as vocab_size + 2. We overwrite it to be 1.\n",
+        "  vectorized = tf.where(vectorized == len(keys), tf.constant(1, dtype=tf.int64), vectorized)\n",
         "  return vectorized, label"
       ]
     },


### PR DESCRIPTION
In the Beginners tutorials > Load and preprocess data > Text, under Example 2, I believe there is an issue handling OOV tokens. The code does this:
```python
keys = vocab
values = range(2, len(vocab) + 2)  # Reserve `0` for padding, `1` for OOV tokens.

init = tf.lookup.KeyValueTensorInitializer(
    keys, values, key_dtype=tf.string, value_dtype=tf.int64)

num_oov_buckets = 1
vocab_table = tf.lookup.StaticVocabularyTable(init, num_oov_buckets)
```
However, note that `StaticVocabularyTable` does not return the value 1 for OOV, but rather `hash(<term>) % num_oov_buckets + vocab_size` per its documentation. In our case, this is equal to vocab_size, which is actually 10000 (and not 1 nor 10002). This in fact collides with the token in the original index 9998. To fix this, I suggest to first map the OOV to 10002 by providing vocabulary that includes the padding and OOV tokens inherently:
```python
# Reserve `0` for padding, `1` for OOV tokens.
keys = ['', '[UNK]'] + vocab
values = range(len(keys))
```
Then, in the subsequent cell remap the 10002 to 1. I'm using `len(keys)` here rather than `vocab_size + 2` as later in the tutorial we do `vocab_size += 2`.
```python
def preprocess_text(text, label):
  standardized = tf_text.case_fold_utf8(text)
  tokenized = tokenizer.tokenize(standardized)
  vectorized = vocab_table.lookup(tokenized)
  # StaticVocabularyTable returns the OOV token as vocab_size + 2. We overwrite it to be 1.
  vectorized = tf.where(vectorized == len(keys), tf.constant(1, dtype=tf.int64), vectorized)
  return vectorized, label
```