### PR TITLE
Fix predict_next_note() param

### DIFF
--- a/site/en/tutorials/audio/music_generation.ipynb
+++ b/site/en/tutorials/audio/music_generation.ipynb
@@ -1072,7 +1072,7 @@
       "source": [
         "def predict_next_note(\n",
         "    notes: np.ndarray, \n",
-        "    keras_model: tf.keras.Model, \n",
+        "    model: tf.keras.Model, \n",
         "    temperature: float = 1.0) -> tuple[int, float, float]:\n",
         "  \"\"\"Generates a note as a tuple of (pitch, step, duration), using a trained sequence model.\"\"\"\n",
         "\n",


### PR DESCRIPTION
The parameter name is `keras_model` but the function uses `model`, updating the parameter name to match the function
![image](https://github.com/tensorflow/docs/assets/133994400/b705808c-6dd2-478a-a348-e0036e203a40)
