### PR TITLE
Fix path to dataset in image classification tutorial

### DIFF
--- a/site/en/tutorials/images/classification.ipynb
+++ b/site/en/tutorials/images/classification.ipynb
@@ -154,7 +154,7 @@
         "\n",
         "dataset_url = \"https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz\"\n",
         "data_dir = tf.keras.utils.get_file('flower_photos.tar', origin=dataset_url, extract=True)\n",
-        "data_dir = pathlib.Path(data_dir).with_suffix('')"
+        "data_dir = pathlib.Path(data_dir) / \"flower_photos\""
       ]
     },
     {


### PR DESCRIPTION
The [image classification tutorial](https://www.tensorflow.org/tutorials/images/classification#visualize_training_results) does not properly index into the extracted directory that contains the downloaded image dataset.