### PR TITLE
Support button-cells without tfo class

### DIFF
--- a/tools/tensorflow_docs/tools/nblint/style/tensorflow.py
+++ b/tools/tensorflow_docs/tools/nblint/style/tensorflow.py
@@ -81,7 +81,9 @@ def not_translation(args):
 
 # Button checks
 
-is_button_cell_re = re.compile(r"class.*tfo-notebook-buttons")
+# Look for class="tfo-notebook-buttons" (CSS used on website versions) or the
+# run-in-colab logo (for notebooks that stick to GitHub/Colab).
+is_button_cell_re = re.compile(r"class.*tfo-notebook-buttons|colab_logo_32px\.png")
 
 
 def get_arg_or_fail(user_args, arg_name, arg_fmt):


### PR DESCRIPTION
This would support the Gemini API cookbook style of table cell, and any other case that doesn't use the TFO classes.