### PR TITLE
Loading text tutorial: removed +1 from VOCAB_SIZE+1

### DIFF
--- a/site/en/tutorials/load_data/text.ipynb
+++ b/site/en/tutorials/load_data/text.ipynb
@@ -1653,7 +1653,7 @@
       },
       "outputs": [],
       "source": [
-        "model = create_model(vocab_size=VOCAB_SIZE + 1, num_labels=1)\n",
+        "model = create_model(vocab_size=VOCAB_SIZE, num_labels=1)\n",
         "model.summary()"
       ]
     },


### PR DESCRIPTION
In the Beginners tutorials > Load and preprocess data > Text, under the "Download more datasets using TensorFlow Datasets (TFDS)" section, we do:
```python
vectorize_layer = TextVectorization(
    max_tokens=VOCAB_SIZE,
    output_mode='int',
    output_sequence_length=MAX_SEQUENCE_LENGTH)
    
# ...

model = create_model(vocab_size=VOCAB_SIZE + 1, num_labels=1)
```
Since the vocabulary of the `TextVectorization` layer already includes both the padding token and OOV token (i.e. the maximum index possible is 9999 when VOCAB_SIZE is 10000), I believe the +1 should be removed from `VOCAB_SIZE + 1`. The `Embedding` layer created by `create_model` should not see a token with a value greater than 9999. 