### PR TITLE
Word consistency modification

### DIFF
--- a/site/en/tutorials/structured_data/time_series.ipynb
+++ b/site/en/tutorials/structured_data/time_series.ipynb
@@ -746,7 +746,7 @@
         "\n",
         "![The initial window is all consecutive samples, this splits it into an (inputs, labels) pairs](https://github.com/tensorflow/docs/blob/master/site/en/tutorials/structured_data/images/split_window.png?raw=1)\n",
         "\n",
-        "This diagram doesn't show the `features` axis of the data, but this `split_window` function also handles the `label_columns` so it can be used for both the single output and multi-output examples."
+        "This diagram doesn't show the `features` axis of the data, but this `split_window` function also handles the `label_columns` so it can be used for both the single-output and multi-output examples."
       ]
     },
     {


### PR DESCRIPTION
Before modification:
`...so it can be used for both the single output and multi-output examples.`

After modification:
`...so it can be used for both the single-output and multi-output examples.`