### PR TITLE
Better example code for the "Taking advantage of graphs" section

### DIFF
--- a/site/en/guide/intro_to_graphs.ipynb
+++ b/site/en/guide/intro_to_graphs.ipynb
@@ -203,7 +203,7 @@
         "orig_value = a_regular_function(x1, y1, b1).numpy()\n",
         "# Call a `tf.function` like a Python function.\n",
         "tf_function_value = a_function_that_uses_a_graph(x1, y1, b1).numpy()\n",
-        "assert(orig_value == tf_function_value)"
+        "print(orig_value == tf_function_value)"
       ]
     },
     {


### PR DESCRIPTION
# Better example code for the "Taking advantage of graphs" section

**Position:**  
"Taking advantage of graphs" section

**Link:**  
https://www.tensorflow.org/guide/intro_to_graphs#taking_advantage_of_graphs

**Condition:**  
The example code is OK, no bug. I am talking about a more detailed consideration about the tutorial.

In the last line of the example code, the `assert` keyword is used to check the values between `a_regular_function()` and `tf.function(a_regular_function)`.
```Python
assert(orig_value == tf_function_value)
```
However, when I run the code, nothing happens. As I learned the usage of `assert`, I understood that "noting happens" indicates "orig_value == tf_function_value". 

NOTE: In Python, the [`assert`](https://docs.python.org/3/reference/simple_stmts.html#grammar-token-python-grammar-assert_stmt) keyword is a debugging tool used to verify that a condition is true. If the condition evaluates to False, the program immediately raises an AssertionError and terminates, helping developers catch bugs during the development and testing phases.

**Suggestion:**  
In my opinion, a tutorial should give readers an "explicit" guide instead of an "implicit" guide. Using `print` is a better choice than using `assert`.

When using `print`, a `True` or `False` will be sent according to the conditional expression `orig_value == tf_function_value`, and readers will understand the result explicitly and immediately.
```Python
print(orig_value == tf_function_value)
```

REF: https://github.com/HsienChing/ML_DL_project_State_Estimation_of_Li-ion_Batteries/blob/main/other/Issues_in_TensorFlow_official_doc_Introduction_to_graphs_and_tf.function.ipynb