### PR TITLE
Update install docs with correct Python, CUDA, cuDNN, and OS versions

### DIFF
--- a/site/en/install/pip.md
+++ b/site/en/install/pip.md
@@ -50,11 +50,10 @@ step-by-step instructions.
     [TensorFlow-DirectML-Plugin](https://github.com/microsoft/tensorflow-directml-plugin#tensorflow-directml-plugin-)
 
     ```bash
-    conda install -c conda-forge cudatoolkit=11.2 cudnn=8.1.0
-    # Anything above 2.10 is not supported on the GPU on Windows Native
-    python -m pip install "tensorflow<2.11"
+    # Install CPU-only TensorFlow on Windows Native
+    python -m pip install tensorflow
     # Verify the installation:
-    python -c "import tensorflow as tf; print(tf.config.list_physical_devices('GPU'))"
+    python -c "import tensorflow as tf; print(tf.reduce_sum(tf.random.normal([1000, 1000])))"
     ```
 
 * {Windows WSL2}
@@ -131,16 +130,16 @@ enable compute capabilities by [building TensorFlow from source](./source.md).
 
 ## System requirements
 
-*   Ubuntu 16.04 or higher (64-bit)
+*   Ubuntu 20.04 or higher (64-bit)
 *   macOS 12.0 (Monterey) or higher (64-bit) *(no GPU support)*
-*   Windows Native - Windows 7 or higher (64-bit) *(no GPU support after TF 2.10)*
+*   Windows Native - Windows 10 or higher (64-bit) *(no GPU support after TF 2.10)*
 *   Windows WSL2 - Windows 10 19044 or higher (64-bit)
 
 Note: GPU support is available for Ubuntu and Windows with CUDA®-enabled cards.
 
 ## Software requirements
 
-*   Python 3.9–3.12
+*   Python 3.10–3.13
 *   pip version 19.0 or higher for Linux (requires `manylinux2014` support) and
     Windows. pip version 20.3 or higher for macOS.
 *   Windows Native Requires
@@ -152,8 +151,8 @@ The following NVIDIA® software are only required for GPU support.
 *   [NVIDIA® GPU drivers](https://www.nvidia.com/drivers)
     * >= 525.60.13 for Linux
     * >= 528.33 for WSL on Windows
-*   [CUDA® Toolkit 12.3](https://developer.nvidia.com/cuda-toolkit-archive).
-*   [cuDNN SDK 8.9.7](https://developer.nvidia.com/cudnn).
+*   [CUDA® Toolkit 12.5](https://developer.nvidia.com/cuda-toolkit-archive).
+*   [cuDNN SDK 9.3](https://developer.nvidia.com/cudnn).
 *   *(Optional)*
     [TensorRT](https://docs.nvidia.com/deeplearning/tensorrt/archives/index.html#trt_7)
     to improve latency and throughput for inference.
@@ -164,7 +163,7 @@ The following NVIDIA® software are only required for GPU support.
 
     ### 1. System requirements
 
-    *  Ubuntu 16.04 or higher (64-bit)
+    *  Ubuntu 20.04 or higher (64-bit)
 
     TensorFlow only officially supports Ubuntu. However, the following
     instructions may also work for other Linux distros.
@@ -284,7 +283,7 @@ The following NVIDIA® software are only required for GPU support.
 
    ### 1. System requirements
 
-    *   macOS 10.12.6 (Sierra) or higher (64-bit)
+    *   macOS 12.0 (Monterey) or higher (64-bit)
 
     Note: While TensorFlow supports Apple Silicon (M1), packages that include
     custom C++ extensions for TensorFlow also need to be compiled for Apple M1.
@@ -300,7 +299,7 @@ The following NVIDIA® software are only required for GPU support.
 
     Check if your Python environment is already configured:
 
-    Note: Requires Python 3.9–3.11, and pip >= 20.3 for MacOS.
+    Note: Requires Python 3.10–3.13, and pip >= 20.3 for MacOS.
 
     ```bash
     python3 --version
@@ -341,7 +340,7 @@ The following NVIDIA® software are only required for GPU support.
 
    ## 1. System requirements
 
-   *   Windows 7 or higher (64-bit)
+   *   Windows 10 or higher (64-bit)
 
     Note: Starting with TensorFlow `2.10`, Windows CPU-builds for x86/x64
     processors are built, maintained, tested and released by a third party:
@@ -392,7 +391,7 @@ The following NVIDIA® software are only required for GPU support.
     Create a new conda environment named `tf` with the following command.
 
     ```bash
-    conda create --name tf python=3.9
+    conda create --name tf python=3.11
     ```
 
     You can deactivate and activate it with the following commands.
@@ -415,7 +414,7 @@ The following NVIDIA® software are only required for GPU support.
     Then install the CUDA, cuDNN with conda.
 
     ```bash
-    conda install -c conda-forge cudatoolkit=11.2 cudnn=8.1.0
+    conda install -c conda-forge cudatoolkit=12.5 cudnn=9.3
     ```
 
     ### 6. Install TensorFlow
@@ -434,8 +433,8 @@ The following NVIDIA® software are only required for GPU support.
     PyPI.
 
     ```bash
-    # Anything above 2.10 is not supported on the GPU on Windows Native
-    pip install "tensorflow<2.11" 
+    # GPU is not supported on Windows Native after TF 2.10; install CPU-only
+    pip install tensorflow
     ```
 
     ### 7. Verify the installation

--- a/site/en/install/source_windows.md
+++ b/site/en/install/source_windows.md
@@ -13,7 +13,7 @@ environment.
 ### Install Python and the TensorFlow package dependencies
 
 Install a
-[Python 3.9+ 64-bit release for Windows](https://www.python.org/downloads/windows/).
+[Python 3.10+ 64-bit release for Windows](https://www.python.org/downloads/windows/).
 Select *pip* as an optional feature and add it to your `%PATH%` environmental
 variable.
 


### PR DESCRIPTION
The install guides had several outdated version references that no longer match TensorFlow 2.21's tested build configurations:

- Python: 3.9-3.12 -> 3.10-3.13
- CUDA Toolkit: 12.3 -> 12.5
- cuDNN SDK: 8.9.7 -> 9.3
- Ubuntu minimum: 16.04 -> 20.04
- macOS minimum: 10.12.6 (Sierra) -> 12.0 (Monterey)
- Windows minimum: 7 -> 10
- Windows Native conda example: python=3.9 -> python=3.11
- Windows Native pip example: tensorflow<2.11 -> tensorflow (CPU-only)
- Windows source build: Python 3.9+ -> 3.10+

Contributes to #111734