### PR TITLE
Update file paths in site/en/tutorials/keras/text_classification.ipynb

### DIFF
--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -171,7 +171,7 @@
         "                                    untar=True, cache_dir='.',\n",
         "                                    cache_subdir='')\n",
         "\n",
-        "dataset_dir = os.path.join(os.path.dirname(dataset), 'aclImdb')"
+        "dataset_dir = os.path.join(os.path.dirname(dataset), 'aclImdb_v1')"
       ]
     },
     {
@@ -193,7 +193,7 @@
       },
       "outputs": [],
       "source": [
-        "train_dir = os.path.join(dataset_dir, 'train')\n",
+        "train_dir = os.path.join(dataset_dir, 'aclImdb', 'train')\n",
         "os.listdir(train_dir)"
       ]
     },
@@ -214,7 +214,7 @@
       },
       "outputs": [],
       "source": [
-        "sample_file = os.path.join(train_dir, 'pos/1181_9.txt')\n",
+        "sample_file = os.path.join(train_dir, 'pos', '1181_9.txt')\n",
         "with open(sample_file) as f:\n",
         "  print(f.read())"
       ]
@@ -286,7 +286,7 @@
         "seed = 42\n",
         "\n",
         "raw_train_ds = tf.keras.utils.text_dataset_from_directory(\n",
-        "    'aclImdb/train',\n",
+        "    train_dir,\n",
         "    batch_size=batch_size,\n",
         "    validation_split=0.2,\n",
         "    subset='training',\n",
@@ -366,7 +366,7 @@
       "outputs": [],
       "source": [
         "raw_val_ds = tf.keras.utils.text_dataset_from_directory(\n",
-        "    'aclImdb/train',\n",
+        "    train_dir,\n",
         "    batch_size=batch_size,\n",
         "    validation_split=0.2,\n",
         "    subset='validation',\n",

--- a/site/en/tutorials/keras/text_classification.ipynb
+++ b/site/en/tutorials/keras/text_classification.ipynb
@@ -194,6 +194,7 @@
       "outputs": [],
       "source": [
         "train_dir = os.path.join(dataset_dir, 'aclImdb', 'train')\n",
+        "test_dir = os.path.join(dataset_dir, 'aclImdb', 'test')\n",
         "os.listdir(train_dir)"
       ]
     },
@@ -382,7 +383,7 @@
       "outputs": [],
       "source": [
         "raw_test_ds = tf.keras.utils.text_dataset_from_directory(\n",
-        "    'aclImdb/test',\n",
+        "    test_dir,\n",
         "    batch_size=batch_size)"
       ]
     },


### PR DESCRIPTION
I was walking through this tutorial in Google Colab and it wasn't working quite right. Looks like there were some issues with the paths.

1. When the tar.gz was being unzipped the original `dataset_dir` variable was missing the `_v1`
2. All the training documents were nested under a `aclImdb` folder, so included that
3. Changed occurences of `aclImdb/train` to use the `train_dir`