### PR TITLE
Update installation instructions in pip.md to address PEP 668 compliance for Windows WSL2 with Ubuntu 24.04 or later.

### DIFF
--- a/site/en/install/pip.md
+++ b/site/en/install/pip.md
@@ -70,6 +70,10 @@ step-by-step instructions.
     for CUDA in WSL.
 
     ```bash
+    # Windows WSL2 with Ubuntu 24.04 or later adheres to PEP 668, requiring users to manage their Python environments independently.
+    sudo apt install python3-venv
+    python3 -m venv ~/tf
+    source ~/tf/bin/activate
     python3 -m pip install tensorflow[and-cuda]
     # Verify the installation:
     python3 -c "import tensorflow as tf; print(tf.config.list_physical_devices('GPU'))"


### PR DESCRIPTION
Hi, Team
This PR will addresse the issue of outdated installation instructions for Windows WSL2 on the [TensorFlow Pip Installation Guide](https://www.tensorflow.org/install/pip#windows-wsl2).

**Problem :**
The existing instructions do not account for the changes introduced in `Ubuntu 24.04` which enforces `PEP 668`. This specification treats Python environments as externally managed deprecating global installations of Python packages via pip.

The command `python3 -m pip install tensorflow[and-cuda]` no longer works on Ubuntu 24.04. User encounter the `externally-managed-environment` error unless they create and use a virtual environment.

The installation instructions have been updated to include steps for creating and using a virtual environment when working with TensorFlow on Ubuntu 24.04 or later. The steps ensure compatibility and compliance with PEP 668.


**Updated Instructions** :
For Ubuntu 24.04 in WSL2 the following steps are required to set up TensorFlow with CUDA:

```
1. sudo apt install python3-venv
2. python3 -m venv ~/tf
3. source ~/tf/bin/activate
4. python3 -m pip install tensorflow[and-cuda]
```
For more information please refer this issue https://github.com/tensorflow/tensorflow/issues/79370#issuecomment-2553333075 and it will fix that issue https://github.com/tensorflow/tensorflow/issues/79370

if you've any feedback or suggestions for these changes please feel free to let me know. Thank you.
