### PR TITLE
Fix Text classification with TensorFlow Hub

### DIFF
--- a/site/en/tutorials/keras/text_classification_with_hub.ipynb
+++ b/site/en/tutorials/keras/text_classification_with_hub.ipynb
@@ -121,7 +121,8 @@
       "outputs": [],
       "source": [
         "!pip install tensorflow-hub\n",
-        "!pip install tensorflow-datasets"
+        "!pip install tensorflow-datasets\n",
+        "!pip install tf_keras"
       ]
     },
     {
@@ -138,6 +139,7 @@
         "import tensorflow as tf\n",
         "import tensorflow_hub as hub\n",
         "import tensorflow_datasets as tfds\n",
+        "import tf_keras\n",
         "\n",
         "print(\"Version: \", tf.__version__)\n",
         "print(\"Eager mode: \", tf.executing_eagerly())\n",
@@ -290,10 +292,10 @@
       },
       "outputs": [],
       "source": [
-        "model = tf.keras.Sequential()\n",
+        "model = tf_keras.Sequential()\n",
         "model.add(hub_layer)\n",
-        "model.add(tf.keras.layers.Dense(16, activation='relu'))\n",
-        "model.add(tf.keras.layers.Dense(1))\n",
+        "model.add(tf_keras.layers.Dense(16, activation='relu'))\n",
+        "model.add(tf_keras.layers.Dense(1))\n",
         "\n",
         "model.summary()"
       ]


### PR DESCRIPTION
* install tf_keras
* use tf_keras model and layers

Run into a problem while running the cell:

> Only instances of `keras.Layer` can be added to a Sequential model. Received: <tensorflow_hub.keras_layer.KerasLayer

Applied the fix described in https://github.com/tensorflow/tensorflow/issues/63849.
After the change, the notebook works end to end. 
But I think this actually downgrades the tf_keras support from 3 to 2, as noted in https://github.com/tensorflow/tensorflow/issues/63849#issuecomment-2011748852.

If the notebook is supposed to work as is, without this fix applied, then this PR shows how to apply the workaround to the notebook until the main issue is figured out :)