### PR TITLE
ADDED- A command to move mini_speech_commands so that the notebook runs

### DIFF
--- a/site/en/tutorials/audio/simple_audio.ipynb
+++ b/site/en/tutorials/audio/simple_audio.ipynb
@@ -160,6 +160,15 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "! mv /content/data/mini_speech_commands_extracted/mini_speech_commands /content/data/mini_speech_commands"
+      ]
+    },
+    {
       "cell_type": "markdown",
       "metadata": {
         "id": "BgvFq3uYiS5G"


### PR DESCRIPTION
The current notebook doesn't work after 

```python
DATASET_PATH = 'data/mini_speech_commands'

data_dir = pathlib.Path(DATASET_PATH)
if not data_dir.exists():
  tf.keras.utils.get_file(
      'mini_speech_commands.zip',
      origin="http://storage.googleapis.com/download.tensorflow.org/data/mini_speech_commands.zip",
      extract=True,
      cache_dir='.', cache_subdir='data')
```

The snippet

```python
commands = np.array(tf.io.gfile.listdir(str(data_dir)))
commands = commands[(commands != 'README.md') & (commands != '.DS_Store')]
print('Commands:', commands)
```

gives the error
```bash
---------------------------------------------------------------------------
NotFoundError                             Traceback (most recent call last)
[<ipython-input-5-5c3ad82a2720>](https://localhost:8080/#) in <cell line: 0>()
----> 1 commands = np.array(tf.io.gfile.listdir(str(data_dir)))
      2 commands = commands[(commands != 'README.md') & (commands != '.DS_Store')]
      3 print('Commands:', commands)

[/usr/local/lib/python3.11/dist-packages/tensorflow/python/lib/io/file_io.py](https://localhost:8080/#) in list_directory_v2(path)
    766   """
    767   if not is_directory(path):
--> 768     raise errors.NotFoundError(
    769         node_def=None,
    770         op=None,

NotFoundError: Could not find directory data/mini_speech_commands
```

This fix moves the `mini_speech_commands` dir from `/content/data/mini_speech_commands_extracted/mini_speech_commands` to `/content/data/mini_speech_commands`.