### PR TITLE
Update pandas_dataframe.ipynb

### DIFF
--- a/site/en/tutorials/load_data/pandas_dataframe.ipynb
+++ b/site/en/tutorials/load_data/pandas_dataframe.ipynb
@@ -240,7 +240,7 @@
       },
       "outputs": [],
       "source": [
-        "tf.convert_to_tensor(numeric_features)"
+        "numeric_features = tf.convert_to_tensor(numeric_features)"
       ]
     },
     {
@@ -312,7 +312,7 @@
       },
       "outputs": [],
       "source": [
-        "normalizer(numeric_features.iloc[:3])"
+        "normalizer(numeric_features[:3])"
       ]
     },
     {
@@ -616,7 +616,7 @@
       },
       "outputs": [],
       "source": [
-        "model.predict(dict(numeric_features.iloc[:3]))"
+        "model.predict(dict(numeric_features[:3]))"
       ]
     },
     {


### PR DESCRIPTION
Passing a dataframe into normalizer.adapt() yields the following error: 
```local variable 'input_shape' referenced before assignment``` 
even if  it can be converted to a tensor with tf.convert_to_tensor. It seems you have to actually pass in the converted tensor or ```np.array(df)``` .

Since it's no longer a dataframe you also can't use iloc.