### PR TITLE
Fix MyDense example input to use tf.Variable instead of list

### DIFF
--- a/site/en/guide/intro_to_modules.ipynb
+++ b/site/en/guide/intro_to_modules.ipynb
@@ -775,7 +775,7 @@
       },
       "outputs": [],
       "source": [
-        "simple_layer([[2.0, 2.0, 2.0]])"
+        "simple_layer(tf.Variable([[2.0, 2.0, 2.0]]))"
       ]
     },
     {


### PR DESCRIPTION
The original example in intro_to_modules.ipynb used a plain Python list as input: simple_layer([[2.0, 2.0, 2.0]])

This caused an error because tf.matmul expects a TensorFlow tensor or variable. Updated the code to:
simple_layer(tf.Variable([[2.0, 2.0, 2.0]]))

This change ensures the example runs successfully and aligns with TensorFlow’s expected input types for custom Keras layers.