### PR TITLE
Update `in-depth-guide.md` reference

### DIFF
--- a/site/en/guide/saved_model.ipynb
+++ b/site/en/guide/saved_model.ipynb
@@ -752,7 +752,7 @@
         ")\n",
         "```\n",
         "\n",
-        "More information can be found in the [Proto Splitter / Merger Library guide](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/proto_splitter/in-depth-guide.md)."
+        "More information can be found in the [Proto Splitter / Merger Library guide](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/proto_splitter/g3doc/in-depth-guide.md)."
       ]
     },
     {


### PR DESCRIPTION
# PR Summary
Small PR - The `tensorflow/tools/proto_splitter/in-depth-guide.md` was moved to `tensorflow/tools/proto_splitter/g3doc/in-depth-guide.md`. This PR adjusts sources to changes. See here for more info: https://github.com/tensorflow/tensorflow/commit/752a1abd6ff73f654d2f9d331c722180e595ff55