### PR TITLE
Update the Segmentation Tutorial Colab to be compatible with Keras 3

### DIFF
--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -817,8 +817,8 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "toc_visible": true,
-      "provenance": []
+      "name": "segmentation.ipynb",
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/site/en/tutorials/images/segmentation.ipynb
+++ b/site/en/tutorials/images/segmentation.ipynb
@@ -97,7 +97,10 @@
       },
       "outputs": [],
       "source": [
-        "!pip install git+https://github.com/tensorflow/examples.git"
+        "!pip install git+https://github.com/tensorflow/examples.git\n",
+        "!pip install -U keras\n",
+        "!pip install -q tensorflow_datasets\n",
+        "!pip install -q -U tensorflow-text tensorflow"
       ]
     },
     {
@@ -108,8 +111,9 @@
       },
       "outputs": [],
       "source": [
-        "import tensorflow as tf\n",
+        "import numpy as np\n",
         "\n",
+        "import tensorflow as tf\n",
         "import tensorflow_datasets as tfds"
       ]
     },
@@ -252,7 +256,7 @@
         "    # both use the same seed, so they'll make the same random changes.\n",
         "    self.augment_inputs = tf.keras.layers.RandomFlip(mode=\"horizontal\", seed=seed)\n",
         "    self.augment_labels = tf.keras.layers.RandomFlip(mode=\"horizontal\", seed=seed)\n",
-        "  \n",
+        "\n",
         "  def call(self, inputs, labels):\n",
         "    inputs = self.augment_inputs(inputs)\n",
         "    labels = self.augment_labels(labels)\n",
@@ -450,7 +454,7 @@
       "source": [
         "## Train the model\n",
         "\n",
-        "Now, all that is left to do is to compile and train the model. \n",
+        "Now, all that is left to do is to compile and train the model.\n",
         "\n",
         "Since this is a multiclass classification problem, use the `tf.keras.losses.SparseCategoricalCrossentropy` loss function with the `from_logits` argument set to `True`, since the labels are scalar integers instead of vectors of scores for each pixel of every class.\n",
         "\n",
@@ -490,7 +494,7 @@
       },
       "outputs": [],
       "source": [
-        "tf.keras.utils.plot_model(model, show_shapes=True)"
+        "tf.keras.utils.plot_model(model, show_shapes=True, expand_nested=True, dpi=64)"
       ]
     },
     {
@@ -695,12 +699,14 @@
       },
       "outputs": [],
       "source": [
-        "label = [0,0]\n",
-        "prediction = [[-3., 0], [-3, 0]] \n",
-        "sample_weight = [1, 10] \n",
+        "label = np.array([0,0])\n",
+        "prediction = np.array([[-3., 0], [-3, 0]])\n",
+        "sample_weight = [1, 10]\n",
         "\n",
-        "loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True,\n",
-        "                                               reduction=tf.keras.losses.Reduction.NONE)\n",
+        "loss = tf.keras.losses.SparseCategoricalCrossentropy(\n",
+        "    from_logits=True,\n",
+        "    reduction=tf.keras.losses.Reduction.NONE\n",
+        ")\n",
         "loss(label, prediction, sample_weight).numpy()"
       ]
     },
@@ -729,7 +735,7 @@
         "  class_weights = tf.constant([2.0, 2.0, 1.0])\n",
         "  class_weights = class_weights/tf.reduce_sum(class_weights)\n",
         "\n",
-        "  # Create an image of `sample_weights` by using the label at each pixel as an \n",
+        "  # Create an image of `sample_weights` by using the label at each pixel as an\n",
         "  # index into the `class weights` .\n",
         "  sample_weights = tf.gather(class_weights, indices=tf.cast(label, tf.int32))\n",
         "\n",
@@ -811,9 +817,8 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "collapsed_sections": [],
-      "name": "segmentation.ipynb",
-      "toc_visible": true
+      "toc_visible": true,
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION
I've identified a couple of issues that occur under specific conditions when using TensorFlow 2.16 and Keras 3's plotting utilities, along with their respective solutions. 

#### Issue 1: AttributeError with `plot_model`
- **Issue:** When executing `tf.keras.utils.plot_model(model, show_shapes=True)`, users encounter an AttributeError stating that a 'list' object has no attribute 'shape'.
- **Fix:** Enhancing the `plot_model` function call by adding keyword arguments `expand_nested=True` and `dpi=64`. This not only resolves the AttributeError but also improves the visualization output (might be a little verbose but works without needing any changes to the plotting APIs). The adjusted function call looks like this:
```python
tf.keras.utils.plot_model(model, show_shapes=True, expand_nested=True, dpi=64)
```

#### Issue 2: AttributeError with `SparseCategoricalCrossentropy`
- **Issue:** The following code sequence leads to an AttributeError similar to Issue 1, indicating a 'list' object has no attribute 'shape':
```python
loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True, reduction=tf.keras.losses.Reduction.NONE)
loss(label, prediction, sample_weight).numpy()
```
This occurs when `label` and `prediction` are defined as lists, e.g., `label = [0,0]` and `prediction = [[-3., 0], [-3, 0]]`.
- **Fix:** Converting `label` and `prediction` objects into numpy arrays resolves the issue. The corrected definitions should be as follows:
```python
label = np.array([0,0])
prediction = np.array([[-3., 0], [-3, 0]])
```

**Summary of Changes:**
- Added `expand_nested=True` and `dpi=64` keyword arguments to `plot_model` for enhanced visualization and error prevention.
- Converted `y_true` and `y_pred` objects into numpy arrays before passing them to `SparseCategoricalCrossentropy` to fix the AttributeError.