### PR TITLE
checkpoint must be saved as a .keras file

### DIFF
--- a/site/en/tutorials/distribute/keras.ipynb
+++ b/site/en/tutorials/distribute/keras.ipynb
@@ -363,7 +363,7 @@
         "# Define the checkpoint directory to store the checkpoints.\n",
         "checkpoint_dir = './training_checkpoints'\n",
         "# Define the name of the checkpoint files.\n",
-        "checkpoint_prefix = os.path.join(checkpoint_dir, \"ckpt_{epoch}\")"
+        "checkpoint_prefix = os.path.join(checkpoint_dir, \"ckpt_{epoch}.keras\")"
       ]
     },
     {
@@ -486,7 +486,9 @@
       },
       "outputs": [],
       "source": [
-        "model.load_weights(tf.train.latest_checkpoint(checkpoint_dir))\n",
+        "# model.load_weights(tf.train.latest_checkpoint(checkpoint_dir))\n",
+        "model.load_weights('/content/training_checkpoints/ckpt_12.keras')\n",
+        "# model.load_weights('/content/training_checkpoints/ckpt_1.weights.h5')\n",
         "\n",
         "eval_loss, eval_acc = model.evaluate(eval_dataset)\n",
         "\n",

--- a/site/en/tutorials/distribute/keras.ipynb
+++ b/site/en/tutorials/distribute/keras.ipynb
@@ -488,7 +488,6 @@
       "source": [
         "# model.load_weights(tf.train.latest_checkpoint(checkpoint_dir))\n",
         "model.load_weights('/content/training_checkpoints/ckpt_12.keras')\n",
-        "# model.load_weights('/content/training_checkpoints/ckpt_1.weights.h5')\n",
         "\n",
         "eval_loss, eval_acc = model.evaluate(eval_dataset)\n",
         "\n",


### PR DESCRIPTION
checkpoint must be saved as a .keras file

checkpoint_prefix = os.path.join(checkpoint_dir, "ckpt_{epoch}.keras")

tf.train.latest_checkpoint returns None
model must be loaded with the appropriate extension

model.load_weights('/content/training_checkpoints/ckpt_12.keras')