### PR TITLE
Fix: format consistency issue

### DIFF
--- a/site/en/guide/autodiff.ipynb
+++ b/site/en/guide/autodiff.ipynb
@@ -109,7 +109,7 @@
       "source": [
         "## Computing gradients\n",
         "\n",
-        "To differentiate automatically, TensorFlow needs to remember what operations happen in what order during the *forward* pass.  Then, during the *backward pass*, TensorFlow traverses this list of operations in reverse order to compute gradients."
+        "To differentiate automatically, TensorFlow needs to remember what operations happen in what order during the *forward pass*.  Then, during the *backward pass*, TensorFlow traverses this list of operations in reverse order to compute gradients."
       ]
     },
     {


### PR DESCRIPTION
Format consistency issue

**Position:** "Computing gradients" section

**Link:** https://www.tensorflow.org/guide/autodiff#computing_gradients

**Condition:** There is a format issue in the "*forward* pass" and "*backward pass*", as shown in the red rectangles in the following image.

Readers might confuse the whole termiology.

**Suggestion:** It seems that "*forward pass*" and "*backward pass*" are more reasonable.

REF: https://github.com/HsienChing/ML_DL_project_State_Estimation_of_Li-ion_Batteries/blob/main/other/Issues_in_TensorFlow_official_doc_Introduction_to_gradients_and_automatic_differentiation.ipynb