### PR TITLE
Documentation Fix - Ragged Tensor

### DIFF
--- a/site/en/guide/ragged_tensor.ipynb
+++ b/site/en/guide/ragged_tensor.ipynb
@@ -681,7 +681,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "pHls7hQVJlk5"
+        "id": "ucYf2sSzTvQo"
       },
       "outputs": [],
       "source": [
@@ -691,26 +691,77 @@
         "     'She turned me into a newt.',\n",
         "     'A newt?',\n",
         "     'Well, I got better.'])\n",
-        "is_question = tf.constant([True, False, True, False])\n",
-        "\n",
+        "is_question = tf.constant([True, False, True, False])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "MGYKmizJTw8B"
+      },
+      "outputs": [],
+      "source": [
         "# Preprocess the input strings.\n",
         "hash_buckets = 1000\n",
         "words = tf.strings.split(sentences, ' ')\n",
         "hashed_words = tf.strings.to_hash_bucket_fast(words, hash_buckets)\n",
-        "\n",
+        "hashed_words.to_list()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "7FTujwOlUT8J"
+      },
+      "outputs": [],
+      "source": [
+        "hashed_words.to_tensor()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "vzWudaESUBOZ"
+      },
+      "outputs": [],
+      "source": [
+        "tf.keras.Input?"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "pHls7hQVJlk5"
+      },
+      "outputs": [],
+      "source": [
         "# Build the Keras model.\n",
         "keras_model = tf.keras.Sequential([\n",
-        "    tf.keras.layers.Embedding(hash_buckets, 16, input_length=hashed_words.shape[1]),\n",
+        "    tf.keras.layers.Embedding(hash_buckets, 16, mask_zero=True),\n",
         "    tf.keras.layers.LSTM(32, return_sequences=True, use_bias=False),\n",
-        "    tf.keras.layers.Flatten(),\n",
+        "    tf.keras.layers.GlobalAveragePooling1D(),\n",
         "    tf.keras.layers.Dense(32),\n",
         "    tf.keras.layers.Activation(tf.nn.relu),\n",
         "    tf.keras.layers.Dense(1)\n",
         "])\n",
         "\n",
         "keras_model.compile(loss='binary_crossentropy', optimizer='rmsprop')\n",
-        "keras_model.fit(hashed_words, is_question, epochs=5)\n",
-        "print(keras_model.predict(hashed_words))\n"
+        "keras_model.fit(hashed_words.to_tensor(), is_question, epochs=5)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "1IAjjmdTU9OU"
+      },
+      "outputs": [],
+      "source": [
+        "print(keras_model.predict(hashed_words.to_tensor()))"
       ]
     },
     {
@@ -799,7 +850,7 @@
       "source": [
         "### Datasets\n",
         "\n",
-        "[tf.data](https://www.tensorflow.org/guide/data) is an API that enables you to build complex input pipelines from simple, reusable pieces.  Its core data structure is `tf.data.Dataset`, which represents a sequence of elements, in which each element consists of one or more components. "
+        "[tf.data](https://www.tensorflow.org/guide/data) is an API that enables you to build complex input pipelines from simple, reusable pieces.  Its core data structure is `tf.data.Dataset`, which represents a sequence of elements, in which each element consists of one or more components."
       ]
     },
     {
@@ -1078,9 +1129,11 @@
         "import tempfile\n",
         "\n",
         "keras_module_path = tempfile.mkdtemp()\n",
-        "tf.saved_model.save(keras_model, keras_module_path)\n",
-        "imported_model = tf.saved_model.load(keras_module_path)\n",
-        "imported_model(hashed_words)"
+        "keras_model.save(keras_module_path+\"/my_model.keras\")\n",
+        "\n",
+        "imported_model = tf.keras.models.load_model(keras_module_path+\"/my_model.keras\")\n",
+        "\n",
+        "imported_model(hashed_words.to_tensor())"
       ]
     },
     {
@@ -2125,7 +2178,6 @@
   ],
   "metadata": {
     "colab": {
-      "collapsed_sections": [],
       "name": "ragged_tensor.ipynb",
       "toc_visible": true
     },

--- a/site/en/guide/ragged_tensor.ipynb
+++ b/site/en/guide/ragged_tensor.ipynb
@@ -674,7 +674,7 @@
       "source": [
         "### Keras\n",
         "\n",
-        "[tf.keras](https://www.tensorflow.org/guide/keras) is TensorFlow's high-level API for building and training deep learning models. Ragged tensors can be passed as inputs to a Keras model by using ragged tensors between Keras layers, and returning ragged tensors by Keras models. The following example shows a toy LSTM model that is trained using ragged tensors:"
+        "[tf.keras](https://www.tensorflow.org/guide/keras) is TensorFlow's high-level API for building and training deep learning models. It doesn't have ragged support. But it does support masked tensors. So the easiest way to use a ragged tensor in a Keras model  is to convert the ragged tensor to a dense tensor, using `.to_tensor()` and then using Keras's builtin masking:"
       ]
     },
     {

--- a/site/en/guide/ragged_tensor.ipynb
+++ b/site/en/guide/ragged_tensor.ipynb
@@ -674,7 +674,7 @@
       "source": [
         "### Keras\n",
         "\n",
-        "[tf.keras](https://www.tensorflow.org/guide/keras) is TensorFlow's high-level API for building and training deep learning models. Ragged tensors may be passed as inputs to a Keras model by setting `ragged=True` on `tf.keras.Input` or `tf.keras.layers.InputLayer`.  Ragged tensors may also be passed between Keras layers, and returned by Keras models.  The following example shows a toy LSTM model that is trained using ragged tensors."
+        "[tf.keras](https://www.tensorflow.org/guide/keras) is TensorFlow's high-level API for building and training deep learning models. Ragged tensors can be passed as inputs to a Keras model by using ragged tensors between Keras layers, and returning ragged tensors by Keras models. The following example shows a toy LSTM model that is trained using ragged tensors:"
       ]
     },
     {
@@ -700,9 +700,9 @@
         "\n",
         "# Build the Keras model.\n",
         "keras_model = tf.keras.Sequential([\n",
-        "    tf.keras.layers.Input(shape=[None], dtype=tf.int64, ragged=True),\n",
-        "    tf.keras.layers.Embedding(hash_buckets, 16),\n",
-        "    tf.keras.layers.LSTM(32, use_bias=False),\n",
+        "    tf.keras.layers.Embedding(hash_buckets, 16, input_length=hashed_words.shape[1]),\n",
+        "    tf.keras.layers.LSTM(32, return_sequences=True, use_bias=False),\n",
+        "    tf.keras.layers.Flatten(),\n",
         "    tf.keras.layers.Dense(32),\n",
         "    tf.keras.layers.Activation(tf.nn.relu),\n",
         "    tf.keras.layers.Dense(1)\n",
@@ -710,7 +710,7 @@
         "\n",
         "keras_model.compile(loss='binary_crossentropy', optimizer='rmsprop')\n",
         "keras_model.fit(hashed_words, is_question, epochs=5)\n",
-        "print(keras_model.predict(hashed_words))"
+        "print(keras_model.predict(hashed_words))\n"
       ]
     },
     {


### PR DESCRIPTION
Addressing issue #65399 in tensorflow repo, The documentation for RaggedTensors in which it stated that 
"Ragged tensors may be passed as inputs to a Keras model by setting ragged=True on tf.keras.Input or tf.keras.layers.InputLayer." 
As there was no support for ragged tensors in the input layer as a parameter. I have altered the documentation to reflect this change and resolve the inconsistency.