### PR TITLE
Keras ModelCheckpoint Path Update for Weight Serialization

### DIFF
--- a/site/en/tutorials/audio/music_generation.ipynb
+++ b/site/en/tutorials/audio/music_generation.ipynb
@@ -999,7 +999,7 @@
       "source": [
         "callbacks = [\n",
         "    tf.keras.callbacks.ModelCheckpoint(\n",
-        "        filepath='./training_checkpoints/ckpt_{epoch}',\n",
+        "        filepath='./training_checkpoints/ckpt_{epoch}.weights.h5',\n",
         "        save_weights_only=True),\n",
         "    tf.keras.callbacks.EarlyStopping(\n",
         "        monitor='loss',\n",


### PR DESCRIPTION
# Keras ModelCheckpoint Path Update for Weight Serialization

## Overview
Updates ModelCheckpoint filepath to comply with Keras weight serialization requirements by appending `.weights.h5` extension.

## Technical Context
The ModelCheckpoint callback requires specific file extensions when `save_weights_only=True` is enabled.

From:
```python
filepath='./training_checkpoints/ckpt_{epoch}'
```

To:
```python
filepath='./training_checkpoints/ckpt_{epoch}.weights.h5'
```

## Implementation Details
- Maintains existing epoch-based checkpoint pattern using `{epoch}` placeholder
- Adds required `.weights.h5` extension
- Preserves checkpoint directory structure and naming convention

## Validation
- Checkpoint saving executes without ValueError
- Weight files load correctly into model instances
- Per-epoch checkpoint pattern verified

## Impact
No changes to model architecture, training dynamics, or checkpoint frequency. Purely file format compliance update for Keras weight serialization requirements.

## References
* https://keras.io/api/models/model_saving_apis/weights_saving_and_loading/