### PR TITLE
fix: better comment suggestion

### DIFF
--- a/site/en/guide/autodiff.ipynb
+++ b/site/en/guide/autodiff.ipynb
@@ -157,7 +157,7 @@
       },
       "outputs": [],
       "source": [
-        "# dy = 2x * dx\n",
+        "# dy/dx = 2x\n",
         "dy_dx = tape.gradient(y, x)\n",
         "dy_dx.numpy()"
       ]
@@ -396,7 +396,7 @@
         "  tape.watch(x)\n",
         "  y = x**2\n",
         "\n",
-        "# dy = 2x * dx\n",
+        "# dy/dx = 2x\n",
         "dy_dx = tape.gradient(y, x)\n",
         "print(dy_dx.numpy())"
       ]


### PR DESCRIPTION
# Better comment suggestion 

**Position:** "Gradient tapes" section

**Condition:**
It's better to use "`# dy/dx = 2x`" instead of "`# dy = 2x * dx`" in the comment.

I know that the "dy/dx = 2x" and "dy = 2x * dx" are equivalent. 

As this is the first time I see the comment "`# dy = 2x * dx`" and the following code "`dy_dx = tape.gradient(y, x)`", I don't get the meaning immediately. 

When I changed the comment to "`# dy/dx = 2x`", which is much closer to the code "`dy_dx = tape.gradient(y, x)`". And I can obviously understand the code.

**Suggestion:** Use "`# dy/dx = 2x`" instead of "`# dy = 2x * dx`" in the comment.

The same thing happened again in the "Controlling what the tape watches" section.

REF: https://github.com/HsienChing/ML_DL_project_State_Estimation_of_Li-ion_Batteries/blob/main/other/Issues_in_TensorFlow_official_doc_Introduction_to_gradients_and_automatic_differentiation.ipynb