### PR TITLE
Add missing docstrings and improve clarity in doc_controls module

### DIFF
--- a/tools/tensorflow_docs/api_generator/doc_controls.py
+++ b/tools/tensorflow_docs/api_generator/doc_controls.py
@@ -360,7 +360,9 @@ def doc_private(obj: T) -> T:
   setattr(obj, _DOC_PRIVATE, None)
   return obj
 
-"""Check whether a private object should be documented.
+
+def should_doc_private(obj) -> bool:
+  """Check whether a private object should be documented.
 
 Args:
   obj: The object to check.
@@ -368,7 +370,6 @@ Args:
 Returns:
   True if the object is marked for documentation, otherwise False.
 """
-def should_doc_private(obj) -> bool:
   return hasattr(obj, _DOC_PRIVATE)
 
 

--- a/tools/tensorflow_docs/api_generator/doc_controls.py
+++ b/tools/tensorflow_docs/api_generator/doc_controls.py
@@ -27,6 +27,14 @@ def set_deprecated(obj: T) -> T:
 
 
 def is_deprecated(obj) -> bool:
+  """Check whether an object is marked as deprecated.
+
+  Args:
+    obj: The object to check.
+
+  Returns:
+    True if the object is marked as deprecated, otherwise False.
+  """
   return hasattr(obj, _DEPRECATED)
 
 
@@ -86,7 +94,14 @@ def set_custom_page_builder_cls(obj, cls):
 
 
 def get_custom_page_builder_cls(obj):
-  """Gets custom page content if available."""
+  """Return the custom page builder class for an object if set.
+
+Args:
+  obj: The object to inspect.
+
+Returns:
+  The custom page builder class if available, otherwise None.
+"""
   return getattr(obj, _CUSTOM_PAGE_BUILDER_CLS, None)
 
 
@@ -345,7 +360,14 @@ def doc_private(obj: T) -> T:
   setattr(obj, _DOC_PRIVATE, None)
   return obj
 
+"""Check whether a private object should be documented.
 
+Args:
+  obj: The object to check.
+
+Returns:
+  True if the object is marked for documentation, otherwise False.
+"""
 def should_doc_private(obj) -> bool:
   return hasattr(obj, _DOC_PRIVATE)
 

--- a/tools/tensorflow_docs/api_generator/generate_lib.py
+++ b/tools/tensorflow_docs/api_generator/generate_lib.py
@@ -69,7 +69,7 @@ def write_docs(
     extra_docs: Optional[dict[int, str]] = None,
     page_builder_classes: Optional[docs_for_object.PageBuilderDict] = None,
 ):
-  """Write extracted API documentation to disk.  This function generates markdown documentation files for each API symbol defined in the parser configuration. It also handles creation of auxiliary files such as table of contents (`_toc.yaml`), redirects (`_redirects.yaml`), and a global symbol index.  Each symbol is processed into a documentation page, resolving cross-references and optionally generating search metadata and API reports. """
+  """Write previously extracted docs to disk.
 
   Write a docs page for each symbol included in the indices of parser_config to
   a tree of docs at `output_dir`.
@@ -113,8 +113,7 @@ def write_docs(
 
   # Collect redirects for an api _redirects.yaml file.
   redirects = []
-  
-  # Optional report object used to collect API documentation metrics
+
   api_report = None
   if gen_report:
     api_report = utils.ApiReport()
@@ -221,7 +220,7 @@ def extract(
     ] = doc_generator_visitor.DocGeneratorVisitor,
     filters: Optional[public_api.ApiFilter] = None,
 ):
-  """Traverse module contents and return an index of discovered API objects.  This function walks through the given Python module, applies optional filters, and collects all public API symbols using the provided visitor class.  It builds and returns a structured index representing the module's API hierarchy, which is later used for documentation generation. """
+  """Walks the module contents, returns an index of all visited objects.
 
   The return value is an instance of `self._visitor_cls`, usually:
   `doc_generator_visitor.DocGeneratorVisitor`
@@ -256,7 +255,7 @@ EXCLUDED = set(['__init__.py', 'OWNERS', 'README.txt'])
 
 
 class DocGenerator:
-  """Main entry point for generating API documentation.  This class coordinates the extraction, parsing, and generation of documentation for a given Python module. It manages configuration, filters, and output structure to produce consistent API reference docs. """
+  """Main entry point for generating docs."""
 
   def __init__(
       self,
@@ -403,7 +402,7 @@ class DocGenerator:
     ]
 
   def run_extraction(self) -> config.ParserConfig:
-    """Traverse module contents and return an index of discovered API objects.  This function walks through the given Python module, applies optional filters, and collects all public API symbols using the provided visitor class.  It builds and returns a structured index representing the module's API hierarchy, which is later used for documentation generation. """
+    """Walks the module contents, returns an index of all visited objects.
 
     Returns:
         An instance of `parser_config.ParserConfig`.

--- a/tools/tensorflow_docs/api_generator/generate_lib.py
+++ b/tools/tensorflow_docs/api_generator/generate_lib.py
@@ -69,7 +69,7 @@ def write_docs(
     extra_docs: Optional[dict[int, str]] = None,
     page_builder_classes: Optional[docs_for_object.PageBuilderDict] = None,
 ):
-  """Write previously extracted docs to disk.
+  """Write extracted API documentation to disk.  This function generates markdown documentation files for each API symbol defined in the parser configuration. It also handles creation of auxiliary files such as table of contents (`_toc.yaml`), redirects (`_redirects.yaml`), and a global symbol index.  Each symbol is processed into a documentation page, resolving cross-references and optionally generating search metadata and API reports. """
 
   Write a docs page for each symbol included in the indices of parser_config to
   a tree of docs at `output_dir`.
@@ -113,7 +113,8 @@ def write_docs(
 
   # Collect redirects for an api _redirects.yaml file.
   redirects = []
-
+  
+  # Optional report object used to collect API documentation metrics
   api_report = None
   if gen_report:
     api_report = utils.ApiReport()
@@ -220,7 +221,7 @@ def extract(
     ] = doc_generator_visitor.DocGeneratorVisitor,
     filters: Optional[public_api.ApiFilter] = None,
 ):
-  """Walks the module contents, returns an index of all visited objects.
+  """Traverse module contents and return an index of discovered API objects.  This function walks through the given Python module, applies optional filters, and collects all public API symbols using the provided visitor class.  It builds and returns a structured index representing the module's API hierarchy, which is later used for documentation generation. """
 
   The return value is an instance of `self._visitor_cls`, usually:
   `doc_generator_visitor.DocGeneratorVisitor`
@@ -255,7 +256,7 @@ EXCLUDED = set(['__init__.py', 'OWNERS', 'README.txt'])
 
 
 class DocGenerator:
-  """Main entry point for generating docs."""
+  """Main entry point for generating API documentation.  This class coordinates the extraction, parsing, and generation of documentation for a given Python module. It manages configuration, filters, and output structure to produce consistent API reference docs. """
 
   def __init__(
       self,
@@ -402,7 +403,7 @@ class DocGenerator:
     ]
 
   def run_extraction(self) -> config.ParserConfig:
-    """Walks the module contents, returns an index of all visited objects.
+    """Traverse module contents and return an index of discovered API objects.  This function walks through the given Python module, applies optional filters, and collects all public API symbols using the provided visitor class.  It builds and returns a structured index representing the module's API hierarchy, which is later used for documentation generation. """
 
     Returns:
         An instance of `parser_config.ParserConfig`.


### PR DESCRIPTION
This PR improves documentation clarity in the doc_controls module.

Changes include:
- Added missing docstrings for helper functions (`is_deprecated`, `should_doc_private`)
- Improved clarity of existing docstrings (`get_custom_page_builder_cls`)
- Ensured consistent docstring formatting

No functional changes were made. These updates improve readability and make the code easier to understand for new contributors.

