### PR TITLE
Update reset_states() -> reset_state() in Custom Training Loops Tutorials

### DIFF
--- a/site/en/tutorials/distribute/custom_training.ipynb
+++ b/site/en/tutorials/distribute/custom_training.ipynb
@@ -514,9 +514,9 @@
         "                         train_accuracy.result() * 100, test_loss.result(),\n",
         "                         test_accuracy.result() * 100))\n",
         "\n",
-        "  test_loss.reset_states()\n",
-        "  train_accuracy.reset_states()\n",
-        "  test_accuracy.reset_states()"
+        "  test_loss.reset_state()\n",
+        "  train_accuracy.reset_state()\n",
+        "  test_accuracy.reset_state()"
       ]
     },
     {
@@ -633,7 +633,7 @@
         "\n",
         "  template = (\"Epoch {}, Loss: {}, Accuracy: {}\")\n",
         "  print(template.format(epoch + 1, average_train_loss, train_accuracy.result() * 100))\n",
-        "  train_accuracy.reset_states()"
+        "  train_accuracy.reset_state()"
       ]
     },
     {
@@ -672,7 +672,7 @@
         "  template = (\"Epoch {}, Loss: {}, Accuracy: {}\")\n",
         "  print(template.format(epoch + 1, train_loss, train_accuracy.result() * 100))\n",
         "\n",
-        "  train_accuracy.reset_states()"
+        "  train_accuracy.reset_state()"
       ]
     },
     {


### PR DESCRIPTION
As title. This is to fix the following:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
[<ipython-input-14-e4b89749e4d3>](https://localhost:8080/#) in <cell line: 13>()
     33                          test_accuracy.result() * 100))
     34 
---> 35   test_loss.reset_states()
     36   train_accuracy.reset_states()
     37   test_accuracy.reset_states()

AttributeError: 'Mean' object has no attribute 'reset_states'
```