### PR TITLE
Fix TypeError in simple_audio.ipynb

### DIFF
--- a/site/en/tutorials/audio/simple_audio.ipynb
+++ b/site/en/tutorials/audio/simple_audio.ipynb
@@ -816,7 +816,7 @@
       },
       "outputs": [],
       "source": [
-        "x = data_dir/'no/01bb6a2a_nohash_0.wav'\n",
+        "x = data_dir+'/no/01bb6a2a_nohash_0.wav'\n",
         "x = tf.io.read_file(str(x))\n",
         "x, sample_rate = tf.audio.decode_wav(x, desired_channels=1, desired_samples=16000,)\n",
         "x = tf.squeeze(x, axis=-1)\n",


### PR DESCRIPTION
change` x = data_dir/'no/01bb6a2a_nohash_0.wav'`
to `x = data_dir+'/no/01bb6a2a_nohash_0.wav'`
to prevent a TypeError at line 819, caused by attempting to concatenate a Path object with a string.
