### PR TITLE
Strange description in "2. Split" subsection

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -813,7 +813,7 @@
       "source": [
         "Typically, data in TensorFlow is packed into arrays where the outermost index is across examples (the \"batch\" dimension). The middle indices are the \"time\" or \"space\" (width, height) dimension(s). The innermost indices are the features.\n",
         "\n",
-        "The code above took a batch of three 7-time step windows with 19 features at each time step. It splits them into a batch of 6-time step 19-feature inputs, and a 1-time step 1-feature label. The label only has one feature because the `WindowGenerator` was initialized with `label_columns=['T (degC)']`. Initially, this tutorial will build models that predict single output labels."
+        "The code above took three batches of a 7-time step windows with 19 features at each time step. It splits them into three batches of a 6-time step 19-feature inputs, and a 1-time step 1-feature label. The label only has one feature because the `WindowGenerator` was initialized with `label_columns=['T (degC)']`. Initially, this tutorial will build models that predict single output labels."
       ]
     },
     {


### PR DESCRIPTION
#  Strange description in "2. Split" subsection

**Position:**  
"2. Split" subsection

**Link:**  
https://www.tensorflow.org/tutorials/structured_data/time_series#2_split

**Condition:**  

The original description is:  
The code above took a batch of three 7-time step windows with 19 features at each time step. It splits them into a batch of 6-time step 19-feature inputs, and a 1-time step 1-feature label.

However, it's better to be modified as:  
The code above took ~~a batch~~ three batches of ~~three~~ a 7-time step windows with 19 features at each time step. It splits them into ~~a batch~~ three batches of a 6-time step 19-feature inputs, and a 1-time step 1-feature label.

**Reason:**

Please see the screenshot below.
We know it's three batches instead of one.

1. A description of the tensor structure is provided.

> Typically, data in TensorFlow is packed into arrays where the outermost index is across examples (the "batch" dimension). The middle indices are the "time" or "space" (width, height) dimension(s). The innermost indices are the features.

2. The result of the code is
```
All shapes are: (batch, time, features)
Window shape: (3, 7, 19)
Inputs shape: (3, 6, 19)
Labels shape: (3, 1, 1)
```

<img width="2772" height="1263" alt="image" src="https://github.com/user-attachments/assets/90524781-90d6-46cb-98f5-42d7516c4e62" />

Screenshot date: 2026-04-22  
Link: [Run in Google Colab](https://colab.research.google.com/github/tensorflow/docs/blob/master/site/en/tutorials/structured_data/time_series.ipynb)