### PR TITLE
Docs: Update supported Python versions on install landing page (Engli…

### DIFF
--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -20,7 +20,7 @@ landing_page:
         <table class="columns">
           <tr><td>
             <ul>
-              <li>Python 3.8–3.11</li>
+              <li>Python 3.9–3.12</li>
               <li>Ubuntu 16.04 or later</li>
               <li>Windows 7 or later (with <a href="https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads">C++ redistributable</a>)</li>
             </ul>


### PR DESCRIPTION
## Summary

This PR updates the supported Python versions listed on the `/install` landing page to reflect the current TensorFlow compatibility (3.9–3.12). The previous versions (3.8–3.11) were outdated, which was raised in issue [tensorflow/tensorflow#88226](https://github.com/tensorflow/tensorflow/issues/88226).

## Fixes

Fixes [tensorflow/tensorflow#88226](https://github.com/tensorflow/tensorflow/issues/88226)

## Notes

- Change made in `docs/site/en/install/_index.yaml`
- Verified no existing open PR currently resolves this.
- Signed the [Contributor License Agreement (CLA)](https://cla.developers.google.com/).
