### PR TITLE
Fixing the wrong predictions in transfer_learning.ipynb

### DIFF
--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -1049,7 +1049,6 @@
         "# Retrieve a batch of images from the test set\n",
         "image_batch, label_batch = test_dataset.as_numpy_iterator().next()\n",
         "predictions = model.predict_on_batch(image_batch).flatten()\n",
-        "# Apply a sigmoid since our model returns logits\n",
         "predictions = tf.where(predictions < 0.5, 0, 1)\n",
         "\n",
         "print('Predictions:\\n', predictions.numpy())\n",

--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -1051,7 +1051,6 @@
         "predictions = model.predict_on_batch(image_batch).flatten()\n",
         "\n",
         "# Apply a sigmoid since our model returns logits\n",
-        "predictions = tf.nn.sigmoid(predictions)\n",
         "predictions = tf.where(predictions < 0.5, 0, 1)\n",
         "\n",
         "print('Predictions:\\n', predictions.numpy())\n",

--- a/site/en/tutorials/images/transfer_learning.ipynb
+++ b/site/en/tutorials/images/transfer_learning.ipynb
@@ -1049,7 +1049,6 @@
         "# Retrieve a batch of images from the test set\n",
         "image_batch, label_batch = test_dataset.as_numpy_iterator().next()\n",
         "predictions = model.predict_on_batch(image_batch).flatten()\n",
-        "\n",
         "# Apply a sigmoid since our model returns logits\n",
         "predictions = tf.where(predictions < 0.5, 0, 1)\n",
         "\n",


### PR DESCRIPTION
In the Transfer_learning https://www.tensorflow.org/tutorials/images/transfer_learning, 
After running the last cell for prediction on test data with fine-tuned model, the output at the end of the code cell predicts all 1, which is wrong prediction 

**Document:**
#Apply a sigmoid since our model returns logits
predictions = tf.nn.sigmoid(predictions)
predictions = tf.where(predictions < 0.5, 0, 1)

This can be fixed by commenting/removing the part in the last cell where we apply the sigmoid function on the predictions,
#Apply a sigmoid since our model returns logits
predictions = tf.nn.sigmoid(predictions)   ======> removed this line
predictions = tf.where(predictions < 0.5, 0, 1)

The original behavior is happening because we already applied a sigmoid activation in the classification head's prediction layer while we were making the model for feature extraction.

Kindly find the [gist](https://colab.research.google.com/gist/tilakrayal/37e55c061576c3599d233d5a66c34a2f/transfer_learning.ipynb) for the reference which was providing the correct output after removing/commenting the above mentioned(TF.nn.sigmoid) line. Thank you!