### PR TITLE
BLD: tensor.ipynb: empty commit to send a note about error messages

### DIFF
--- a/site/en/guide/tensor.ipynb
+++ b/site/en/guide/tensor.ipynb
@@ -1,4 +1,4 @@
-{
+{ 
   "cells": [
     {
       "cell_type": "markdown",


### PR DESCRIPTION

- [ ] https://www.tensorflow.org/guide/tensor has these errors up top, which are a bit confusing for "Intro to tensors": 

```
external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:485] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
```


```
cuda_executor.cc:1015] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero. See more at https://github.com/torvalds/linux/blob/v6.0/Documentation/ABI/testing/sysfs-bus-pci#L344-L355
```

