### PR TITLE
Fix Microsoft Visual C++ Redistributable for Visual Studio 2015, 2017…

### DIFF
--- a/site/en/install/pip.md
+++ b/site/en/install/pip.md
@@ -144,7 +144,7 @@ Note: GPU support is available for Ubuntu and Windows with CUDA®-enabled cards.
 *   pip version 19.0 or higher for Linux (requires `manylinux2014` support) and
     Windows. pip version 20.3 or higher for macOS.
 *   Windows Native Requires
-    [Microsoft Visual C++ Redistributable for Visual Studio 2015, 2017 and 2019](https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads)
+    [Microsoft Visual C++ Redistributable for Visual Studio 2015, 2017 and 2019](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170)
 
 
 The following NVIDIA® software are only required for GPU support.


### PR DESCRIPTION
… and 2019 broken link

Fixed Microsoft Visual C++ Redistributable for Visual Studio 2015, 2017 and 2019 broken link.