### PR TITLE
Bug: IsADirectoryError in "The weather dataset" section

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -138,7 +138,7 @@
         "    origin='https://storage.googleapis.com/tensorflow/tf-keras-datasets/jena_climate_2009_2016.csv.zip',\n",
         "    fname='jena_climate_2009_2016.csv.zip',\n",
         "    extract=True)\n",
-        "csv_path, _ = os.path.splitext(zip_path)"
+        "csv_path = zip_path + \"/jena_climate_2009_2016.csv\""
       ]
     },
     {


### PR DESCRIPTION
# Bug: `IsADirectoryError` in "The weather dataset" section

**Position:**  
"The weather dataset" section

**Link:**  
https://www.tensorflow.org/tutorials/structured_data/time_series#the_weather_dataset

**Condition:**  
A `IsADirectoryError` is encountered, indicating the program couldn't reach and read the file.

```python
IsADirectoryError: [Errno 21] Is a directory: '/root/.keras/datasets/jena_climate_2009_2016_extracted'
```

**Suggestion:**  
Modify the code from
```python
csv_path, _ = os.path.splitext(zip_path)
```
to
```python
csv_path = zip_path + "/jena_climate_2009_2016.csv"
```

And then, we could reach the file and read it.

**Error condition screenshot:**  

<img width="1898" height="1306" alt="image" src="https://github.com/user-attachments/assets/d6d4afce-a6f7-4ebc-8e5a-6b78a35b231c" />

Screendate: 2026-04-21    
Link: [Run in Google Colab](https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/structured_data/time_series.ipynb)