### PR TITLE
Correct typo "YOu" to "You" in tutorial text

### DIFF
--- a/site/en/tutorials/audio/simple_audio.ipynb
+++ b/site/en/tutorials/audio/simple_audio.ipynb
@@ -873,7 +873,7 @@
         "    self.model = model\n",
         "\n",
         "    # Accept either a string-filename or a batch of waveforms.\n",
-        "    # YOu could add additional signatures for a single wave, or a ragged-batch. \n",
+        "    # You could add additional signatures for a single wave, or a ragged-batch. \n",
         "    self.__call__.get_concrete_function(\n",
         "        x=tf.TensorSpec(shape=(), dtype=tf.string))\n",
         "    self.__call__.get_concrete_function(\n",


### PR DESCRIPTION
Hi, This PR corrects a minor typo in the [simple audio tutorial notebook](https://www.tensorflow.org/tutorials/audio/simple_audio#export_the_model_with_preprocessing). The word "YOu" was changed to "You" to ensure proper grammar and readability.

Thank you for reviewing this minor fix!


<img width="680" alt="스크린샷 2024-11-15 오후 3 01 04" src="https://github.com/user-attachments/assets/6f2c6a35-e27c-4e68-b8cc-2ad7b0dc345c">
