### PR TITLE
Correct description: Since there are two `9999` values in the table.

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -256,7 +256,7 @@
         "id": "i47LiW5DCVsP"
       },
       "source": [
-        "One thing that should stand out is the `min` value of the wind velocity (`wv (m/s)`) and the maximum value (`max. wv (m/s)`) columns. This `-9999` is likely erroneous.\n",
+        "One thing that should stand out is the `min` value of the wind velocity (`wv (m/s)`) and the maximum value (`max. wv (m/s)`) columns. These `-9999` values are likely erroneous.\n",
         "\n",
         "There's a separate wind direction column, so the velocity should be greater than zero (`>=0`). Replace it with zeros:"
       ]


### PR DESCRIPTION
Since there are two `9999` values in the table.

The description is corrected from
```
This `-9999` is likely erroneous.
```
to
```
These `-9999` values are likely erroneous.
```