### PR TITLE
Correct link to list of dtypes

### DIFF
--- a/site/en/guide/tensor.ipynb
+++ b/site/en/guide/tensor.ipynb
@@ -80,7 +80,7 @@
         "id": "VQ3s2J8Vgowq"
       },
       "source": [
-        "Tensors are multi-dimensional arrays with a uniform type (called a `dtype`).  You can see all supported `dtypes` at `tf.dtypes.DType`.\n",
+        "Tensors are multi-dimensional arrays with a uniform type (called a `dtype`).  You can see all supported `dtypes` at `tf.dtypes`.\n",
         "\n",
         "If you're familiar with [NumPy](https://numpy.org/devdocs/user/quickstart.html){:.external}, tensors are (kind of) like `np.arrays`.\n",
         "\n",


### PR DESCRIPTION
This change should be appropriate whether the doc is viewed through:

- the web page: linked to https://www.tensorflow.org/api_docs/python/tf/dtypes
- as a notebook: ie execute dir(tf.dtypes)