### PR TITLE
Update tf2_image_retraining.ipynb

### DIFF
--- a/site/en/hub/tutorials/tf2_image_retraining.ipynb
+++ b/site/en/hub/tutorials/tf2_image_retraining.ipynb
@@ -221,7 +221,7 @@
         "  \"efficientnetv2-b0-21k-ft1k\": 224,\n",
         "  \"efficientnetv2-b1-21k-ft1k\": 240,\n",
         "  \"efficientnetv2-b2-21k-ft1k\": 260,\n",
-        "  \"efficientnetv2-b3-21k-ft1k\": 300, \n",
+        "  \"efficientnetv2-b3-21k-ft1k\": 300,\n",
         "  \"efficientnet_b0\": 224,\n",
         "  \"efficientnet_b1\": 240,\n",
         "  \"efficientnet_b2\": 260,\n",
@@ -363,8 +363,8 @@
         "model = tf.keras.Sequential([\n",
         "    # Explicitly define the input shape so the model can be properly\n",
         "    # loaded by the TFLiteConverter\n",
-        "    tf.keras.layers.InputLayer(input_shape=IMAGE_SIZE + (3,)),\n",
-        "    hub.KerasLayer(model_handle, trainable=do_fine_tuning),\n",
+        "    tf.keras.layers.InputLayer(shape=IMAGE_SIZE + (3,)),\n",
+        "    tf.keras.layers.Lambda(lambda x: hub.KerasLayer(model_handle, trainable=do_fine_tuning)(x)),\n",
         "    tf.keras.layers.Dropout(rate=0.2),\n",
         "    tf.keras.layers.Dense(len(class_names),\n",
         "                          kernel_regularizer=tf.keras.regularizers.l2(0.0001))\n",
@@ -391,7 +391,7 @@
       "outputs": [],
       "source": [
         "model.compile(\n",
-        "  optimizer=tf.keras.optimizers.SGD(learning_rate=0.005, momentum=0.9), \n",
+        "  optimizer=tf.keras.optimizers.SGD(learning_rate=0.005, momentum=0.9),\n",
         "  loss=tf.keras.losses.CategoricalCrossentropy(from_logits=True, label_smoothing=0.1),\n",
         "  metrics=['accuracy'])"
       ]


### PR DESCRIPTION
Hi 👋

While working through the tutorials, I ran into an hiccup with `tf2_image_retraining.ipynb`:

```
/usr/local/lib/python3.10/dist-packages/keras/src/layers/core/input_layer.py:26: UserWarning: Argument `input_shape` is deprecated. Use `shape` instead.
  warnings.warn(
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
[<ipython-input-3-4ec403fe43da>](https://localhost:8080/#) in <cell line: 170>()
    168 
    169 print("Building model with", model_handle)
--> 170 model = tf.keras.Sequential([
    171     # Explicitly define the input shape so the model can be properly
    172     # loaded by the TFLiteConverter

1 frames
[/usr/local/lib/python3.10/dist-packages/keras/src/models/sequential.py](https://localhost:8080/#) in __init__(self, layers, trainable, name)
     71         if layers:
     72             for layer in layers:
---> 73                 self.add(layer, rebuild=False)
     74             self._maybe_rebuild()
     75 

[/usr/local/lib/python3.10/dist-packages/keras/src/models/sequential.py](https://localhost:8080/#) in add(self, layer, rebuild)
     93                 layer = origin_layer
     94         if not isinstance(layer, Layer):
---> 95             raise ValueError(
     96                 "Only instances of `keras.Layer` can be "
     97                 f"added to a Sequential model. Received: {layer} "

ValueError: Only instances of `keras.Layer` can be added to a Sequential model. Received: <tensorflow_hub.keras_layer.KerasLayer object at 0x7823dd59b7f0> (of type <class 'tensorflow_hub.keras_layer.KerasLayer'>)
```

The code change fixes the `ValueError`, as well as the deprecation warning.

Thanks for all the amazing work on these tutorials! 😊