### PR TITLE
Change to follow the change of Keras v3.5.0

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -97,7 +97,6 @@
       },
       "outputs": [],
       "source": [
-        "import os\n",
         "import datetime\n",
         "\n",
         "import IPython\n",
@@ -138,7 +137,7 @@
         "    origin='https://storage.googleapis.com/tensorflow/tf-keras-datasets/jena_climate_2009_2016.csv.zip',\n",
         "    fname='jena_climate_2009_2016.csv.zip',\n",
         "    extract=True)\n",
-        "csv_path, _ = os.path.splitext(zip_path)"
+        "csv_path = f'{zip_path}/jena_climate_2009_2016.csv'"
       ]
     },
     {


### PR DESCRIPTION
### Description
Keras has introduced a new way of what/how `get_file()` returns since v3.5.0 with [this commit](https://github.com/keras-team/keras/commit/dcefb139863505d166dd1325066f329b3033d45a). Therefore, the tutorial is not working anymore with the latest TensorFlow with the affected Keras, for instance, TensorFlow v2.18.0 and Keras v3.8.0 are currently installed in Colab and it failed to get the data file as in the screenshot below.
<img width="1002" alt="Screenshot 2025-02-10 at 7 17 33 PM" src="https://github.com/user-attachments/assets/e2d20808-4c8b-4ef0-8405-04865de9536d" />
It could be dealt with in the better way to consider the older versions, though, it's a bit off-track from the tutorial's purpose itself. So, this PR starts from the shortest version.

Please feel free to correct me. I'm usually making a mistake.
Thank you! :D

### References
- https://github.com/keras-team/keras/compare/v3.5.0...master
- https://github.com/keras-team/keras/commit/dcefb139863505d166dd1325066f329b3033d45a