### PR TITLE
Update broken link CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,7 @@ This guide shows how to make contributions to [tensorflow.org](https://www.tenso
 
 See the
 [TensorFlow docs contributor guide](https://www.tensorflow.org/community/contribute/docs)
-for guidance. For questions, the
-[docs@tensorflow.org](https://discuss.tensorflow.org/)
-mailing list is available.
+for guidance. For questions, check out [TensorFlow Forum](https://discuss.tensorflow.org/).
 
 Questions about TensorFlow usage are better addressed on
 [Stack Overflow](https://stackoverflow.com/questions/tagged/tensorflow) or the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This guide shows how to make contributions to [tensorflow.org](https://www.tenso
 See the
 [TensorFlow docs contributor guide](https://www.tensorflow.org/community/contribute/docs)
 for guidance. For questions, the
-[docs@tensorflow.org](https://groups.google.com/a/tensorflow.org/forum/#!forum/docs)
+[docs@tensorflow.org](https://discuss.tensorflow.org/)
 mailing list is available.
 
 Questions about TensorFlow usage are better addressed on

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To file a docs issue, use the issue tracker in the
 [tensorflow/tensorflow](https://github.com/tensorflow/tensorflow/issues/new?template=20-documentation-issue.md) repo.
 
 And join the TensorFlow documentation contributors on the
-[docs@tensorflow.org mailing list](https://discuss.tensorflow.org/).
+[TensorFlow Forum](https://discuss.tensorflow.org/).
 
 ## Community translations
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To file a docs issue, use the issue tracker in the
 [tensorflow/tensorflow](https://github.com/tensorflow/tensorflow/issues/new?template=20-documentation-issue.md) repo.
 
 And join the TensorFlow documentation contributors on the
-[docs@tensorflow.org mailing list](https://groups.google.com/a/tensorflow.org/forum/#!forum/docs).
+[docs@tensorflow.org mailing list](https://discuss.tensorflow.org/).
 
 ## Community translations
 


### PR DESCRIPTION
The hyperlink for `docs@tensorflow.org` not working. Updating it to `https://discuss.tensorflow.org/` as suggested by doc-Infra team.

Fixes #[62784](https://github.com/tensorflow/tensorflow/issues/62784)