### PR TITLE
tfhub.dev --> kaggle.com/models in overview.md

### DIFF
--- a/site/en/hub/overview.md
+++ b/site/en/hub/overview.md
@@ -2,10 +2,10 @@
 # TensorFlow Hub
 
 TensorFlow Hub is an open repository and library for reusable machine learning.
-The [tfhub.dev](https://tfhub.dev) repository provides many pre-trained models:
+[Kaggle Models](https://www.kaggle.com/models) provides many pre-trained models:
 text embeddings, image classification models, TF.js/TFLite models and much more.
 The repository is open to
-[community contributors](https://tfhub.dev/s?subtype=publisher).
+[community contributors](https://www.kaggle.com/models?owner-type=user).
 
 The [`tensorflow_hub`](https://github.com/tensorflow/hub) library lets you
 download and reuse them in your TensorFlow program with a minimum amount of
@@ -14,7 +14,7 @@ code.
 ```python
 import tensorflow_hub as hub
 
-model = hub.KerasLayer("https://tfhub.dev/google/nnlm-en-dim128/2")
+model = hub.KerasLayer("https://www.kaggle.com/models/google/nnlm/TensorFlow2/en-dim128/2")
 embeddings = model(["The rain in Spain.", "falls",
                     "mainly", "In the plain!"])
 
@@ -23,8 +23,8 @@ print(embeddings.shape)  #(4,128)
 
 ## Next Steps
 
--   [Find models on tfhub.dev](https://tfhub.dev)
--   [Publish models on tfhub.dev](publish.md)
+-   [Find models on kaggle.com](https://www.kaggle.com/models)
+-   [Publish models on kaggle.com](publish.md)
 -   TensorFlow Hub library
     -   [Install TensorFlow Hub](installation.md)
     -   [Library overview](lib_overview.md)


### PR DESCRIPTION
As the home page of TF Hub docs, it would be ideal to point to the correct model catalog at this point, IMO.