### PR TITLE
Fix the broken link of Mnist dataset in beginner.ipynb

### DIFF
--- a/site/en/tutorials/quickstart/beginner.ipynb
+++ b/site/en/tutorials/quickstart/beginner.ipynb
@@ -125,7 +125,7 @@
         "\n",
         "## Load a dataset\n",
         "\n",
-        "Load and prepare the [MNIST dataset](http://yann.lecun.com/exdb/mnist/). The pixel values of the images range from 0 through 255. Scale these values to a range of 0 to 1 by dividing the values by `255.0`. This also converts the sample data from integers to floating-point numbers:"
+        "Load and prepare the MNIST dataset. The pixel values of the images range from 0 through 255. Scale these values to a range of 0 to 1 by dividing the values by `255.0`. This also converts the sample data from integers to floating-point numbers:"
       ]
     },
     {


### PR DESCRIPTION
This page contains hyperlink for Mnist dataset which is actually asking for credentials now. IMO, for this page the hyperlink may not required.Hence I propose to delete the hyperlink here.

Fixes TF ticket #[62306](https://github.com/tensorflow/tensorflow/issues/62306)

Thanks!