### PR TITLE
(Take 2) Fix oob index in sparse example

### DIFF
--- a/site/en/guide/sparse_tensor.ipynb
+++ b/site/en/guide/sparse_tensor.ipynb
@@ -256,7 +256,7 @@
         "                       values=[31, 2], \n",
         "                       dense_shape=[4, 10])\n",
         "\n",
-        "st_b = tf.sparse.SparseTensor(indices=[[0, 2], [7, 0]],\n",
+        "st_b = tf.sparse.SparseTensor(indices=[[0, 2], [3, 0]],\n",
         "                       values=[56, 38],\n",
         "                       dense_shape=[4, 10])\n",
         "\n",


### PR DESCRIPTION
Re-making this PR commit after updating my Google CLA and GitHub email settings to make this commit using the email address I signed with.

From [my other PR](https://github.com/tensorflow/docs/pull/2288):

A sparse matrix with shape [4, 10] is being assigned an element at location [7, 0]. This changes that to the valid [3, 0].

Thanks for your time.