### PR TITLE
Docs: Update supported Python version to 3.13 on install page

### DIFF
--- a/site/en/install/_index.yaml
+++ b/site/en/install/_index.yaml
@@ -20,7 +20,7 @@ landing_page:
         <table class="columns">
           <tr><td>
             <ul>
-              <li>Python 3.9–3.12</li>
+              <li>Python 3.9–3.13</li>
               <li>Ubuntu 16.04 or later</li>
               <li>Windows 7 or later (with <a href="https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads">C++ redistributable</a>)</li>
             </ul>


### PR DESCRIPTION
This PR updates the supported Python version listed on the TensorFlow installation page.

The current documentation at https://www.tensorflow.org/install lists Python support as 3.9–3.12, but `pip install tensorflow` works with Python 3.13.

Updated the version range from 3.9–3.12 to 3.9–3.13 in `_index.yaml` to reflect the current compatibility.

Fixes: https://github.com/tensorflow/tensorflow/issues/112027